### PR TITLE
Fix timeouts/allow authority override

### DIFF
--- a/demo-client/Demo/Client/Cmdline.hs
+++ b/demo-client/Demo/Client/Cmdline.hs
@@ -129,18 +129,23 @@ parseServer =
                    , Opt.help "Connect over TLS"
                    ])
               *> parseServerValidation)
+      <*> (Opt.optional $ Opt.option Opt.str $ mconcat [
+              Opt.long "authority"
+            , Opt.help "Override the HTTP2 :authority pseudo-header"
+            ])
   where
     mkServer ::
          String                          -- Host
       -> Maybe Word                      -- Port
       -> Maybe Client.ServerValidation   -- Secure?
+      -> Maybe String
       -> Client.Server
-    mkServer host mPort Nothing =
+    mkServer host mPort Nothing mAuth =
         Client.ServerInsecure $
-          Client.Authority host (fromMaybe 50051 mPort)
-    mkServer host mPort (Just validation) =
+          Client.Address host (fromMaybe 50051 mPort) mAuth
+    mkServer host mPort (Just validation) mAuth =
         Client.ServerSecure validation def $
-          Client.Authority host (fromMaybe 50052 mPort)
+          Client.Address host (fromMaybe 50052 mPort) mAuth
 
 parseServerValidation :: Opt.Parser Client.ServerValidation
 parseServerValidation = asum [

--- a/docs/demo-client.md
+++ b/docs/demo-client.md
@@ -52,6 +52,12 @@ a self-signed certificate, the above will result in
 demo-client: HandshakeFailed (Error_Protocol ("certificate has unknown CA",True,UnknownCa))
 ```
 
+You might see an error such as this on the Python side (if using):
+
+```
+Handshake failed with fatal error SSL_ERROR_SSL: error:10000070:SSL routines:OPENSSL_internal:BAD_PACKET_LENGTH
+```
+
 There are two ways to address this. We can disable certificate validation
 altogether:
 
@@ -63,7 +69,8 @@ cabal run demo-client -- sayHello \
 ```
 
 or we can define our own roots; for example, we can declare the demo server's
-own certificate as a root:
+own certificate as a root (this works with both the Python demo server as well
+as our own):
 
 ```
 cabal run demo-client -- sayHello \

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -139,40 +139,36 @@ library
       src
       debug
   build-depends:
-      -- Lower bounds initially based on
-      --
-      -- * ghc 8.10.7
-      -- * Hackage snapshot hackage.haskell.org,2021-08-28T00:00:00Z
-    , async                >= 2.2  && < 2.3
-    , base64-bytestring    >= 1.2  && < 1.3
-    , binary               >= 0.8  && < 0.9
-    , bytestring           >= 0.10 && < 0.12
-    , case-insensitive     >= 1.2  && < 1.3
-    , containers           >= 0.6  && < 0.7
-    , contra-tracer        >= 0.2  && < 0.3
-    , data-default         >= 0.7  && < 0.8
-    , exceptions           >= 0.10 && < 0.11
-    , generics-sop         >= 0.5  && < 0.6
-    , hashable             >= 1.3  && < 1.5
-    , http-types           >= 0.12 && < 0.13
-    , http2                >= 5.0  && < 5.1
-    , http2-tls            >= 0.2  && < 0.3
-    , mtl                  >= 2.2  && < 2.4
-    , network              >= 3.1  && < 3.2
-    , network-byte-order   >= 0.1  && < 0.2
-    , network-run          >= 0.2  && < 0.3
-    , pipes                >= 4.3  && < 4.4
-    , pipes-safe           >= 2.3  && < 2.4
-    , pretty-show          >= 1.10 && < 1.11
-    , proto-lens           >= 0.7  && < 0.8
-    , random               >= 1.2  && < 1.3
-    , sop-core             >= 0.5  && < 0.6
-    , stm                  >= 2.5  && < 2.6
-    , text                 >= 1.2  && < 2.1
-    , transformers         >= 0.5  && < 0.7
-    , unordered-containers >= 0.2  && < 0.3
-    , utf8-string          >= 1.0  && < 1.1
-    , zlib                 >= 0.6  && < 0.7
+    , async                >= 2.2   && < 2.3
+    , base64-bytestring    >= 1.2   && < 1.3
+    , binary               >= 0.8   && < 0.9
+    , bytestring           >= 0.10  && < 0.12
+    , case-insensitive     >= 1.2   && < 1.3
+    , containers           >= 0.6   && < 0.7
+    , contra-tracer        >= 0.2   && < 0.3
+    , data-default         >= 0.7   && < 0.8
+    , exceptions           >= 0.10  && < 0.11
+    , generics-sop         >= 0.5   && < 0.6
+    , hashable             >= 1.3   && < 1.5
+    , http-types           >= 0.12  && < 0.13
+    , http2                >= 5.0   && < 5.1
+    , http2-tls            >= 0.2.1 && < 0.3
+    , mtl                  >= 2.2   && < 2.4
+    , network              >= 3.1   && < 3.2
+    , network-byte-order   >= 0.1   && < 0.2
+    , network-run          >= 0.2   && < 0.3
+    , pipes                >= 4.3   && < 4.4
+    , pipes-safe           >= 2.3   && < 2.4
+    , pretty-show          >= 1.10  && < 1.11
+    , proto-lens           >= 0.7   && < 0.8
+    , random               >= 1.2   && < 1.3
+    , sop-core             >= 0.5   && < 0.6
+    , stm                  >= 2.5   && < 2.6
+    , text                 >= 1.2   && < 2.1
+    , transformers         >= 0.5   && < 0.7
+    , unordered-containers >= 0.2   && < 0.3
+    , utf8-string          >= 1.0   && < 1.1
+    , zlib                 >= 0.6   && < 0.7
 
   -- tls 1.7 starts using Kazu's forked versions of x509-* packages
   if flag(crypton)

--- a/src/Network/GRPC/Client.hs
+++ b/src/Network/GRPC/Client.hs
@@ -13,7 +13,7 @@ module Network.GRPC.Client (
 
     -- ** Connection parameters
   , Scheme(..)
-  , Authority(..)
+  , Address(..)
 
     -- ** Secure connection (TLS)
   , ServerValidation(..)

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -50,18 +50,15 @@ module Network.GRPC.Spec (
   , ServerHeaders(..)
   , ResourceHeaders(..)
   , Path(..)
-  , Authority(..)
+  , Address(..)
   , Scheme(..)
   , Method(..)
   , rpcPath
     -- ** Serialization
-  , RawPseudoHeaders(..)
-  , RawServerHeaders(..)
   , RawResourceHeaders(..)
-  , InvalidPseudoHeaders(..)
+  , InvalidResourceHeaders(..)
   , buildResourceHeaders
-  , buildServerHeaders
-  , parsePseudoHeaders
+  , parseResourceHeaders
     -- ** Headers
   , buildRequestHeaders
   , parseRequestHeaders

--- a/src/Network/GRPC/Spec/Request.hs
+++ b/src/Network/GRPC/Spec/Request.hs
@@ -140,7 +140,6 @@ callDefinition proxy = \hdrs -> catMaybes [
           "grpc-timeout"
         , mconcat [
               BS.Strict.C8.pack $ show $ getTimeoutValue val
-            , " "
             , case unit of
                 Hour        -> "H"
                 Minute      -> "M"

--- a/test-common/Test/Util/ClientServer.hs
+++ b/test-common/Test/Util/ClientServer.hs
@@ -422,19 +422,21 @@ runTestClient cfg clientTracer clientRun = do
                 Client.ValidateServer $
                   Client.certStoreFromPath pubCert
 
-        clientAuthority :: Client.Authority
+        clientAuthority :: Client.Address
         clientAuthority =
             case useTLS cfg of
-              Just tlsSetup -> Client.Authority {
-                  authorityHost = case tlsSetup of
-                                    TlsFail TlsFailHostname -> "127.0.0.1"
-                                    _otherwise              -> "localhost"
-                , authorityPort = 50052
+              Just tlsSetup -> Client.Address {
+                  addressHost      = case tlsSetup of
+                                       TlsFail TlsFailHostname -> "127.0.0.1"
+                                       _otherwise              -> "localhost"
+                , addressPort      = 50052
+                , addressAuthority = Nothing
                 }
 
-              Nothing -> Client.Authority {
-                  authorityHost = "localhost"
-                , authorityPort = 50051
+              Nothing -> Client.Address {
+                  addressHost      = "localhost"
+                , addressPort      = 50051
+                , addressAuthority = Nothing
                 }
 
     clientRun $ Client.withConnection clientParams clientServer


### PR DESCRIPTION
* For timeouts, the gRPC spec does not allow spaces
* For some deployments it is useful to be able to specify the HTTP2 :authority pseudo-header separate from the address.

