### PR TITLE
Test compression negotiation failures

### DIFF
--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -211,10 +211,12 @@ test-suite test-grapesy
   build-depends:
       -- External dependencies
     , async         >= 2.2  && < 2.3
+    , containers    >= 0.6  && < 0.7
     , contra-tracer >= 0.2  && < 0.3
     , data-default  >= 0.7  && < 0.8
     , tasty         >= 1.4  && < 1.5
     , tasty-hunit   >= 0.10 && < 0.11
+    , text          >= 1.2  && < 2.1
     , tls           >= 1.5  && < 1.8
 
 executable demo-client
@@ -328,9 +330,11 @@ executable test-stress
   build-depends:
       -- External dependencies
     , async                >= 2.2  && < 2.3
+    , containers           >= 0.6  && < 0.7
     , contra-tracer        >= 0.2  && < 0.3
     , data-default         >= 0.7  && < 0.8
     , optparse-applicative >= 0.16 && < 0.19
+    , text                 >= 1.2  && < 2.1
     , tls                  >= 1.5  && < 1.8
 
   if !flag(build-stress-test)

--- a/src/Network/GRPC/Common/Exceptions.hs
+++ b/src/Network/GRPC/Common/Exceptions.hs
@@ -4,10 +4,14 @@
 module Network.GRPC.Common.Exceptions (
     -- * gRPC exception
     GrpcException(..)
+  , GrpcError(..)
   , grpcExceptionFromTrailers
   , grpcExceptionToTrailers
     -- * Protocol exception
   , ProtocolException(..)
+    -- * Low-level exceptions
+  , ThreadCancelled(..)
+  , ChannelClosed(..)
   ) where
 
 import Control.Exception
@@ -16,6 +20,8 @@ import Data.Text (Text)
 import Network.GRPC.Spec
 import Network.GRPC.Spec.CustomMetadata
 import Network.GRPC.Spec.RPC
+import Network.GRPC.Util.Session.Channel (ChannelClosed(..))
+import Network.GRPC.Util.Thread (ThreadCancelled(..))
 
 {-------------------------------------------------------------------------------
   gRPC exception

--- a/src/Network/GRPC/Server/Context.hs
+++ b/src/Network/GRPC/Server/Context.hs
@@ -14,6 +14,7 @@ module Network.GRPC.Server.Context (
   , ServerDebugMsg(..)
   ) where
 
+import Control.Exception
 import Control.Tracer
 import Data.Default
 
@@ -61,6 +62,8 @@ data ServerDebugMsg =
   | forall rpc.
           IsRPC rpc
        => PeerDebugMsg (Session.DebugMsg (ServerSession rpc))
+
+   | AcceptCallFailed SomeException
 
 deriving instance Show ServerDebugMsg
 

--- a/src/Network/GRPC/Util/Thread.hs
+++ b/src/Network/GRPC/Util/Thread.hs
@@ -6,6 +6,7 @@ module Network.GRPC.Util.Thread (
   , threadBody
   , cancelThread
   , getThreadInterface
+  , ThreadCancelled(..)
   ) where
 
 import Control.Concurrent
@@ -127,7 +128,7 @@ cancelThread state e = do
 
 -- | Exception thrown by 'cancelThread' to the thread to the cancelled
 newtype ThreadCancelled = ThreadCancelled {
-      reason :: SomeException
+      threadCancelledReason :: SomeException
     }
   deriving stock (Show)
   deriving anyclass (Exception)

--- a/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -47,11 +47,23 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
                       }
                 ]
             ]
-        , testCaseInfo "gzip" $
-            test_increment def {
-                clientCompr = Compr.require Compr.gzip
-              , serverCompr = Compr.require Compr.gzip
-              }
+        , testGroup "compression" [
+              testCaseInfo "gzip" $
+                test_increment def {
+                    clientCompr = Compr.require Compr.gzip
+                  , serverCompr = Compr.require Compr.gzip
+                  }
+            , testCaseInfo "serverUnsupported" $
+                test_increment def {
+                    clientCompr = Compr.require Compr.gzip
+                  , serverCompr = Compr.none
+                  }
+            , testCaseInfo "clientUnsupported" $
+                test_increment def {
+                    clientCompr = Compr.none
+                  , serverCompr = Compr.require Compr.gzip
+                  }
+            ]
         ]
     ]
 


### PR DESCRIPTION
This now makes use of the new proper Trailers-Only support to ensure that we get a proper gRPC error raised on the client side.