### PR TITLE
More interop

### DIFF
--- a/dev/interop.md
+++ b/dev/interop.md
@@ -115,6 +115,29 @@ Make sure all changes you want to test are committed:
 
 ### Testing `grapesy` as a server
 
+To run the tests automatically:
+
+```bash
+tools/run_tests/run_interop_tests.py -l python -s grapesy --use_docker
+tools/run_tests/run_interop_tests.py -l c++    -s grapesy --use_docker
+tools/run_tests/run_interop_tests.py -l go     -s grapesy --use_docker
+```
+
+This will require a directory structure like this:
+
+```
+parent
+  |
+  +---- grpc-repo    https://github.com/grpc/grpc
+  |
+  \---- grpc-go      https://github.com/grpc/grpc-go
+```
+
+### Manual execution
+
+During development however it might be more convenient to use the `--manual`
+flag, which creates a bash script that executes the individual tests:
+
 Create the docker containers:
 
 ```bash
@@ -171,3 +194,9 @@ is the problem.
 The server respects the `SSLKEYLOGFILE` environment variable, which can be
 useful for Wireshark debugging; see [/dev/wireshark.md](/dev/wireshark.md) for
 some suggestions on how to setup Wireshark.
+
+
+
+
+go: checkout /alongside/ (as a sibling of) `grpc-repo`
+

--- a/dev/interop.md
+++ b/dev/interop.md
@@ -121,6 +121,7 @@ To run the tests automatically:
 tools/run_tests/run_interop_tests.py -l python -s grapesy --use_docker
 tools/run_tests/run_interop_tests.py -l c++    -s grapesy --use_docker
 tools/run_tests/run_interop_tests.py -l go     -s grapesy --use_docker
+tools/run_tests/run_interop_tests.py -l java   -s grapesy --use_docker
 ```
 
 This will require a directory structure like this:
@@ -130,7 +131,9 @@ parent
   |
   +---- grpc-repo    https://github.com/grpc/grpc
   |
-  \---- grpc-go      https://github.com/grpc/grpc-go
+  +---- grpc-go      https://github.com/grpc/grpc-go
+  |
+  \---- grpc-java    https://github.com/grpc/grpc-java
 ```
 
 ### Manual execution

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -121,6 +121,7 @@ library
       Network.GRPC.Spec.RPC.StreamType
       Network.GRPC.Spec.Status
       Network.GRPC.Spec.Timeout
+      Network.GRPC.Spec.TraceContext
       Network.GRPC.Util.AccumulatedByteString
       Network.GRPC.Util.ByteString
       Network.GRPC.Util.HTTP2
@@ -145,6 +146,7 @@ library
       debug
   build-depends:
     , async                >= 2.2   && < 2.3
+    , base16-bytestring    >= 1.0   && < 1.1
     , base64-bytestring    >= 1.2   && < 1.3
     , binary               >= 0.8   && < 0.9
     , bytestring           >= 0.10  && < 0.12

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -105,6 +105,7 @@ library
       Network.GRPC.Server.RequestHandler
       Network.GRPC.Server.RequestHandler.API
       Network.GRPC.Server.Session
+      Network.GRPC.Spec.Base64
       Network.GRPC.Spec.Call
       Network.GRPC.Spec.Common
       Network.GRPC.Spec.Compression
@@ -236,6 +237,7 @@ test-suite test-grapesy
   build-depends:
       -- External dependencies
     , async              >= 2.2  && < 2.3
+    , base64-bytestring  >= 1.2  && < 1.3
     , bytestring         >= 0.10 && < 0.12
     , containers         >= 0.6  && < 0.7
     , contra-tracer      >= 0.2  && < 0.3

--- a/src/Network/GRPC/Client/Connection.hs
+++ b/src/Network/GRPC/Client/Connection.hs
@@ -365,6 +365,8 @@ startRPC Connection{connMetaVar, connParams, connStateVar} _ callParams = do
             Compression.offer $ connCompression connParams
         , requestOverrideContentType =
             connContentType connParams
+        , requestTraceContext =
+            Nothing
         }
 
     callSession :: ClientSession rpc

--- a/src/Network/GRPC/Server.hs
+++ b/src/Network/GRPC/Server.hs
@@ -31,6 +31,7 @@ module Network.GRPC.Server (
   , isCallHealthy
   , recvInputWithEnvelope
   , sendOutputWithEnvelope
+  , getRequestTraceContext
 
     -- * Common serialization formats
   , Protobuf

--- a/src/Network/GRPC/Server/Call.hs
+++ b/src/Network/GRPC/Server/Call.hs
@@ -28,6 +28,7 @@ module Network.GRPC.Server.Call (
   , isCallHealthy
   , recvInputWithEnvelope
   , sendOutputWithEnvelope
+  , getRequestTraceContext
 
     -- ** Internal API
   , sendProperTrailers
@@ -537,6 +538,13 @@ data ResponseAlreadyInitiated = ResponseAlreadyInitiated
 -- non-deterministic result of this function.
 isCallHealthy :: Call rpc -> STM Bool
 isCallHealthy = Session.isChannelHealthy . callChannel
+
+-- | Get trace context for the request (if any)
+--
+-- This provides (minimal) support for OpenTelemetry.
+getRequestTraceContext :: Call rpc -> IO (Maybe TraceContext)
+getRequestTraceContext Call{callRequestHeaders} =
+    atomically $ requestTraceContext <$> readTMVar callRequestHeaders
 
 {-------------------------------------------------------------------------------
   Protocol specific wrappers

--- a/src/Network/GRPC/Server/Call.hs
+++ b/src/Network/GRPC/Server/Call.hs
@@ -72,10 +72,10 @@ data Call rpc = IsRPC rpc => Call {
       -- | Bidirectional channel to the client
     , callChannel :: Session.Channel (ServerSession rpc)
 
-      -- | Request metadata
+      -- | Request headers
       --
       -- This is filled once we get the request headers
-    , callRequestMetadata :: TMVar [CustomMetadata]
+    , callRequestHeaders :: TMVar RequestHeaders
 
       -- | Response metadata
       --
@@ -125,7 +125,7 @@ setupCall :: forall rpc.
   -> ServerContext
   -> IO (Either SomeException (Call rpc))
 setupCall conn ServerContext{params} = runExceptT $ do
-    callRequestMetadata  <- liftIO $ newEmptyTMVarIO
+    callRequestHeaders   <- liftIO $ newEmptyTMVarIO
     callResponseMetadata <- liftIO $ newTVarIO []
     callResponseKickoff  <- liftIO $ newEmptyTMVarIO
 
@@ -140,9 +140,8 @@ setupCall conn ServerContext{params} = runExceptT $ do
               Session.FlowStartRegular    headers  -> inbHeaders headers
               Session.FlowStartNoMessages trailers ->            trailers
 
-    -- Make request metadata available (see 'getRequestMetadata')
-    liftIO $ atomically $
-      putTMVar callRequestMetadata $ requestMetadata inboundHeaders
+    -- Make request headers available (e.g., see 'getRequestMetadata')
+    liftIO $ atomically $ putTMVar callRequestHeaders inboundHeaders
 
     -- Technically compression is only relevant in the 'KickoffRegular' case
     -- (i.e., in the case that the /server/ responds with messages, rather than
@@ -173,7 +172,7 @@ setupCall conn ServerContext{params} = runExceptT $ do
 
     return Call{
         callSession
-      , callRequestMetadata
+      , callRequestHeaders
       , callResponseMetadata
       , callResponseKickoff
       , callChannel
@@ -456,8 +455,8 @@ sendOutputWithEnvelope call@Call{callChannel} msg = do
 -- This will block until we have received the initial request /headers/ (but may
 -- well return before we receive the first /message/ from the client).
 getRequestMetadata :: Call rpc -> IO [CustomMetadata]
-getRequestMetadata Call{callRequestMetadata} =
-    atomically $ readTMVar callRequestMetadata
+getRequestMetadata Call{callRequestHeaders} =
+    atomically $ requestMetadata <$> readTMVar callRequestHeaders
 
 -- | Set the initial response metadata
 --

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -110,6 +110,13 @@ module Network.GRPC.Spec (
   , safeAsciiValue
     -- ** Convenience
   , lookupCustomMetadata
+    -- * OpenTelemetry
+  , TraceContext(..)
+  , TraceId(..)
+  , SpanId(..)
+  , TraceOptions(..)
+  , buildTraceContext
+  , parseTraceContext
   ) where
 
 import Network.GRPC.Spec.Call
@@ -125,3 +132,4 @@ import Network.GRPC.Spec.RPC.Protobuf
 import Network.GRPC.Spec.RPC.StreamType
 import Network.GRPC.Spec.Status
 import Network.GRPC.Spec.Timeout
+import Network.GRPC.Spec.TraceContext

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -101,6 +101,8 @@ module Network.GRPC.Spec (
   , NoMetadata(..)
   , customHeaderName
     -- ** Serialization
+  , buildBinaryValue
+  , parseBinaryValue
   , parseCustomMetadata
   , buildCustomMetadata
     -- ** Validation

--- a/src/Network/GRPC/Spec/Base64.hs
+++ b/src/Network/GRPC/Spec/Base64.hs
@@ -1,0 +1,82 @@
+-- | gRPC-style base64-encoding
+--
+-- The gRPC specification mandates standard Base64-encoding for binary headers
+-- <https://datatracker.ietf.org/doc/html/rfc4648#section-4>, /but/ without
+-- padding.
+module Network.GRPC.Spec.Base64 (
+    encodeBase64
+  , decodeBase64
+  ) where
+
+import Control.Monad
+import Data.ByteString qualified as BS.Strict
+import Data.ByteString qualified as Strict (ByteString)
+import Data.ByteString.Base64 qualified as BS.Strict.B64
+import Data.ByteString.Char8 qualified as BS.Strict.Char8
+
+{-------------------------------------------------------------------------------
+  Top-level
+-------------------------------------------------------------------------------}
+
+encodeBase64 :: Strict.ByteString -> Strict.ByteString
+encodeBase64 = removePadding . BS.Strict.B64.encode
+
+decodeBase64 :: Strict.ByteString -> Either String Strict.ByteString
+decodeBase64 = BS.Strict.B64.decode <=< addPadding
+
+{-------------------------------------------------------------------------------
+  Internal: Adding and removing padding
+
+  In Base64 encoding, every group of three bytes in the input is represented as
+  4 bytes in the output. We therefore have three possibilities:
+
+  * The input has size @3n@. No padding bytes are added.
+  * The input has size @3n + 1@. Two padding byte are added.
+  * The input has size @3n + 2@. One padding byte is added.
+
+  Standard base64 encoding (including padding) therefore /always/ has size @4m@.
+-------------------------------------------------------------------------------}
+
+removePadding :: Strict.ByteString -> Strict.ByteString
+removePadding bs
+  -- Empty bytestring
+  --
+  -- If the bytestring is not null, it must have at least 4 bytes, justifying
+  -- the calls to @index@ below.
+  | BS.Strict.null bs
+  = bs
+
+  -- Two padding bytes
+  | BS.Strict.Char8.index bs (len - 2) == '='
+  = BS.Strict.take (len - 2) bs
+
+  -- One padding byte
+  | BS.Strict.Char8.index bs (len - 1) == '='
+  = BS.Strict.take (len - 1) bs
+
+  | otherwise
+  = bs
+  where
+    len :: Int
+    len = BS.Strict.length bs
+
+addPadding :: Strict.ByteString -> Either String Strict.ByteString
+addPadding bs
+  -- Three padding bytes (i.e., invalid strict)
+  | len `mod` 4 == 1
+  = Left $ "Invalid length of unpadded base64-encoded string " ++ show len
+
+  -- Two padding bytes
+  | len `mod` 4 == 2
+  = Right $ bs <> BS.Strict.Char8.pack "=="
+
+  -- One padding bytes
+  | len `mod` 4 == 3
+  = Right $ bs <> BS.Strict.Char8.pack "="
+
+  -- No padding (this includes the empty string)
+  | otherwise
+  = Right bs
+  where
+    len :: Int
+    len = BS.Strict.length bs

--- a/src/Network/GRPC/Spec/TraceContext.hs
+++ b/src/Network/GRPC/Spec/TraceContext.hs
@@ -1,0 +1,249 @@
+-- | Trace context
+--
+-- See documentation of 'TraceContext'.
+module Network.GRPC.Spec.TraceContext (
+    -- * Definition
+    TraceContext(..)
+  , TraceId(..)
+  , SpanId(..)
+  , TraceOptions(..)
+    -- ** Serialization
+  , buildTraceContext
+  , parseTraceContext
+  ) where
+
+import Control.Applicative (many)
+import Control.Monad.Except
+import Data.Binary (Binary(..))
+import Data.Binary qualified as Binary
+import Data.Binary.Get qualified as Get
+import Data.Binary.Put qualified as Put
+import Data.ByteString qualified as Strict (ByteString)
+import Data.ByteString.Base16 qualified as BS.Strict.Base16
+import Data.ByteString.Char8 qualified as BS.Strict.Char8
+import Data.ByteString.Lazy qualified as BS.Lazy
+import Data.Default
+import Data.Maybe (maybeToList)
+import Data.String
+import Data.Word
+
+import Network.GRPC.Spec.CustomMetadata
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+-- | Trace context
+--
+-- Representation of the \"trace context\" in OpenTelemetry, corresponding
+-- directly to the W3C @traceparent@ header.
+--
+-- References:
+--
+-- * <https://www.w3.org/TR/trace-context/#traceparent-header>
+--   W3C spec
+--
+-- * <https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md>
+--   Binary format used for the @grpc-trace-bin@ header
+--
+-- * <https://github.com/open-telemetry/opentelemetry-specification/issues/639>
+--   Current status of the binary encoding.
+--
+-- Relation to Haskell OpenTelemetry implementations:
+--
+-- * The Haskell @opentelemetry@ package calls this a @SpanContext@, but
+--    provides no binary @PropagationFormat@, and does not support
+--    'TraceOptions'.
+--
+--   <https://hackage.haskell.org/package/opentelemetry>
+--
+-- * The Haskell @hs-opentelemetry@ ecosystem defines @SpanContext@, which is
+--   the combination of the W3C @traceparent@ header (our 'TraceContext') and
+--   the W3C @tracestate@ header (which we do not support). It too does not
+--   support the @grpc-trace-bin@ binary format.
+--
+--   <https://github.com/iand675/hs-opentelemetry>
+--   <https://hackage.haskell.org/package/hs-opentelemetry-propagator-w3c>
+data TraceContext = TraceContext {
+      traceContextTraceId  :: Maybe TraceId
+    , traceContextSpanId   :: Maybe SpanId
+    , traceContextOptions  :: Maybe TraceOptions
+    }
+  deriving stock (Show, Eq)
+
+instance Default TraceContext where
+  def = TraceContext {
+        traceContextTraceId = Nothing
+      , traceContextSpanId  = Nothing
+      , traceContextOptions = Nothing
+      }
+
+-- | Trace ID
+--
+-- The ID of the whole trace forest. Must be a 16-byte string.
+newtype TraceId = TraceId {
+      getTraceId :: Strict.ByteString
+    }
+  deriving stock (Eq)
+
+-- | Span ID
+--
+-- ID of the caller span (parent). Must be an 8-byte string.
+newtype SpanId = SpanId {
+      getSpanId :: Strict.ByteString
+    }
+  deriving stock (Eq)
+
+-- | Tracing options
+--
+-- The flags are recommendations given by the caller rather than strict rules to
+-- follow for 3 reasons:
+--
+-- * Trust and abuse.
+-- * Bug in caller
+-- * Different load between caller service and callee service might force callee
+--   to down sample.
+data TraceOptions = TraceOptions {
+      -- | Sampled
+      --
+      -- When set, denotes that the caller may have recorded trace data. When
+      -- unset, the caller did not record trace data out-of-band.
+      traceOptionsSampled :: Bool
+    }
+  deriving stock (Show, Eq)
+
+{-------------------------------------------------------------------------------
+  Show instances for IDs
+
+  We follow the W3C spec and show these as base16 strings.
+-------------------------------------------------------------------------------}
+
+instance Show TraceId where
+  show (TraceId tid) =
+      show . BS.Strict.Char8.unpack $
+        BS.Strict.Base16.encode tid
+
+instance IsString TraceId where
+  fromString str =
+      case BS.Strict.Base16.decode (BS.Strict.Char8.pack str) of
+        Left  err -> error err
+        Right tid -> TraceId tid
+
+instance Show SpanId where
+  show (SpanId tid) =
+      show . BS.Strict.Char8.unpack $
+        BS.Strict.Base16.encode tid
+
+instance IsString SpanId where
+  fromString str =
+      case BS.Strict.Base16.decode (BS.Strict.Char8.pack str) of
+        Left  err -> error err
+        Right tid -> SpanId tid
+
+{-------------------------------------------------------------------------------
+  Parsing
+-------------------------------------------------------------------------------}
+
+buildTraceContext :: TraceContext -> BinaryValue
+buildTraceContext = BinaryValue . BS.Lazy.toStrict . Binary.encode
+
+parseTraceContext :: MonadError String m => BinaryValue -> m TraceContext
+parseTraceContext (BinaryValue bs) =
+    case Binary.decodeOrFail (BS.Lazy.fromStrict bs) of
+      Right (_, _, ctxt) -> return ctxt
+      Left  (_, _, err)  -> throwError err
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary: parsing
+
+  <https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md>
+-------------------------------------------------------------------------------}
+
+instance Binary TraceId where
+  put = Put.putByteString . getTraceId
+  get = TraceId <$> Get.getByteString 16
+
+instance Binary SpanId where
+  put = Put.putByteString . getSpanId
+  get = SpanId <$> Get.getByteString 8
+
+instance Binary TraceOptions where
+  put = Put.putWord8 . traceOptionsToWord8
+  get = traceOptionsFromWord8 =<< Get.getWord8
+
+instance Binary Field where
+  put (FieldTraceId tid)  = Put.putWord8 0 <> put tid
+  put (FieldSpanId  sid)  = Put.putWord8 1 <> put sid
+  put (FieldOptions opts) = Put.putWord8 2 <> put opts
+
+  get = do
+      fieldId <- Get.getWord8
+      case fieldId of
+        0 -> FieldTraceId <$> get
+        1 -> FieldSpanId  <$> get
+        2 -> FieldOptions <$> get
+        _ -> fail $ "Invalid fieldId " ++ show fieldId
+
+instance Binary TraceContext where
+  put ctxt = mconcat [
+        Put.putWord8 0 -- Version 0
+      , foldMap put (traceContextToFields ctxt)
+      ]
+
+  get = do
+      version <- Get.getWord8
+      case version of
+        0 -> traceContextFromFields =<< many get
+        _ -> fail $ "Invalid version " ++ show version
+
+{-------------------------------------------------------------------------------
+  Internal: fields
+-------------------------------------------------------------------------------}
+
+data Field =
+    FieldTraceId TraceId
+  | FieldSpanId SpanId
+  | FieldOptions TraceOptions
+
+traceContextToFields :: TraceContext -> [Field]
+traceContextToFields (TraceContext tid sid opts) = concat [
+      FieldTraceId <$> maybeToList tid
+    , FieldSpanId  <$> maybeToList sid
+    , FieldOptions <$> maybeToList opts
+    ]
+
+traceContextFromFields :: forall m. MonadFail m => [Field] -> m TraceContext
+traceContextFromFields = flip go def
+  where
+    go :: [Field] -> TraceContext -> m TraceContext
+    go []     acc = return acc
+    go (f:fs) acc =
+        case f of
+          FieldTraceId tid ->
+            case traceContextTraceId acc of
+              Nothing -> go fs $ acc{traceContextTraceId = Just tid}
+              Just _  -> fail "Multiple TraceId fields"
+          FieldSpanId sid ->
+            case traceContextSpanId acc of
+              Nothing -> go fs $ acc{traceContextSpanId = Just sid}
+              Just _  -> fail "Multiple SpanId fields"
+          FieldOptions opts ->
+            case traceContextOptions acc of
+              Nothing -> go fs $ acc{traceContextOptions = Just opts}
+              Just _  -> fail "Multiple TraceOptions fields"
+
+{-------------------------------------------------------------------------------
+  Internal: dealing with 'TraceOptions'
+
+  We take advantage of the fact that currently only a single option is defined.
+  Once we have more than one, this code will be a bit more complicated.
+-------------------------------------------------------------------------------}
+
+traceOptionsToWord8 :: TraceOptions -> Word8
+traceOptionsToWord8 (TraceOptions False) = 0
+traceOptionsToWord8 (TraceOptions True)  = 1
+
+traceOptionsFromWord8 :: MonadFail m => Word8 -> m TraceOptions
+traceOptionsFromWord8 0 = return $ TraceOptions False
+traceOptionsFromWord8 1 = return $ TraceOptions True
+traceOptionsFromWord8 n = fail $ "Invalid TraceOptions " ++ show n


### PR DESCRIPTION
After this PR, the situation is as follows:

#### `grapesy` server versus official reference client

| Test                          | Python | C++  | Go | Java |
| ----------------------------- | ------ | ---- | -- | ---- |
| `cancel_after_begin`          | ✅     | ✅   | ✅ | ✅   |
| `cancel_after_first_response` | ✅     | ✅   | ✅ | ✅   |
| `client_compressed_streaming` | ❔     | ✅   | ❔ | ✅   |
| `client_compressed_unary`     | ❔     | ✅   | ❔ | ✅   |
| `client_streaming`            | ✅     | ✅   | ✅ | ✅   |
| `custom_metadata`             | ✅     | ✅   | ✅ | ✅   |
| `empty_stream`                | ✅     | ✅   | ✅ | ✅   |
| `empty_unary`                 | ✅     | ✅   | ✅ | ✅   |
| `large_unary`                 | ✅     | ✅   | ✅ | ✅   |
| `ping_pong`                   | ✅     | ✅   | ✅ | ✅   |
| `server_compressed_streaming` | ❔     | ✅   | ❔ | ✅   |
| `server_compressed_unary`     | ❔     | ✅   | ❔ | ✅   |
| `server_streaming`            | ✅     | ✅   | ✅ | ✅   |
| `special_status_message`      | ✅     | ❔   | ✅ | ✅   |
| `status_code_and_message`     | ✅     | ✅   | ✅ | ✅   |
| `timeout_on_sleeping_server`  | ✅     | ✅   | ✅ | ✅   |
| `unimplemented_method`        | ✅     | ✅   | ✅ | ✅   |
| `unimplemented_service`       | ✅     | ✅   | ✅ | ✅   |

where ❔ are test cases that are not supported by the reference client.


