### PR TITLE
Use latest http2 with `RST_STREAM` fix

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -160,6 +160,11 @@ jobs:
           echo "package grapesy" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
+          source-repository-package
+            type:     git
+            location: https://github.com/edsko/http2
+            tag:      373dfcc257a71867113dda79314e30f1cb0015db
+
           package grapesy
             tests:       True
             flags:       +build-demo +build-stress-test +build-interop

--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,8 @@ packages: .
 package grapesy
   tests: True
   flags: +build-demo +build-stress-test +build-interop
+
+source-repository-package 
+  type: git
+  location: https://github.com/edsko/http2
+  tag: 373dfcc257a71867113dda79314e30f1cb0015db

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -4,3 +4,8 @@ package grapesy
   tests: True
   flags: +build-demo +build-stress-test +build-interop
   ghc-options: -Werror
+
+source-repository-package 
+  type: git
+  location: https://github.com/edsko/http2
+  tag: 373dfcc257a71867113dda79314e30f1cb0015db


### PR DESCRIPTION
After this fix, the interop status is now as below, reference client against `grapesy` server:

| Test                          | Python | C++  |
| ----------------------------- | ------ | ---- |
| `cancel_after_begin`          | ✅     | ✅   |
| `cancel_after_first_response` | ✅     | ✅   |
| `client_compressed_streaming` | ❔     | ✅   |
| `client_compressed_unary`     | ❔     | ✅   |
| `client_streaming`            | ✅     | ✅   |
| `custom_metadata`             | ✅     | ✅   |
| `empty_stream`                | ✅     | ✅   |
| `empty_unary`                 | ✅     | ✅   |
| `large_unary`                 | ✅     | ✅   |
| `ping_pong`                   | ✅     | ✅   |
| `server_compressed_streaming` | ❔     | ✅   |
| `server_compressed_unary`     | ❔     | ✅   |
| `server_streaming`            | ✅     | ✅   |
| `special_status_message`      | ✅     | ❔   |
| `status_code_and_message`     | ✅     | ✅   |
| `timeout_on_sleeping_server`  | ✅     | ✅   |
| `unimplemented_method`        | ✅     | ✅   |
| `unimplemented_service`       | ✅     | ✅   |

(❔ entries are where the test is not supported by the reference client.)


