### PR TITLE
Introduce `DataFlow`

### DIFF
--- a/src/Network/GRPC/Server/Call.hs
+++ b/src/Network/GRPC/Server/Call.hs
@@ -82,8 +82,8 @@ acceptCall conn mkResponseMetadata = do
           Context.serverDebugTracer $ Context.params (Connection.context conn)
 
     mkOutboundHeaders ::
-             Session.InboundHeaders  (ServerSession rpc)
-      -> IO (Session.OutboundHeaders (ServerSession rpc))
+             Session.Headers (ServerInbound  rpc)
+      -> IO (Session.Headers (ServerOutbound rpc))
     mkOutboundHeaders InboundHeaders{inbHeaders} = do
         responseMetadata <- mkResponseMetadata $ requestMetadata inbHeaders
 

--- a/src/Network/GRPC/Util/Session.hs
+++ b/src/Network/GRPC/Util/Session.hs
@@ -14,7 +14,8 @@
 -- > import Network.GRPC.Util.Session qualified as Session
 module Network.GRPC.Util.Session (
     -- * Session API
-    IsSession(..)
+    DataFlow(..)
+  , IsSession(..)
   , InitiateSession(..)
   , AcceptSession(..)
     -- ** Raw request/response info


### PR DESCRIPTION
This is a minor abstraction, which captures the data flow over a session: headers, then messages, then trailers. This allows us to talk about an "inbound dataflow" and an "outbound dataflow". This by itself is merely a nice-to-have, but it sets the stage for the next step, which is to properly deal with the gRPC Trailers-Only case.