### PR TITLE
Introduce `InboundEnvelope` and `OutboundEnvelope`

### DIFF
--- a/dev/grpc-proto/README.md
+++ b/dev/grpc-proto/README.md
@@ -1,0 +1,4 @@
+# `.proto` files from the gRPC repo
+
+These are copied and slightly modified for easier loading into Wireshark.
+Based on version v1.60.0.

--- a/dev/grpc-proto/empty.proto
+++ b/dev/grpc-proto/empty.proto
@@ -1,0 +1,28 @@
+
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+// An empty message that you can re-use to avoid defining duplicated empty
+// messages in your project. A typical example is to use it as argument or the
+// return value of a service API. For instance:
+//
+//   service Foo {
+//     rpc Bar (grpc.testing.Empty) returns (grpc.testing.Empty) { };
+//   };
+//
+message Empty {}

--- a/dev/grpc-proto/helloworld.proto
+++ b/dev/grpc-proto/helloworld.proto
@@ -1,0 +1,42 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+  rpc SayHelloStreamReply (HelloRequest) returns (stream HelloReply) {}
+
+  rpc SayHelloBidiStream (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/dev/grpc-proto/messages.proto
+++ b/dev/grpc-proto/messages.proto
@@ -1,0 +1,347 @@
+// Copyright 2015-2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Message definitions to be used by integration test service definitions.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+option java_package = "io.grpc.testing.integration";
+
+// TODO(dgq): Go back to using well-known types once
+// https://github.com/grpc/grpc/issues/6980 has been fixed.
+// import "google/protobuf/wrappers.proto";
+message BoolValue {
+  // The bool value.
+  bool value = 1;
+}
+
+// The type of payload that should be returned.
+enum PayloadType {
+  // Compressable text format.
+  COMPRESSABLE = 0;
+}
+
+// A block of data, to simply increase gRPC message size.
+message Payload {
+  // The type of data in body.
+  PayloadType type = 1;
+  // Primary contents of payload.
+  bytes body = 2;
+}
+
+// A protobuf representation for grpc status. This is used by test
+// clients to specify a status that the server should attempt to return.
+message EchoStatus {
+  int32 code = 1;
+  string message = 2;
+}
+
+// The type of route that a client took to reach a server w.r.t. gRPCLB.
+// The server must fill in "fallback" if it detects that the RPC reached
+// the server via the "gRPCLB fallback" path, and "backend" if it detects
+// that the RPC reached the server via "gRPCLB backend" path (i.e. if it got
+// the address of this server from the gRPCLB server BalanceLoad RPC). Exactly
+// how this detection is done is context and server dependent.
+enum GrpclbRouteType {
+  // Server didn't detect the route that a client took to reach it.
+  GRPCLB_ROUTE_TYPE_UNKNOWN = 0;
+  // Indicates that a client reached a server via gRPCLB fallback.
+  GRPCLB_ROUTE_TYPE_FALLBACK = 1;
+  // Indicates that a client reached a server as a gRPCLB-given backend.
+  GRPCLB_ROUTE_TYPE_BACKEND = 2;
+}
+
+// Unary request.
+message SimpleRequest {
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, server randomly chooses one from other formats.
+  PayloadType response_type = 1;
+
+  // Desired payload size in the response from the server.
+  int32 response_size = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether SimpleResponse should include username.
+  bool fill_username = 4;
+
+  // Whether SimpleResponse should include OAuth scope.
+  bool fill_oauth_scope = 5;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue response_compressed = 6;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+
+  // Whether the server should expect this request to be compressed.
+  BoolValue expect_compressed = 8;
+
+  // Whether SimpleResponse should include server_id.
+  bool fill_server_id = 9;
+
+  // Whether SimpleResponse should include grpclb_route_type.
+  bool fill_grpclb_route_type = 10;
+
+  // If set the server should record this metrics report data for the current RPC.
+  TestOrcaReport orca_per_query_report = 11;
+}
+
+// Unary response, as configured by the request.
+message SimpleResponse {
+  // Payload to increase message size.
+  Payload payload = 1;
+  // The user the request came from, for verifying authentication was
+  // successful when the client expected it.
+  string username = 2;
+  // OAuth scope.
+  string oauth_scope = 3;
+
+  // Server ID. This must be unique among different server instances,
+  // but the same across all RPC's made to a particular server instance.
+  string server_id = 4;
+  // gRPCLB Path.
+  GrpclbRouteType grpclb_route_type = 5;
+
+  // Server hostname.
+  string hostname = 6;
+}
+
+// Client-streaming request.
+message StreamingInputCallRequest {
+  // Optional input payload sent along with the request.
+  Payload payload = 1;
+
+  // Whether the server should expect this request to be compressed. This field
+  // is "nullable" in order to interoperate seamlessly with servers not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the request's compression status.
+  BoolValue expect_compressed = 2;
+
+  // Not expecting any payload from the response.
+}
+
+// Client-streaming response.
+message StreamingInputCallResponse {
+  // Aggregated size of payloads received from the client.
+  int32 aggregated_payload_size = 1;
+}
+
+// Configuration for a particular response.
+message ResponseParameters {
+  // Desired payload sizes in responses from the server.
+  int32 size = 1;
+
+  // Desired interval between consecutive responses in the response stream in
+  // microseconds.
+  int32 interval_us = 2;
+
+  // Whether to request the server to compress the response. This field is
+  // "nullable" in order to interoperate seamlessly with clients not able to
+  // implement the full compression tests by introspecting the call to verify
+  // the response's compression status.
+  BoolValue compressed = 3;
+}
+
+// Server-streaming request.
+message StreamingOutputCallRequest {
+  // Desired payload type in the response from the server.
+  // If response_type is RANDOM, the payload from each response in the stream
+  // might be of different types. This is to simulate a mixed type of payload
+  // stream.
+  PayloadType response_type = 1;
+
+  // Configuration for each expected response message.
+  repeated ResponseParameters response_parameters = 2;
+
+  // Optional input payload sent along with the request.
+  Payload payload = 3;
+
+  // Whether server should return a given status
+  EchoStatus response_status = 7;
+
+  // If set the server should update this metrics report data at the OOB server.
+  TestOrcaReport orca_oob_report = 8;
+}
+
+// Server-streaming response, as configured by the request and parameters.
+message StreamingOutputCallResponse {
+  // Payload to increase response size.
+  Payload payload = 1;
+}
+
+// For reconnect interop test only.
+// Client tells server what reconnection parameters it used.
+message ReconnectParams {
+  int32 max_reconnect_backoff_ms = 1;
+}
+
+// For reconnect interop test only.
+// Server tells client whether its reconnects are following the spec and the
+// reconnect backoffs it saw.
+message ReconnectInfo {
+  bool passed = 1;
+  repeated int32 backoff_ms = 2;
+}
+
+message LoadBalancerStatsRequest {
+  // Request stats for the next num_rpcs sent by client.
+  int32 num_rpcs = 1;
+  // If num_rpcs have not completed within timeout_sec, return partial results.
+  int32 timeout_sec = 2;
+  // Response header + trailer metadata entries we want the values of.
+  // Matching of the keys is case-insensitive as per rfc7540#section-8.1.2
+  // * (asterisk) is a special value that will return all metadata entries
+  repeated string metadata_keys = 3;
+}
+
+message LoadBalancerStatsResponse {
+  enum MetadataType {
+    UNKNOWN = 0;
+    INITIAL = 1;
+    TRAILING = 2;
+  }
+  message MetadataEntry {
+    // Key, exactly as received from the server. Case may be different from what
+    // was requested in the LoadBalancerStatsRequest)
+    string key = 1;
+    // Value, exactly as received from the server.
+    string value = 2;
+    // Metadata type
+    MetadataType type = 3;
+  }
+  message RpcMetadata {
+    // metadata values for each rpc for the keys specified in
+    // LoadBalancerStatsRequest.metadata_keys.
+    repeated MetadataEntry metadata = 1;
+  }
+  message MetadataByPeer {
+    // List of RpcMetadata in for each RPC with a given peer
+    repeated RpcMetadata rpc_metadata = 1;
+  }
+  message RpcsByPeer {
+    // The number of completed RPCs for each peer.
+    map<string, int32> rpcs_by_peer = 1;
+  }
+  // The number of completed RPCs for each peer.
+  map<string, int32> rpcs_by_peer = 1;
+  // The number of RPCs that failed to record a remote peer.
+  int32 num_failures = 2;
+  map<string, RpcsByPeer> rpcs_by_method = 3;
+  // All the metadata of all RPCs for each peer.
+  map<string, MetadataByPeer> metadatas_by_peer = 4;
+}
+
+// Request for retrieving a test client's accumulated stats.
+message LoadBalancerAccumulatedStatsRequest {}
+
+// Accumulated stats for RPCs sent by a test client.
+message LoadBalancerAccumulatedStatsResponse {
+  // The total number of RPCs have ever issued for each type.
+  // Deprecated: use stats_per_method.rpcs_started instead.
+  map<string, int32> num_rpcs_started_by_method = 1 [deprecated = true];
+  // The total number of RPCs have ever completed successfully for each type.
+  // Deprecated: use stats_per_method.result instead.
+  map<string, int32> num_rpcs_succeeded_by_method = 2 [deprecated = true];
+  // The total number of RPCs have ever failed for each type.
+  // Deprecated: use stats_per_method.result instead.
+  map<string, int32> num_rpcs_failed_by_method = 3 [deprecated = true];
+
+  message MethodStats {
+    // The number of RPCs that were started for this method.
+    int32 rpcs_started = 1;
+
+    // The number of RPCs that completed with each status for this method.  The
+    // key is the integral value of a google.rpc.Code; the value is the count.
+    map<int32, int32> result = 2;
+  }
+
+  // Per-method RPC statistics.  The key is the RpcType in string form; e.g.
+  // 'EMPTY_CALL' or 'UNARY_CALL'
+  map<string, MethodStats> stats_per_method = 4;
+}
+
+// Configurations for a test client.
+message ClientConfigureRequest {
+  // Type of RPCs to send.
+  enum RpcType {
+    EMPTY_CALL = 0;
+    UNARY_CALL = 1;
+  }
+
+  // Metadata to be attached for the given type of RPCs.
+  message Metadata {
+    RpcType type = 1;
+    string key = 2;
+    string value = 3;
+  }
+
+  // The types of RPCs the client sends.
+  repeated RpcType types = 1;
+  // The collection of custom metadata to be attached to RPCs sent by the client.
+  repeated Metadata metadata = 2;
+  // The deadline to use, in seconds, for all RPCs.  If unset or zero, the
+  // client will use the default from the command-line.
+  int32 timeout_sec = 3;
+}
+
+// Response for updating a test client's configuration.
+message ClientConfigureResponse {}
+
+message MemorySize {
+  int64 rss = 1;
+}
+
+// Metrics data the server will update and send to the client. It mirrors orca load report
+// https://github.com/cncf/xds/blob/eded343319d09f30032952beda9840bbd3dcf7ac/xds/data/orca/v3/orca_load_report.proto#L15,
+// but avoids orca dependency. Used by both per-query and out-of-band reporting tests.
+message TestOrcaReport {
+  double cpu_utilization = 1;
+  double memory_utilization = 2;
+  map<string, double> request_cost = 3;
+  map<string, double> utilization = 4;
+}
+
+// Status that will be return to callers of the Hook method
+message SetReturnStatusRequest {
+  int32 grpc_code_to_return = 1;
+  string grpc_status_description = 2;
+}
+
+message HookRequest {
+  enum HookRequestCommand {
+    // Default value
+    UNSPECIFIED = 0;
+    // Start the HTTP endpoint
+    START = 1;
+    // Stop
+    STOP = 2;
+    // Return from HTTP GET/POST
+    RETURN = 3;
+  }
+  HookRequestCommand command = 1;
+  int32 grpc_code_to_return = 2;
+  string grpc_status_description = 3;
+  // Server port to listen to
+  int32 server_port = 4;
+}
+
+message HookResponse {
+}

--- a/dev/grpc-proto/route_guide.proto
+++ b/dev/grpc-proto/route_guide.proto
@@ -1,0 +1,111 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.routeguide";
+option java_outer_classname = "RouteGuideProto";
+option objc_class_prefix = "RTG";
+
+package routeguide;
+
+// Interface exported by the server.
+service RouteGuide {
+  // A simple RPC.
+  //
+  // Obtains the feature at a given position.
+  //
+  // A feature with an empty name is returned if there's no feature at the given
+  // position.
+  rpc GetFeature(Point) returns (Feature) {}
+
+  // A server-to-client streaming RPC.
+  //
+  // Obtains the Features available within the given Rectangle.  Results are
+  // streamed rather than returned at once (e.g. in a response message with a
+  // repeated field), as the rectangle may cover a large area and contain a
+  // huge number of features.
+  rpc ListFeatures(Rectangle) returns (stream Feature) {}
+
+  // A client-to-server streaming RPC.
+  //
+  // Accepts a stream of Points on a route being traversed, returning a
+  // RouteSummary when traversal is completed.
+  rpc RecordRoute(stream Point) returns (RouteSummary) {}
+
+  // A Bidirectional streaming RPC.
+  //
+  // Accepts a stream of RouteNotes sent while a route is being traversed,
+  // while receiving other RouteNotes (e.g. from other users).
+  rpc RouteChat(stream RouteNote) returns (stream RouteNote) {}
+}
+
+// Points are represented as latitude-longitude pairs in the E7 representation
+// (degrees multiplied by 10**7 and rounded to the nearest integer).
+// Latitudes should be in the range +/- 90 degrees and longitude should be in
+// the range +/- 180 degrees (inclusive).
+message Point {
+  int32 latitude = 1;
+  int32 longitude = 2;
+}
+
+// A latitude-longitude rectangle, represented as two diagonally opposite
+// points "lo" and "hi".
+message Rectangle {
+  // One corner of the rectangle.
+  Point lo = 1;
+
+  // The other corner of the rectangle.
+  Point hi = 2;
+}
+
+// A feature names something at a given point.
+//
+// If a feature could not be named, the name is empty.
+message Feature {
+  // The name of the feature.
+  string name = 1;
+
+  // The point where the feature is detected.
+  Point location = 2;
+}
+
+// A RouteNote is a message sent while at a given point.
+message RouteNote {
+  // The location from which the message is sent.
+  Point location = 1;
+
+  // The message to be sent.
+  string message = 2;
+}
+
+// A RouteSummary is received in response to a RecordRoute rpc.
+//
+// It contains the number of individual points received, the number of
+// detected features, and the total distance covered as the cumulative sum of
+// the distance between each point.
+message RouteSummary {
+  // The number of points received.
+  int32 point_count = 1;
+
+  // The number of known features passed while traversing the route.
+  int32 feature_count = 2;
+
+  // The distance covered in metres.
+  int32 distance = 3;
+
+  // The duration of the traversal in seconds.
+  int32 elapsed_time = 4;
+}

--- a/dev/grpc-proto/test.proto
+++ b/dev/grpc-proto/test.proto
@@ -1,0 +1,116 @@
+
+// Copyright 2015-2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+
+syntax = "proto3";
+
+import "empty.proto";
+import "messages.proto";
+
+package grpc.testing;
+
+option java_package = "io.grpc.testing.integration";
+
+// A simple service to test the various types of RPCs and experiment with
+// performance with various types of payload.
+service TestService {
+  // One empty request followed by one empty response.
+  rpc EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+
+  // One request followed by one response.
+  rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // One request followed by one response. Response has cache control
+  // headers set such that a caching HTTP proxy (such as GFE) can
+  // satisfy subsequent requests.
+  rpc CacheableUnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // One request followed by a sequence of responses (streamed download).
+  // The server returns the payload with client desired type and sizes.
+  rpc StreamingOutputCall(StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // A sequence of requests followed by one response (streamed upload).
+  // The server returns the aggregated size of client payload as the result.
+  rpc StreamingInputCall(stream StreamingInputCallRequest)
+      returns (StreamingInputCallResponse);
+
+  // A sequence of requests with each request served by the server immediately.
+  // As one request could lead to multiple responses, this interface
+  // demonstrates the idea of full duplexing.
+  rpc FullDuplexCall(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // A sequence of requests followed by a sequence of responses.
+  // The server buffers all the client requests and then serves them in order. A
+  // stream of responses are returned to the client when the server starts with
+  // first request.
+  rpc HalfDuplexCall(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // The test server will not implement this method. It will be used
+  // to test the behavior when clients call unimplemented methods.
+  rpc UnimplementedCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+}
+
+// A simple service NOT implemented at servers so clients can test for
+// that case.
+service UnimplementedService {
+  // A call that no server should implement
+  rpc UnimplementedCall(grpc.testing.Empty) returns (grpc.testing.Empty);
+}
+
+// A service used to control reconnect server.
+service ReconnectService {
+  rpc Start(grpc.testing.ReconnectParams) returns (grpc.testing.Empty);
+  rpc Stop(grpc.testing.Empty) returns (grpc.testing.ReconnectInfo);
+}
+
+// A service used to obtain stats for verifying LB behavior.
+service LoadBalancerStatsService {
+  // Gets the backend distribution for RPCs sent by a test client.
+  rpc GetClientStats(LoadBalancerStatsRequest)
+      returns (LoadBalancerStatsResponse) {}
+
+  // Gets the accumulated stats for RPCs sent by a test client.
+  rpc GetClientAccumulatedStats(LoadBalancerAccumulatedStatsRequest)
+      returns (LoadBalancerAccumulatedStatsResponse) {}
+}
+
+// Hook service. Used to keep Kubernetes from shutting the pod down.
+service HookService {
+  // Sends a request that will "hang" until the return status is set by a call
+  // to a SetReturnStatus
+  rpc Hook(grpc.testing.Empty) returns (grpc.testing.Empty);
+  // Sets a return status for pending and upcoming calls to Hook
+  rpc SetReturnStatus(SetReturnStatusRequest) returns (grpc.testing.Empty);
+  // Clears the return status. Incoming calls to Hook will "hang"
+  rpc ClearReturnStatus(grpc.testing.Empty) returns (grpc.testing.Empty);
+}
+
+// A service to remotely control health status of an xDS test server.
+service XdsUpdateHealthService {
+  rpc SetServing(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc SetNotServing(grpc.testing.Empty) returns (grpc.testing.Empty);
+  rpc SendHookRequest(HookRequest) returns (HookResponse);
+}
+
+// A service to dynamically update the configuration of an xDS test client.
+service XdsUpdateClientConfigureService {
+  // Update the tes client's configuration.
+  rpc Configure(ClientConfigureRequest) returns (ClientConfigureResponse);
+}

--- a/dev/wireshark.md
+++ b/dev/wireshark.md
@@ -12,12 +12,10 @@ communication and 50052 for secure communication):
 
 * `Protocols/HTTP/SSL/TLS Ports`: add 50052
 
-* `Protocols/Protobuf/Protobuf search paths`: make sure that the directory
-  containing the `.proto` definitions for the examples is listed here:
-
-  - /path/to/grpc-repo/examples/protos
-
-  For each of these you should enable "Load all files"
+* `Protocols/Protobuf/Protobuf search paths`: include
+  `/path/to/grapesy/dev/grpc-proto`. This contains a slightly modified version
+  of various `.proto` files from the official gRPC repo, specifically for use
+  in Wireshark.  Enable "Load all files".
 
 * `Preferences`/`Protocols`/`TLS`/`(Pre-)-Master-Secret log filename`:
   Set this to the same path that you set the `SSLKEYLOGFILE` environment

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -196,7 +196,6 @@ test-suite test-grapesy
   import:
       lang
   ghc-options:
-      -Wprepositive-qualified-module
       -threaded
       -rtsopts
   type:
@@ -205,6 +204,7 @@ test-suite test-grapesy
       test-grapesy
       test-common
       debug
+      proto
   main-is:
       Main.hs
   other-modules:
@@ -217,6 +217,7 @@ test-suite test-grapesy
       Test.Prop.Dialogue
       Test.Prop.Serialization
       Test.Sanity.HalfClosedLocal
+      Test.Sanity.Interop
       Test.Sanity.StreamingType.CustomFormat
       Test.Sanity.StreamingType.NonStreaming
       Test.Util.ClientServer
@@ -224,28 +225,34 @@ test-suite test-grapesy
 
       Paths_grapesy
 
+      Proto.Src.Proto.Grpc.Testing.Empty
+      Proto.Src.Proto.Grpc.Testing.Messages
+      Proto.Src.Proto.Grpc.Testing.Test
+
       Debug.Concurrent
   build-depends:
       -- Internal dependencies
     , grapesy
   build-depends:
       -- External dependencies
-    , async            >= 2.2  && < 2.3
-    , bytestring       >= 0.10 && < 0.12
-    , serialise        >= 0.2  && < 0.3
-    , containers       >= 0.6  && < 0.7
-    , contra-tracer    >= 0.2  && < 0.3
-    , data-default     >= 0.7  && < 0.8
-    , exceptions       >= 0.10 && < 0.11
-    , mtl              >= 2.2  && < 2.4
-    , pretty-show      >= 1.10 && < 1.11
-    , QuickCheck       >= 2.14 && < 2.15
-    , stm              >= 2.5  && < 2.6
-    , tasty            >= 1.4  && < 1.6
-    , tasty-hunit      >= 0.10 && < 0.11
-    , tasty-quickcheck >= 0.10 && < 0.11
-    , text             >= 1.2  && < 2.1
-    , tls              >= 1.5  && < 1.10
+    , async              >= 2.2  && < 2.3
+    , bytestring         >= 0.10 && < 0.12
+    , containers         >= 0.6  && < 0.7
+    , contra-tracer      >= 0.2  && < 0.3
+    , data-default       >= 0.7  && < 0.8
+    , exceptions         >= 0.10 && < 0.11
+    , mtl                >= 2.2  && < 2.4
+    , pretty-show        >= 1.10 && < 1.11
+    , proto-lens         >= 0.7  && < 0.8
+    , proto-lens-runtime >= 0.7  && < 0.8
+    , QuickCheck         >= 2.14 && < 2.15
+    , serialise          >= 0.2  && < 0.3
+    , stm                >= 2.5  && < 2.6
+    , tasty              >= 1.4  && < 1.6
+    , tasty-hunit        >= 0.10 && < 0.11
+    , tasty-quickcheck   >= 0.10 && < 0.11
+    , text               >= 1.2  && < 2.1
+    , tls                >= 1.5  && < 1.10
 
 executable demo-client
   import:

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -241,6 +241,7 @@ test-suite test-grapesy
     , contra-tracer      >= 0.2  && < 0.3
     , data-default       >= 0.7  && < 0.8
     , exceptions         >= 0.10 && < 0.11
+    , lens               >= 5.0  && < 5.3
     , mtl                >= 2.2  && < 2.4
     , pretty-show        >= 1.10 && < 1.11
     , proto-lens         >= 0.7  && < 0.8

--- a/interop/Interop/Server.hs
+++ b/interop/Interop/Server.hs
@@ -49,8 +49,8 @@ methodsTestService =
     $ Method (mkNonStreaming handleEmptyCall)
     $ RawMethod (mkRpcHandler Proxy handleFullDuplexCall)
     $ UnsupportedMethod -- halfDuplexCall
-    $ Method (mkClientStreaming handleStreamingInputCall)
-    $ Method (mkServerStreaming handleStreamingOutputCall)
+    $ RawMethod (mkRpcHandler Proxy handleStreamingInputCall)
+    $ RawMethod (mkRpcHandler Proxy handleStreamingOutputCall)
     $ RawMethod (mkRpcHandler Proxy handleUnaryCall)
     $ UnsupportedMethod -- unimplementedCall
     $ NoMoreMethods

--- a/interop/Interop/Server/TestService/FullDuplexCall.hs
+++ b/interop/Interop/Server/TestService/FullDuplexCall.hs
@@ -23,13 +23,12 @@ handleFullDuplexCall call = do
 
     let handleRequest :: StreamingOutputCallRequest -> IO ()
         handleRequest request = do
-            handleStreamingOutputCall request sendResponse
+            handleStreamingOutputCallRequest call request
             echoStatus (request ^. #responseStatus) trailers
 
         loop :: IO ()
         loop = do
             streamElem <- recvInput call
-            print streamElem
             case streamElem of
               StreamElem  r   -> handleRequest r >> loop
               FinalElem   r _ -> handleRequest r
@@ -37,6 +36,3 @@ handleFullDuplexCall call = do
 
     loop
     sendTrailers call trailers
-  where
-    sendResponse :: StreamingOutputCallResponse -> IO ()
-    sendResponse = sendOutput call . StreamElem

--- a/interop/Interop/Server/TestService/StreamingInputCall.hs
+++ b/interop/Interop/Server/TestService/StreamingInputCall.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedLabels  #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Interop.Server.TestService.StreamingInputCall (handleStreamingInputCall) where
 
@@ -9,33 +10,42 @@ import Data.ProtoLens
 import Data.ProtoLens.Labels ()
 
 import Network.GRPC.Common
+import Network.GRPC.Server
+import Network.GRPC.Spec
 
 import Proto.Src.Proto.Grpc.Testing.Messages
+import Proto.Src.Proto.Grpc.Testing.Test
+
+import Interop.Server.Util
 
 -- | Handle @TestService.StreamingInputCall@
 --
 -- <https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#streaminginputcall>
+-- <https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#client_compressed_streaming>
 handleStreamingInputCall ::
-     IO (StreamElem NoMetadata StreamingInputCallRequest)
-  -> IO StreamingInputCallResponse
-handleStreamingInputCall getRequest = do
+     Call (Protobuf TestService "streamingInputCall")
+  -> IO ()
+handleStreamingInputCall call = do
     sz <- loop 0
-    return $ defMessage & #aggregatedPayloadSize .~ fromIntegral sz
+
+    let response :: StreamingInputCallResponse
+        response = defMessage & #aggregatedPayloadSize .~ fromIntegral sz
+
+    sendFinalOutput call (response, [])
   where
     -- Returns the sum of all request payload bodies received.
     loop :: Int -> IO Int
     loop !acc = do
-        streamElem <- getRequest
+        streamElem <- recvInputWithEnvelope call
         case streamElem of
           StreamElem  r   -> handleRequest r >>= \sz -> loop (acc + sz)
           FinalElem   r _ -> handleRequest r >>= \sz -> return $ acc + sz
           NoMoreElems   _ -> return acc
 
-    handleRequest :: StreamingInputCallRequest -> IO Int
-    handleRequest request =
+    handleRequest :: (InboundEnvelope, StreamingInputCallRequest) -> IO Int
+    handleRequest (envelope, request) = do
+        checkInboundCompression expectCompressed envelope
         return $ BS.Strict.length (request ^. #payload ^. #body)
       where
-        -- TODO: grapesy does not currently make it possible to inspect
-        -- whether a message is compressed or not.
-        _expectCompressed :: Bool
-        _expectCompressed = request ^. #expectCompressed ^. #value
+        expectCompressed :: Bool
+        expectCompressed = request ^. #expectCompressed ^. #value

--- a/interop/Interop/Server/TestService/StreamingOutputCall.hs
+++ b/interop/Interop/Server/TestService/StreamingOutputCall.hs
@@ -1,15 +1,25 @@
 {-# LANGUAGE OverloadedLabels #-}
 
-module Interop.Server.TestService.StreamingOutputCall (handleStreamingOutputCall) where
+module Interop.Server.TestService.StreamingOutputCall (
+    handleStreamingOutputCall
+  , handleStreamingOutputCallRequest
+  ) where
 
 import Control.Concurrent
 import Control.Lens ((.~), (^.))
 import Control.Monad
+import Data.Default
 import Data.Function ((&))
 import Data.ProtoLens
 import Data.ProtoLens.Labels ()
+import Data.ProtoLens.Service.Types
+
+import Network.GRPC.Common
+import Network.GRPC.Server
+import Network.GRPC.Spec
 
 import Proto.Src.Proto.Grpc.Testing.Messages
+import Proto.Src.Proto.Grpc.Testing.Test
 
 import Interop.Server.Util
 
@@ -17,21 +27,38 @@ import Interop.Server.Util
 --
 -- <https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#streamingoutputcall>
 handleStreamingOutputCall ::
-     StreamingOutputCallRequest
-  -> (StreamingOutputCallResponse -> IO ())
+     Call (Protobuf TestService "streamingOutputCall")
   -> IO ()
-handleStreamingOutputCall request sendResponse =
+handleStreamingOutputCall call = do
+    request <- recvFinalInput call
+    handleStreamingOutputCallRequest call request
+    sendTrailers call []
+
+-- | Handle specific request
+--
+-- Abstracted out because also used in the @fullDuplexCall@ test.
+handleStreamingOutputCallRequest :: forall meth.
+     (MethodOutput TestService meth ~ StreamingOutputCallResponse)
+  => Call (Protobuf TestService meth)
+  -> StreamingOutputCallRequest
+  -> IO ()
+handleStreamingOutputCallRequest call request =
     forM_ (request ^. #responseParameters) $ \responseParameters -> do
       let size, intervalUs :: Int
           size       = fromIntegral $ responseParameters ^. #size
           intervalUs = fromIntegral $ responseParameters ^. #intervalUs
 
-          -- TODO: grapesy currently does not support setting compression
-          -- on a per-response basis
-          _compressed :: Bool
-          _compressed = responseParameters ^. #compressed ^. #value
+          shouldCompress :: Bool
+          shouldCompress = responseParameters ^. #compressed ^. #value
 
       payload <- mkPayload COMPRESSABLE size
-      sendResponse $ defMessage & #payload .~ payload
+
+      let envelope :: OutboundEnvelope
+          envelope = def { outboundEnableCompression = shouldCompress }
+
+          response :: StreamingOutputCallResponse
+          response = defMessage & #payload .~ payload
+
+      sendOutputWithEnvelope call $ StreamElem (envelope, response)
       threadDelay intervalUs
 

--- a/interop/Interop/Server/TestService/UnaryCall.hs
+++ b/interop/Interop/Server/TestService/UnaryCall.hs
@@ -4,12 +4,15 @@
 module Interop.Server.TestService.UnaryCall (handleUnaryCall) where
 
 import Control.Lens ((.~), (^.))
+import Data.Default
 import Data.Function ((&))
 import Data.ProtoLens
 import Data.ProtoLens.Labels ()
 
 import Network.GRPC.Common
+import Network.GRPC.Common.StreamElem qualified as StreamElem
 import Network.GRPC.Server
+import Network.GRPC.Spec
 
 import Proto.Src.Proto.Grpc.Testing.Messages
 import Proto.Src.Proto.Grpc.Testing.Test
@@ -24,12 +27,36 @@ import Interop.Server.Util
 -- <https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#unarycall>
 handleUnaryCall :: Call (Protobuf TestService "unaryCall") -> IO ()
 handleUnaryCall call = do
+    -- Send initial metadata, hold on the trailers
     trailers <- constructResponseMetadata call
-    request :: SimpleRequest <- recvFinalInput call
+
+    -- Wait for the request
+    (inboundEnvelope, request) <- do
+      streamElem <- recvInputWithEnvelope call
+      case StreamElem.value streamElem of
+        Nothing -> fail "Expected element"
+        Just x  -> return x
+
+    -- Check compression of the input
+    -- <https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#client_compressed_unary>
+    let expectCompressed :: Bool
+        expectCompressed = request ^. #expectCompressed . #value
+    checkInboundCompression expectCompressed inboundEnvelope
+
+    -- Send response
     payload <- mkPayload (request ^. #responseType) (request ^. #responseSize)
-    let response :: SimpleResponse
+
+    let outboundEnvelope :: OutboundEnvelope
+        outboundEnvelope = def {
+              outboundEnableCompression =
+                request ^. #responseCompressed . #value
+            }
+
+        response :: SimpleResponse
         response = defMessage & #payload .~ payload
-    sendOutput call $ StreamElem response
+
+    sendOutputWithEnvelope call $ StreamElem (outboundEnvelope, response)
+
+    -- Send status and trailers
     echoStatus (request ^. #responseStatus) trailers
     sendTrailers call trailers
-

--- a/interop/Interop/Server/Util.hs
+++ b/interop/Interop/Server/Util.hs
@@ -6,6 +6,7 @@ module Interop.Server.Util (
     throwUnrecognized
     -- * Dealing with the test-suite's message types
   , mkPayload
+  , clearPayload
   , constructResponseMetadata
   , echoStatus
   ) where
@@ -13,7 +14,9 @@ module Interop.Server.Util (
 import Control.Exception
 import Control.Lens ((&), (.~), (^.))
 import Data.ByteString qualified as BS.Strict
+import Data.ByteString qualified as Strict (ByteString)
 import Data.ProtoLens
+import Data.ProtoLens.Field (HasField)
 import Data.ProtoLens.Labels ()
 import Data.Text qualified as Text
 
@@ -56,6 +59,13 @@ mkPayload type' size = do
       defMessage
         & #type' .~ type'
         & #body  .~ body
+
+clearPayload ::
+     ( HasField a "payload" b
+     , HasField b "body" Strict.ByteString
+     )
+  => a -> a
+clearPayload x = x & #payload . #body .~ BS.Strict.empty
 
 -- | Construct response metadata
 --

--- a/src/Network/GRPC/Client.hs
+++ b/src/Network/GRPC/Client.hs
@@ -48,8 +48,10 @@ module Network.GRPC.Client (
   , recvFinalOutput
   , recvAllOutputs
 
-    -- ** Low-level API
+    -- ** Low-level\/specialized API
   , isCallHealthy
+  , sendInputWithEnvelope
+  , recvOutputWithEnvelope
 
     -- * Common serialization formats
   , Protobuf

--- a/src/Network/GRPC/Client/Session.hs
+++ b/src/Network/GRPC/Client/Session.hs
@@ -38,7 +38,7 @@ instance IsRPC rpc => DataFlow (ClientInbound rpc) where
       }
     deriving (Show)
 
-  type Message    (ClientInbound rpc) = Output rpc
+  type Message    (ClientInbound rpc) = (InboundEnvelope, Output rpc)
   type Trailers   (ClientInbound rpc) = [CustomMetadata]
   type NoMessages (ClientInbound rpc) = [CustomMetadata]
 
@@ -49,7 +49,7 @@ instance IsRPC rpc => DataFlow (ClientOutbound rpc) where
       }
     deriving (Show)
 
-  type Message  (ClientOutbound rpc) = Input rpc
+  type Message  (ClientOutbound rpc) = (OutboundEnvelope, Input rpc)
   type Trailers (ClientOutbound rpc) = NoMetadata
 
   -- gRPC does not support request trailers, but does not require that a request

--- a/src/Network/GRPC/Server.hs
+++ b/src/Network/GRPC/Server.hs
@@ -25,10 +25,12 @@ module Network.GRPC.Server (
   , sendNextOutput
   , sendTrailers
 
-    -- ** Low-level API
+    -- ** Low-level\/specialized API
   , initiateResponse
   , sendTrailersOnly
   , isCallHealthy
+  , recvInputWithEnvelope
+  , sendOutputWithEnvelope
 
     -- * Common serialization formats
   , Protobuf

--- a/src/Network/GRPC/Server/Session.hs
+++ b/src/Network/GRPC/Server/Session.hs
@@ -35,7 +35,7 @@ instance IsRPC rpc => DataFlow (ServerInbound rpc) where
       }
     deriving (Show)
 
-  type Message  (ServerInbound rpc) = Input rpc
+  type Message  (ServerInbound rpc) = (InboundEnvelope, Input rpc)
   type Trailers (ServerInbound rpc) = NoMetadata
 
   -- See discussion of 'TrailersOnly' in 'ClientOutbound'
@@ -48,7 +48,7 @@ instance IsRPC rpc => DataFlow (ServerOutbound rpc) where
       }
     deriving (Show)
 
-  type Message    (ServerOutbound rpc) = Output rpc
+  type Message    (ServerOutbound rpc) = (OutboundEnvelope, Output rpc)
   type Trailers   (ServerOutbound rpc) = ProperTrailers
   type NoMessages (ServerOutbound rpc) = TrailersOnly
 

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -9,9 +9,13 @@ module Network.GRPC.Spec (
     -- ** Instances
   , Protobuf
   , BinaryRpc
-    -- ** Serialization
+    -- ** Messages
+    -- *** Parsing
+  , InboundEnvelope(..)
   , parseInput
   , parseOutput
+    -- *** Construction
+  , OutboundEnvelope(..)
   , buildInput
   , buildOutput
     -- * Streaming types

--- a/test-common/Test/Util/ClientServer.hs
+++ b/test-common/Test/Util/ClientServer.hs
@@ -73,8 +73,8 @@ data ClientServerConfig = ClientServerConfig {
 
 instance Default ClientServerConfig where
   def = ClientServerConfig {
-      clientCompr       = Compr.none
-    , serverCompr       = Compr.none
+      clientCompr       = def
+    , serverCompr       = def
     , useTLS            = Nothing
     , clientContentType = Nothing
     , serverContentType = Nothing

--- a/test-grapesy/Main.hs
+++ b/test-grapesy/Main.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import Test.Prop.Dialogue                     qualified as Dialogue
 import Test.Prop.Serialization                qualified as Serialization
 import Test.Sanity.HalfClosedLocal            qualified as HalfClosedLocal
+import Test.Sanity.Interop                    qualified as Interop
 import Test.Sanity.StreamingType.CustomFormat qualified as StreamingType.CustomFormat
 import Test.Sanity.StreamingType.NonStreaming qualified as StreamingType.NonStreaming
 
@@ -16,6 +17,7 @@ main = defaultMain $ testGroup "grapesy" [
               StreamingType.NonStreaming.tests
             , StreamingType.CustomFormat.tests
             ]
+        , Interop.tests
         ]
     , testGroup "Prop" [
           Serialization.tests

--- a/test-grapesy/Test/Sanity/HalfClosedLocal.hs
+++ b/test-grapesy/Test/Sanity/HalfClosedLocal.hs
@@ -1,11 +1,9 @@
 -- | Tests to go with <https://github.com/kazu-yamamoto/http2/pull/84>
 module Test.Sanity.HalfClosedLocal (tests) where
 
-import Control.Exception
 import Control.Monad
 import Data.Default
 import Data.Proxy
-import Data.Void
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -31,7 +29,7 @@ tests = testGroup "Test.Sanity.HalfClosedLocal" [
 type Simple = BinaryRpc "HalfClosedLocal" "simple"
 
 test_simple :: IO String
-test_simple = testClientServer assessCustomException $ def {
+test_simple = testClientServer noCustomExceptions $ def {
       client = \withConn -> withConn $ \conn ->
           Client.withRPC conn def (Proxy @Simple) $ \call -> do
             [] <- Client.recvAllOutputs call $ \_ -> error "unexpected output"
@@ -71,7 +69,7 @@ test_simple = testClientServer assessCustomException $ def {
 type TrailersOnly = BinaryRpc "HalfClosedLocal" "trailersOnly"
 
 test_trailersOnly :: IO String
-test_trailersOnly = testClientServer assessCustomException $ def {
+test_trailersOnly = testClientServer noCustomExceptions $ def {
       client = \withConn -> withConn $ \conn ->
           Client.withRPC conn def (Proxy @TrailersOnly) $ \call -> do
             [] <- Client.recvAllOutputs call $ \_ -> error "unexpected output"
@@ -101,10 +99,3 @@ test_trailersOnly = testClientServer assessCustomException $ def {
               return ()
             NoMoreElems NoMetadata ->
               return ()
-
-{-------------------------------------------------------------------------------
-  Auxiliary
--------------------------------------------------------------------------------}
-
-assessCustomException :: SomeException -> CustomException Void
-assessCustomException = const CustomExceptionUnexpected

--- a/test-grapesy/Test/Sanity/Interop.hs
+++ b/test-grapesy/Test/Sanity/Interop.hs
@@ -1,0 +1,75 @@
+-- | Test functionality required by the gRPC interop tests
+module Test.Sanity.Interop (tests) where
+
+import Control.Exception
+import Data.Default
+import Data.Proxy
+import Data.Void
+import Test.Tasty
+import Test.Tasty.HUnit
+import Data.ProtoLens
+
+import Network.GRPC.Client qualified as Client
+import Network.GRPC.Common.StreamElem qualified as StreamElem
+import Network.GRPC.Common.StreamType qualified as StreamType
+import Network.GRPC.Server.StreamType qualified as Server
+import Network.GRPC.Spec
+
+import Proto.Src.Proto.Grpc.Testing.Empty
+import Proto.Src.Proto.Grpc.Testing.Test
+
+import Test.Driver.ClientServer
+
+{-------------------------------------------------------------------------------
+  Top-level
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "Test.Sanity.Interop" [
+      testCaseInfo "emptyUnary" test_emptyUnary
+    ]
+
+{-------------------------------------------------------------------------------
+  Individual tests
+-------------------------------------------------------------------------------}
+
+type EmptyCall = Protobuf TestService "emptyCall"
+
+-- | Test that the empty message has an empty encoding
+--
+-- This test fails if we unconditionally compress (the /compressed/ form of the
+-- empty message is larger than the uncompressed form, as compression introduces
+-- minor overhead).
+test_emptyUnary :: IO String
+test_emptyUnary =
+    testClientServer assessCustomException def {
+        client = \withConn -> withConn $ \conn ->
+          Client.withRPC conn def (Proxy @EmptyCall) $ \call -> do
+            Client.sendFinalInput call (defMessage :: Empty)
+            streamElem <- Client.recvOutputWithEnvelope call
+            case StreamElem.value streamElem of
+              Nothing                      -> fail "Expected answer"
+              Just (envelope, _x :: Empty) -> verifyEnvelope envelope
+      , server = [
+            Server.streamingRpcHandler (Proxy @EmptyCall) $
+              StreamType.mkNonStreaming $ \(_ ::Empty) ->
+                return (defMessage :: Empty)
+          ]
+      }
+  where
+    -- We don't /expect/ the empty message to be compressed, due to the overhead
+    -- mentioned above. However, /if/ it is compressed, perhaps using a custom
+    -- zero-overhead compression algorithm, it's size should be zero.
+    verifyEnvelope :: InboundEnvelope -> IO ()
+    verifyEnvelope envelope = do
+        assertEqual "uncompressed size" (inboundUncompressedSize envelope) 0
+        case inboundCompressedSize envelope of
+          Nothing   -> return ()
+          Just size -> assertEqual "compressed size" size 0
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+assessCustomException :: SomeException -> CustomException Void
+assessCustomException = const CustomExceptionUnexpected

--- a/test-grapesy/Test/Sanity/Interop.hs
+++ b/test-grapesy/Test/Sanity/Interop.hs
@@ -1,21 +1,31 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 -- | Test functionality required by the gRPC interop tests
 module Test.Sanity.Interop (tests) where
 
 import Control.Exception
+import Control.Lens ((^.), (.~))
+import Control.Monad
+import Data.ByteString qualified as BS.Strict
 import Data.Default
+import Data.Function ((&))
+import Data.ProtoLens
+import Data.ProtoLens.Labels ()
 import Data.Proxy
 import Data.Void
 import Test.Tasty
 import Test.Tasty.HUnit
-import Data.ProtoLens
 
 import Network.GRPC.Client qualified as Client
+import Network.GRPC.Common
 import Network.GRPC.Common.StreamElem qualified as StreamElem
 import Network.GRPC.Common.StreamType qualified as StreamType
+import Network.GRPC.Server qualified as Server
 import Network.GRPC.Server.StreamType qualified as Server
 import Network.GRPC.Spec
 
 import Proto.Src.Proto.Grpc.Testing.Empty
+import Proto.Src.Proto.Grpc.Testing.Messages
 import Proto.Src.Proto.Grpc.Testing.Test
 
 import Test.Driver.ClientServer
@@ -26,14 +36,16 @@ import Test.Driver.ClientServer
 
 tests :: TestTree
 tests = testGroup "Test.Sanity.Interop" [
-      testCaseInfo "emptyUnary" test_emptyUnary
+      testCaseInfo "emptyUnary"                test_emptyUnary
+    , testCaseInfo "serverCompressedStreaming" test_serverCompressedStreaming
     ]
 
 {-------------------------------------------------------------------------------
   Individual tests
 -------------------------------------------------------------------------------}
 
-type EmptyCall = Protobuf TestService "emptyCall"
+type EmptyCall           = Protobuf TestService "emptyCall"
+type StreamingOutputCall = Protobuf TestService "streamingOutputCall"
 
 -- | Test that the empty message has an empty encoding
 --
@@ -66,6 +78,75 @@ test_emptyUnary =
         case inboundCompressedSize envelope of
           Nothing   -> return ()
           Just size -> assertEqual "compressed size" size 0
+
+-- | Test that we can enable and disable compression per message
+test_serverCompressedStreaming :: IO String
+test_serverCompressedStreaming =
+    testClientServer assessCustomException def {
+        client = \withConn -> withConn $ \conn ->
+          Client.withRPC conn def (Proxy @StreamingOutputCall) $ \call -> do
+            Client.sendFinalInput call $ defMessage & #responseParameters .~ [
+                defMessage
+                  & #compressed .~ (defMessage & #value .~ True)
+                  & #size .~ 31415
+              , defMessage
+                  & #compressed .~ (defMessage & #value .~ False)
+                  & #size .~ 92653
+              ]
+            output1 <- Client.recvOutputWithEnvelope call
+            output2 <- Client.recvOutputWithEnvelope call
+            verifyOutputs (StreamElem.value output1, StreamElem.value output2)
+      , server = [
+            Server.mkRpcHandler (Proxy @StreamingOutputCall) $ \call -> do
+              handleStreamingOutputCall call
+          ]
+      }
+  where
+    handleStreamingOutputCall :: Server.Call StreamingOutputCall -> IO ()
+    handleStreamingOutputCall call = do
+        -- Wait for request
+        request <- Server.recvFinalInput call
+
+        -- Send all requested messages
+        forM_ (request ^. #responseParameters) $ \responseParams -> do
+
+          let shouldCompress :: Bool
+              shouldCompress = responseParams ^. #compressed . #value
+
+              size :: Int
+              size = fromIntegral $ responseParams ^. #size
+
+              envelope :: OutboundEnvelope
+              envelope = def { outboundEnableCompression = shouldCompress }
+
+              -- Payload matters for the test, because for messages that are too
+              -- small no compression is used even when enabled.
+              payload :: Payload
+              payload = defMessage & #body .~ BS.Strict.pack (replicate size 0)
+
+              response :: StreamingOutputCallResponse
+              response = defMessage & #payload .~ payload
+
+          Server.sendOutputWithEnvelope call $ StreamElem (envelope, response)
+
+        -- No further output
+        Server.sendTrailers call []
+
+    verifyOutputs ::
+         ( Maybe (InboundEnvelope, StreamingOutputCallResponse)
+         , Maybe (InboundEnvelope, StreamingOutputCallResponse)
+         )
+      -> IO ()
+    verifyOutputs = \case
+        (Just (envelope1, _), Just (envelope2, _)) -> do
+          case inboundCompressedSize envelope1 of
+            Nothing -> assertFailure "First output should be compressed"
+            Just _  -> return ()
+          case inboundCompressedSize envelope2 of
+            Nothing -> return ()
+            Just _  -> assertFailure "First output should not be compressed"
+        _otherwise ->
+          assertFailure "Expected value"
 
 {-------------------------------------------------------------------------------
   Auxiliary

--- a/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
@@ -3,7 +3,6 @@
 module Test.Sanity.StreamingType.CustomFormat (tests) where
 
 import Codec.Serialise qualified as Cbor
-import Control.Exception
 import Control.Monad
 import Data.Bifunctor
 import Data.Default
@@ -13,7 +12,6 @@ import Data.List
 import Data.Proxy
 import Data.Text (Text)
 import Data.Typeable
-import Data.Void
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -121,7 +119,7 @@ tests =
 
 test_calculator_cbor :: ClientServerConfig -> IO String
 test_calculator_cbor config = do
-    testClientServer assessCustomException $ def {
+    testClientServer noCustomExceptions $ def {
         config
       , client = \withConn -> withConn $ \conn -> do
           nonStreamingSumCheck conn
@@ -244,10 +242,3 @@ test_calculator_cbor config = do
          (Client.ClientHandler h, IsRPC (Calc fun))
       => Client.Connection -> h (Calc fun)
     rpc = Client.rpc
-
-{-------------------------------------------------------------------------------
-  Auxiliary
--------------------------------------------------------------------------------}
-
-assessCustomException :: SomeException -> CustomException Void
-assessCustomException = const CustomExceptionUnexpected

--- a/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -2,10 +2,8 @@
 
 module Test.Sanity.StreamingType.NonStreaming (tests) where
 
-import Control.Exception
 import Data.Default
 import Data.Proxy
-import Data.Void
 import Data.Word
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -115,7 +113,7 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
 type BinaryIncrement = BinaryRpc "binary" "increment"
 
 test_increment :: ClientServerConfig -> IO String
-test_increment config = testClientServer assessCustomException $ def {
+test_increment config = testClientServer noCustomExceptions $ def {
       config
     , client = \withConn -> withConn $ \conn -> do
         Client.withRPC conn def (Proxy @BinaryIncrement) $ \call -> do
@@ -128,11 +126,3 @@ test_increment config = testClientServer assessCustomException $ def {
               return (succ n)
         ]
     }
-
-{-------------------------------------------------------------------------------
-  Auxiliary
--------------------------------------------------------------------------------}
-
-assessCustomException :: SomeException -> CustomException Void
-assessCustomException = const CustomExceptionUnexpected
-


### PR DESCRIPTION
This gives clients more control and metadata about low-level details of message transmission. Most clients will not need this, but it is required for the interop tests.