### PR TITLE
HTTP2/GRPC spec tweaks

### DIFF
--- a/src/Network/GRPC/Client/Connection.hs
+++ b/src/Network/GRPC/Client/Connection.hs
@@ -470,8 +470,9 @@ stayConnected connParams server connVar connCanClose =
     writeBufferSize = 4096
 
     -- TODO: This is currently only used for the HTTP case, not HTTPS
+    -- | dest is only used if mAuth is Nothing
     clientConfig :: Authority -> Maybe String -> Scheme -> HTTP2.Client.ClientConfig
-    clientConfig auth mAuth scheme = HTTP2.Client.ClientConfig {
+    clientConfig dest mAuth scheme = HTTP2.Client.ClientConfig {
           scheme    = rawScheme serverPseudoHeaders
         , authority = maybe (rawAuthority serverPseudoHeaders) BS.Strict.UTF8.fromString mAuth
 
@@ -482,7 +483,7 @@ stayConnected connParams server connVar connCanClose =
         }
       where
         serverPseudoHeaders :: RawServerHeaders
-        serverPseudoHeaders = buildServerHeaders $ ServerHeaders scheme auth
+        serverPseudoHeaders = buildServerHeaders $ ServerHeaders scheme dest
 
     tracer :: Tracer IO ClientDebugMsg
     tracer = connDebugTracer connParams

--- a/src/Network/GRPC/Spec/Request.hs
+++ b/src/Network/GRPC/Spec/Request.hs
@@ -140,7 +140,6 @@ callDefinition proxy = \hdrs -> catMaybes [
           "grpc-timeout"
         , mconcat [
               BS.Strict.C8.pack $ show $ getTimeoutValue val
-            , " "
             , case unit of
                 Hour        -> "H"
                 Minute      -> "M"


### PR DESCRIPTION
Summary:

* http authority can be different from destination
* no space before timeout unit -- this causes issues in the go grpc server

Issues:

1. Not sure what the best UX would be for specifying the authority -- `Maybe String` seems appropriate since it's expected to just be a literal header value?  But it's also not obvious what's going on if you aren't already familiar with http2/grpc.
2. Not sure if we want to also provide this ability to the TLS version, but I'm also not totally sure that that is supported in http2 in any case.