### PR TITLE
Minor API change: allow sending _no_ messages

### DIFF
--- a/demo/Demo/GRPC/Protobuf/Pipes/RouteGuide.hs
+++ b/demo/Demo/GRPC/Protobuf/Pipes/RouteGuide.hs
@@ -36,7 +36,7 @@ listFeatures conn params r = runSafeT . runEffect $
 recordRoute ::
      Connection
   -> PerCallParams
-  -> Producer' (IsFinal, Point) (SafeT IO) ()
+  -> Producer' (IsFinal, Maybe Point) (SafeT IO) ()
   -> IO ()
 recordRoute conn params ps = runSafeT . runEffect $
     let cons = clientStreaming conn params (RPC @RouteGuide @"recordRoute")
@@ -45,7 +45,7 @@ recordRoute conn params ps = runSafeT . runEffect $
 routeChat ::
      Connection
   -> PerCallParams
-  -> Producer' (IsFinal, RouteNote) IO ()
+  -> Producer' (IsFinal, Maybe RouteNote) IO ()
   -> IO ()
 routeChat conn params ns =
     biDiStreaming conn params (RPC @RouteGuide @"routeChat") $ \cons prod ->

--- a/demo/Demo/GRPC/Protobuf/RouteGuide.hs
+++ b/demo/Demo/GRPC/Protobuf/RouteGuide.hs
@@ -18,18 +18,34 @@ import Demo.Driver.Logging
   routeguide.RouteGuide
 -------------------------------------------------------------------------------}
 
-getFeature :: Connection -> PerCallParams -> Point -> IO ()
+getFeature ::
+     Connection
+  -> PerCallParams
+  -> Point
+  -> IO ()
 getFeature conn params p = log =<<
     nonStreaming conn params (RPC @RouteGuide @"getFeature") p
 
-listFeatures :: Connection -> PerCallParams -> Rectangle -> IO ()
+listFeatures ::
+     Connection
+  -> PerCallParams
+  -> Rectangle
+  -> IO ()
 listFeatures conn params r = log =<<
     serverStreaming conn params (RPC @RouteGuide @"listFeatures") r log
 
-recordRoute :: Connection -> PerCallParams -> IO (IsFinal, Point) -> IO ()
+recordRoute ::
+     Connection
+  -> PerCallParams
+  -> IO (IsFinal, Maybe Point)
+  -> IO ()
 recordRoute conn params ps = log =<<
     clientStreaming conn params (RPC @RouteGuide @"recordRoute") ps
 
-routeChat :: Connection -> PerCallParams -> IO (IsFinal, RouteNote)-> IO ()
+routeChat ::
+     Connection
+  -> PerCallParams
+  -> IO (IsFinal, Maybe RouteNote)
+  -> IO ()
 routeChat conn params notes = log =<<
     biDiStreaming conn params (RPC @RouteGuide @"routeChat") notes log

--- a/docs/status.md
+++ b/docs/status.md
@@ -171,3 +171,6 @@ ever growing (and hopefully eventually shrinking) list of things to do.
 - [ ] `Network.GRPC.Client.Request` currently uses one-place buffers. We should
       replace these with `n`-place buffers, for configurable `n`.
 
+- [ ] Support `content-length` header. This is not part of the spec, but
+      apparently some servers send it anyway
+      (e.g. https://github.com/grpc/grpc-web/issues/1101).

--- a/src/Network/GRPC/Client.hs
+++ b/src/Network/GRPC/Client.hs
@@ -173,8 +173,6 @@ data Aborted = Aborted
 -- If you are using the specialized functions from "Network.GRPC.Protobuf",
 -- you do not need to worry about any of this.
 
-
-
 -- | Send an input to the peer
 --
 -- This lives in @STM@ for improved composability. For example, if the peer is

--- a/src/Network/GRPC/Protobuf/Pipes.hs
+++ b/src/Network/GRPC/Protobuf/Pipes.hs
@@ -33,7 +33,7 @@ clientStreaming :: forall s m.
   -> PerCallParams
   -> RPC s m
   -> Consumer'
-       (IsFinal, Input (RPC s m))
+       (IsFinal, Maybe (Input (RPC s m)))
        (SafeT IO)
        (Output (RPC s m), Trailers)
 clientStreaming conn params rpc =
@@ -81,7 +81,7 @@ biDiStreaming :: forall s m a.
   => Connection
   -> PerCallParams
   -> RPC s m
-  -> (    Consumer' (IsFinal, Input (RPC s m)) IO ()
+  -> (    Consumer' (IsFinal, Maybe (Input (RPC s m))) IO ()
        -> Producer' (Output (RPC s m)) IO Trailers
        -> IO a
      )
@@ -98,13 +98,13 @@ biDiStreaming conn params rpc k =
 sendAll :: forall f s m.
      MonadIO f
   => Call (RPC s m)
-  -> Consumer' (IsFinal, Input (RPC s m)) f ()
+  -> Consumer' (IsFinal, Maybe (Input (RPC s m))) f ()
 sendAll call = loop
   where
-    loop :: Consumer' (IsFinal, Input (RPC s m)) f ()
+    loop :: Consumer' (IsFinal, Maybe (Input (RPC s m))) f ()
     loop = do
         (isFinal, input) <- await
-        liftIO $ atomically $ sendInput call isFinal $ Just input
+        liftIO $ atomically $ sendInput call isFinal input
         unless (isFinal == Final) loop
 
 recvAll :: forall f s m.


### PR DESCRIPTION
The `Protobuf` interface for client and bidirectional streaming took a function

``` haskell
IO (IsFinal, Input (RPC s m))
```

which it repeatedly called until no more inputs needed to be sent. However, this meant that we could not send _no_ inputs; the API is now

``` haskell
IO (IsFinal, Maybe (Input (RPC s m)))
```

The contract here is that `(Final, Nothing)` should _only_ be used in the case there are no messages to be sent at all.

This matches the (already present) detailed discussion of the quirks of `sendInput` in `Network.GRPC.Client`.