### PR TITLE
Add deflate compression

### DIFF
--- a/demo-client/Demo/Client/Cmdline.hs
+++ b/demo-client/Demo/Client/Cmdline.hs
@@ -180,6 +180,10 @@ parseCompression = asum [
           Opt.long "gzip"
         , Opt.help "Use GZip compression for all messages"
         ]
+    , Opt.flag' Compr.deflate $ mconcat [
+          Opt.long "deflate"
+        , Opt.help "Use deflate compression for all messages"
+        ]
     ]
 
 parseAPI :: Opt.Parser API

--- a/docs/demo-client.md
+++ b/docs/demo-client.md
@@ -138,15 +138,15 @@ actually compress anything:
   https://github.com/grpc/grpc/blob/master/examples/python/compression/README.md
 * You need to send a "name" that is long enough that the server actually
   bothers with compression at all.
-* You can also use the `--gzip` command line flag to tell the server to /only/
-  use GZip compression.
+* You can also use the `--gzip` or `--deflate` command line flag to tell the
+  server to *only* use GZip or Deflate compression, respectively.
 
 For example:
 
 ```
-cabal run demo-client -- --gzip sayHello \
-  --name 'John' \
-  --name '0xxxxxxxxxx1xxxxxxxxxx2xxxxxxxxxx3xxxxxxxxxx4xxxxxxxxxx5xxxxxxxxxx'
+cabal run demo-client -- --gzip \
+  sayHello --name 'John' \
+  sayHello --name '0xxxxxxxxxx1xxxxxxxxxx2xxxxxxxxxx3xxxxxxxxxx4xxxxxxxxxx5xxxxxxxxxx'
 ```
 
 Of course, the compression is transparent to the user, but you can observe it

--- a/src/Network/GRPC/Common/Compression.hs
+++ b/src/Network/GRPC/Common/Compression.hs
@@ -11,6 +11,7 @@ module Network.GRPC.Common.Compression (
     -- * Standard compression schemes
   , noCompression
   , gzip
+  , deflate
   , allSupportedCompression
     -- * Negotation
   , Negotation(..)

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -40,6 +40,7 @@ module Network.GRPC.Spec (
     -- ** Compression algorithms
   , noCompression
   , gzip
+  , deflate
   , allSupportedCompression
     -- * Requests
   , RequestHeaders(..)

--- a/src/Network/GRPC/Spec/Compression.hs
+++ b/src/Network/GRPC/Spec/Compression.hs
@@ -15,9 +15,11 @@ module Network.GRPC.Spec.Compression (
     -- * Specific coders
   , noCompression
   , gzip
+  , deflate
   ) where
 
 import Codec.Compression.GZip qualified as GZip
+import Codec.Compression.Zlib qualified as Deflate
 import Data.ByteString qualified as Strict (ByteString)
 import Data.ByteString.Lazy qualified as Lazy (ByteString)
 import Data.ByteString.UTF8 qualified as BS.Strict.UTF8
@@ -50,7 +52,7 @@ instance Show Compression where
 -- The order of this list is important: algorithms listed earlier are preferred
 -- over algorithms listed later.
 allSupportedCompression :: NonEmpty Compression
-allSupportedCompression = gzip :| [noCompression]
+allSupportedCompression = gzip :| [deflate, noCompression]
 
 {-------------------------------------------------------------------------------
   Compression ID
@@ -110,4 +112,18 @@ gzip = Compression {
       compressionId = GZip
     , compress      = GZip.compress
     , decompress    = GZip.decompress
+    }
+
+-- | zlib deflate compression
+--
+-- Note: The gRPC spec calls this "deflate", but it is /not/ raw deflate
+-- format. The expected format (at least by the python server) is just zlib
+-- (which is an envelope holding the deflate data).
+--
+-- TODO: We should deal with exceptions during decompression
+deflate :: Compression
+deflate = Compression {
+      compressionId = Deflate
+    , compress      = Deflate.compress
+    , decompress    = Deflate.decompress
     }

--- a/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -84,6 +84,11 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
                     clientCompr = Compr.require Compr.gzip
                   , serverCompr = Compr.require Compr.gzip
                   }
+            , testCaseInfo "deflate" $
+                test_increment def {
+                    clientCompr = Compr.require Compr.deflate
+                  , serverCompr = Compr.require Compr.deflate
+                  }
             , testCaseInfo "serverUnsupported" $
                 test_increment def {
                     clientCompr = Compr.require Compr.gzip
@@ -92,6 +97,11 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
             , testCaseInfo "clientUnsupported" $
                 test_increment def {
                     clientCompr = Compr.none
+                  , serverCompr = Compr.require Compr.gzip
+                  }
+            , testCaseInfo "mismatch" $
+                test_increment def {
+                    clientCompr = Compr.require Compr.deflate
                   , serverCompr = Compr.require Compr.gzip
                   }
             ]


### PR DESCRIPTION
Tested and works with the python and C++ implementations, added a basic test to the binary increment test group that uses deflate compression.

Resolves #55 