### PR TITLE
Generalize the client-side streaming functions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -160,11 +160,6 @@ jobs:
           echo "package grapesy" >> cabal.project
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
-          source-repository-package
-            type:     git
-            location: https://github.com/edsko/http2
-            tag:      0b638883788fec42a7dd1aae105ee2f97b6a4235
-
           package grapesy
             tests:       True
             flags:       +build-demo +build-stress-test +build-interop

--- a/cabal.project
+++ b/cabal.project
@@ -3,8 +3,3 @@ packages: .
 package grapesy
   tests: True
   flags: +build-demo +build-stress-test +build-interop
-
-source-repository-package 
-  type: git
-  location: https://github.com/edsko/http2
-  tag: 0b638883788fec42a7dd1aae105ee2f97b6a4235 

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -4,8 +4,3 @@ package grapesy
   tests: True
   flags: +build-demo +build-stress-test +build-interop
   ghc-options: -Werror
-
-source-repository-package 
-  type: git
-  location: https://github.com/edsko/http2
-  tag: 0b638883788fec42a7dd1aae105ee2f97b6a4235 

--- a/demo-client/Demo/Client/API/Protobuf/CanCallRPC/Greeter.hs
+++ b/demo-client/Demo/Client/API/Protobuf/CanCallRPC/Greeter.hs
@@ -1,0 +1,64 @@
+-- | Demonstration of using a custom monad stack
+module Demo.Client.API.Protobuf.CanCallRPC.Greeter (
+    sayHello
+  , sayHelloStreamReply
+  ) where
+
+import Control.Monad.Catch
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Reader
+
+import Network.GRPC.Client
+import Network.GRPC.Client.StreamType.CanCallRPC
+
+import Proto.Helloworld
+
+import Demo.Common.Logging qualified as Logging
+
+{-------------------------------------------------------------------------------
+  Example custom monad
+-------------------------------------------------------------------------------}
+
+data ClientState = ClientState {
+      connection :: Connection
+    , logger     :: forall a. Show a => a -> IO ()
+    }
+
+newtype MyClient a = WrapMyClient {
+      unwrapMyClient :: ReaderT ClientState IO a
+    }
+  deriving newtype (
+      Functor
+    , Applicative
+    , Monad
+    , MonadIO
+    , MonadThrow
+    , MonadCatch
+    , MonadMask
+    )
+
+instance CanCallRPC MyClient where
+  getConnection = WrapMyClient $ connection <$> ask
+
+clientLogMsg :: Show a => a -> MyClient ()
+clientLogMsg x = WrapMyClient $ ReaderT $ \state -> logger state x
+
+runMyClient :: Connection -> MyClient a -> IO a
+runMyClient conn client =
+    runReaderT
+      (unwrapMyClient client)
+      (ClientState conn Logging.logMsg)
+
+{-------------------------------------------------------------------------------
+  Implement the Greeter API using 'MyClient'
+-------------------------------------------------------------------------------}
+
+sayHello :: Connection -> HelloRequest -> IO ()
+sayHello conn name = runMyClient conn $ do
+    reply <- nonStreaming (rpc @(Protobuf Greeter "sayHello")) name
+    clientLogMsg reply
+
+sayHelloStreamReply :: Connection -> HelloRequest -> IO ()
+sayHelloStreamReply conn name = runMyClient conn $ do
+    serverStreaming (rpc @(Protobuf Greeter "sayHelloStreamReply")) name $
+      clientLogMsg

--- a/demo-client/Demo/Client/API/Protobuf/IO/Greeter.hs
+++ b/demo-client/Demo/Client/API/Protobuf/IO/Greeter.hs
@@ -1,11 +1,10 @@
-module Demo.Client.API.Protobuf.Greeter (
+module Demo.Client.API.Protobuf.IO.Greeter (
     sayHello
   , sayHelloStreamReply
   ) where
 
 import Network.GRPC.Client
-import Network.GRPC.Client.StreamType
-import Network.GRPC.Common.StreamType
+import Network.GRPC.Client.StreamType.IO
 
 import Proto.Helloworld
 
@@ -17,10 +16,10 @@ import Demo.Common.Logging
 
 sayHello :: Connection -> HelloRequest -> IO ()
 sayHello conn name = do
-    reply <- nonStreaming (rpc @(Protobuf Greeter "sayHello") conn) name
+    reply <- nonStreaming conn (rpc @(Protobuf Greeter "sayHello")) name
     logMsg reply
 
 sayHelloStreamReply :: Connection -> HelloRequest -> IO ()
 sayHelloStreamReply conn name =
-    serverStreaming (rpc @(Protobuf Greeter "sayHelloStreamReply") conn) name $
+    serverStreaming conn (rpc @(Protobuf Greeter "sayHelloStreamReply")) name $
       logMsg

--- a/demo-client/Demo/Client/API/Protobuf/IO/RouteGuide.hs
+++ b/demo-client/Demo/Client/API/Protobuf/IO/RouteGuide.hs
@@ -1,4 +1,4 @@
-module Demo.Client.API.Protobuf.RouteGuide (
+module Demo.Client.API.Protobuf.IO.RouteGuide (
     getFeature
   , listFeatures
   , recordRoute
@@ -6,9 +6,8 @@ module Demo.Client.API.Protobuf.RouteGuide (
   ) where
 
 import Network.GRPC.Client
-import Network.GRPC.Client.StreamType
+import Network.GRPC.Client.StreamType.IO
 import Network.GRPC.Common
-import Network.GRPC.Common.StreamType
 
 import Proto.RouteGuide
 
@@ -21,21 +20,21 @@ import Demo.Common.Logging
 getFeature :: Connection -> Point -> IO ()
 getFeature conn point = do
     features <-
-      nonStreaming (rpc @(Protobuf RouteGuide "getFeature") conn) point
+      nonStreaming conn (rpc @(Protobuf RouteGuide "getFeature")) point
     logMsg features
 
 listFeatures :: Connection -> Rectangle -> IO ()
 listFeatures conn rect = do
-    serverStreaming (rpc @(Protobuf RouteGuide "listFeatures") conn) rect $
+    serverStreaming conn (rpc @(Protobuf RouteGuide "listFeatures")) rect $
       logMsg
 
 recordRoute :: Connection -> IO (StreamElem NoMetadata Point) -> IO ()
 recordRoute conn getPoint = do
     summary <-
-      clientStreaming (rpc @(Protobuf RouteGuide "recordRoute") conn) getPoint
+      clientStreaming conn (rpc @(Protobuf RouteGuide "recordRoute")) getPoint
     logMsg summary
 
 routeChat :: Connection -> IO (StreamElem NoMetadata RouteNote) -> IO ()
 routeChat conn getNote = do
-    biDiStreaming (rpc @(Protobuf RouteGuide "routeChat") conn) getNote $
+    biDiStreaming conn (rpc @(Protobuf RouteGuide "routeChat")) getNote $
       logMsg

--- a/demo-client/Demo/Client/API/Protobuf/Pipes/RouteGuide.hs
+++ b/demo-client/Demo/Client/API/Protobuf/Pipes/RouteGuide.hs
@@ -30,8 +30,8 @@ listFeatures :: Connection -> Rectangle -> IO ()
 listFeatures conn r = runSafeT . runEffect $
     (prod >>= logMsg) >-> Pipes.mapM_ logMsg
   where
-    prod :: Producer' Feature (SafeT IO) ()
-    prod = serverStreaming conn def (Proxy @(Protobuf RouteGuide "listFeatures")) r
+    prod :: Producer Feature (SafeT IO) ()
+    prod = serverStreaming conn (rpc @(Protobuf RouteGuide "listFeatures")) r
 
 recordRoute ::
      Connection
@@ -40,8 +40,8 @@ recordRoute ::
 recordRoute conn ps = runSafeT . runEffect $
     ps >-> (cons >>= logMsg)
   where
-    cons :: Consumer' (StreamElem NoMetadata Point) (SafeT IO) RouteSummary
-    cons = clientStreaming conn def (Proxy @(Protobuf RouteGuide "recordRoute"))
+    cons :: Consumer (StreamElem NoMetadata Point) (SafeT IO) RouteSummary
+    cons = clientStreaming conn (rpc @(Protobuf RouteGuide "recordRoute"))
 
 routeChat ::
      Connection

--- a/demo-client/Demo/Client/Cmdline.hs
+++ b/demo-client/Demo/Client/Cmdline.hs
@@ -58,8 +58,9 @@ data Cmdline = Cmdline {
 
 -- | Which API to use?
 data API =
-    Protobuf
+    ProtobufIO
   | ProtobufPipes
+  | ProtobufCanCallRPC
   | Core
   | CoreNoFinal
   deriving (Show)
@@ -204,13 +205,17 @@ parseCompression = asum [
 
 parseAPI :: Opt.Parser API
 parseAPI = asum [
-      Opt.flag' Protobuf $ mconcat [
-          Opt.long "protobuf"
-        , Opt.help "Use the Protobuf API (if applicable)"
+      Opt.flag' ProtobufIO $ mconcat [
+          Opt.long "protobuf-IO"
+        , Opt.help "Use the Protobuf IO API (if applicable)"
         ]
     , Opt.flag' ProtobufPipes $ mconcat [
-          Opt.long "protobuf-pipes"
-        , Opt.help "Use the Protobuf pipes API (if applicable)"
+          Opt.long "protobuf-Pipe"
+        , Opt.help "Use the Protobuf Pipe API (if applicable)"
+        ]
+    , Opt.flag' ProtobufCanCallRPC $ mconcat [
+          Opt.long "protobuf-CanCallRPC"
+        , Opt.help "Use the Protobuf CanCallRPC API (if applicable)"
         ]
     , Opt.flag' Core $ mconcat [
           Opt.long "core"
@@ -220,7 +225,7 @@ parseAPI = asum [
           Opt.long "core-dont-mark-final"
         , Opt.help "Use the core API; don't mark the last message as final"
         ]
-    , pure Protobuf
+    , pure ProtobufIO
     ]
 
 {-------------------------------------------------------------------------------

--- a/demo-client/Main.hs
+++ b/demo-client/Main.hs
@@ -18,12 +18,13 @@ import Demo.Client.Cmdline
 import Demo.Client.Util.DelayOr
 import Demo.Common.Logging
 
-import Demo.Client.API.Core.Greeter              qualified as Core.Greeter
-import Demo.Client.API.Core.NoFinal.Greeter      qualified as NoFinal.Greeter
-import Demo.Client.API.Core.RouteGuide           qualified as Core.RouteGuide
-import Demo.Client.API.Protobuf.Greeter          qualified as PBuf.Greeter
-import Demo.Client.API.Protobuf.Pipes.RouteGuide qualified as Pipes.RouteGuide
-import Demo.Client.API.Protobuf.RouteGuide       qualified as PBuf.RouteGuide
+import Demo.Client.API.Core.Greeter                qualified as Core.Greeter
+import Demo.Client.API.Core.NoFinal.Greeter        qualified as NoFinal.Greeter
+import Demo.Client.API.Core.RouteGuide             qualified as Core.RouteGuide
+import Demo.Client.API.Protobuf.IO.Greeter         qualified as IO.Greeter
+import Demo.Client.API.Protobuf.IO.RouteGuide      qualified as IO.RouteGuide
+import Demo.Client.API.Protobuf.Pipes.RouteGuide   qualified as Pipes.RouteGuide
+import Demo.Client.API.Protobuf.CanCallRPC.Greeter qualified as CanCallRPC.Greeter
 
 {-------------------------------------------------------------------------------
   Application entry point
@@ -44,8 +45,10 @@ dispatch cmd conn (Exec method) =
     case method of
       SomeMethod SGreeter (SSayHello name) ->
         case cmdAPI cmd of
-          Protobuf ->
-            PBuf.Greeter.sayHello conn name
+          ProtobufIO ->
+            IO.Greeter.sayHello conn name
+          ProtobufCanCallRPC ->
+            CanCallRPC.Greeter.sayHello conn name
           CoreNoFinal ->
             NoFinal.Greeter.sayHello conn name
           _otherwise ->
@@ -54,22 +57,24 @@ dispatch cmd conn (Exec method) =
         case cmdAPI cmd of
           Core ->
             Core.Greeter.sayHelloStreamReply conn name
-          Protobuf ->
-            PBuf.Greeter.sayHelloStreamReply conn name
+          ProtobufIO ->
+            IO.Greeter.sayHelloStreamReply conn name
+          ProtobufCanCallRPC ->
+            CanCallRPC.Greeter.sayHelloStreamReply conn name
           _otherwise ->
             unsupportedMode
       SomeMethod SRouteGuide (SGetFeature p) ->
         case cmdAPI cmd of
-          Protobuf ->
-            PBuf.RouteGuide.getFeature conn p
+          ProtobufIO ->
+            IO.RouteGuide.getFeature conn p
           _otherwise ->
             unsupportedMode
       SomeMethod SRouteGuide (SListFeatures r) ->
         case cmdAPI cmd of
           ProtobufPipes ->
             Pipes.RouteGuide.listFeatures conn r
-          Protobuf ->
-            PBuf.RouteGuide.listFeatures conn r
+          ProtobufIO ->
+            IO.RouteGuide.listFeatures conn r
           Core ->
             Core.RouteGuide.listFeatures conn r
           _otherwise ->
@@ -78,16 +83,16 @@ dispatch cmd conn (Exec method) =
         case cmdAPI cmd of
           ProtobufPipes ->
             Pipes.RouteGuide.recordRoute conn $ yieldAll ps
-          Protobuf ->
-            PBuf.RouteGuide.recordRoute conn =<< execAll ps
+          ProtobufIO ->
+            IO.RouteGuide.recordRoute conn =<< execAll ps
           _otherwise ->
             unsupportedMode
       SomeMethod SRouteGuide (SRouteChat notes) ->
         case cmdAPI cmd of
           ProtobufPipes ->
             Pipes.RouteGuide.routeChat conn $ yieldAll notes
-          Protobuf ->
-            PBuf.RouteGuide.routeChat conn =<< execAll notes
+          ProtobufIO ->
+            IO.RouteGuide.routeChat conn =<< execAll notes
           _otherwise ->
             unsupportedMode
   where

--- a/demo-server/Demo/Server/Service/Greeter.hs
+++ b/demo-server/Demo/Server/Service/Greeter.hs
@@ -13,7 +13,6 @@ import Data.Proxy
 import Data.Text (Text)
 
 import Network.GRPC.Common
-import Network.GRPC.Common.StreamType
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
 import Network.GRPC.Server.StreamType

--- a/demo-server/Demo/Server/Service/RouteGuide.hs
+++ b/demo-server/Demo/Server/Service/RouteGuide.hs
@@ -17,7 +17,6 @@ import Data.Time
 
 import Network.GRPC.Common
 import Network.GRPC.Common.StreamElem qualified as StreamElem
-import Network.GRPC.Common.StreamType
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
 import Network.GRPC.Server.StreamType

--- a/dev/interop.md
+++ b/dev/interop.md
@@ -198,8 +198,9 @@ The server respects the `SSLKEYLOGFILE` environment variable, which can be
 useful for Wireshark debugging; see [/dev/wireshark.md](/dev/wireshark.md) for
 some suggestions on how to setup Wireshark.
 
+## To rebuild the Docker image with the `grapesy` deps
 
-
-
-go: checkout /alongside/ (as a sibling of) `grpc-repo`
+When the `grapesy` dependencies change (and especially when it requires newer
+versions of packages that aren't yet known in the cabal package database),
+you need to rebuild the Docker image.
 

--- a/docs/demo-client.md
+++ b/docs/demo-client.md
@@ -247,7 +247,7 @@ or
 grpc-repo/examples/cpp/route_guide$ cmake/build/route_guide_server
 ```
 
-All methods except `getFeature` support the `--protobuf-pipes` option to use the
+All methods except `getFeature` support the `--protobuf-Pipe` option to use the
 [`pipes` interface](/src/Network/GRPC/Client/Protobuf/Pipes.hs).
 
 ### `routeguide.RouteGuide.GetFeature` (non-streaming RPC)

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -46,6 +46,7 @@ common lang
       GADTs
       GeneralizedNewtypeDeriving
       ImportQualifiedPost
+      InstanceSigs
       LambdaCase
       MultiParamTypeClasses
       MultiWayIf
@@ -79,7 +80,9 @@ library
   exposed-modules:
       Network.GRPC.Client
       Network.GRPC.Client.Binary
-      Network.GRPC.Client.StreamType
+      Network.GRPC.Client.StreamType.CanCallRPC
+      Network.GRPC.Client.StreamType.IO
+      Network.GRPC.Client.StreamType.IO.Binary
       Network.GRPC.Client.StreamType.Pipes
       Network.GRPC.Common
       Network.GRPC.Common.Binary
@@ -98,6 +101,7 @@ library
       Network.GRPC.Client.Connection
       Network.GRPC.Client.Meta
       Network.GRPC.Client.Session
+      Network.GRPC.Client.StreamType
       Network.GRPC.Internal.NestedException
       Network.GRPC.Server.Call
       Network.GRPC.Server.Context
@@ -158,7 +162,7 @@ library
     , generics-sop         >= 0.5   && < 0.6
     , hashable             >= 1.3   && < 1.5
     , http-types           >= 0.12  && < 0.13
-    , http2                >= 5.1   && < 5.2
+    , http2                >= 5.1.1 && < 5.2
     , http2-tls            >= 0.2.2 && < 0.3
     , mtl                  >= 2.2   && < 2.4
     , network              >= 3.1   && < 3.2
@@ -275,9 +279,11 @@ executable demo-client
       Demo.Client.API.Core.Greeter
       Demo.Client.API.Core.NoFinal.Greeter
       Demo.Client.API.Core.RouteGuide
-      Demo.Client.API.Protobuf.Greeter
+      Demo.Client.API.Protobuf.CanCallRPC.Greeter
+      Demo.Client.API.Protobuf.IO.Greeter
+      Demo.Client.API.Protobuf.IO.RouteGuide
       Demo.Client.API.Protobuf.Pipes.RouteGuide
-      Demo.Client.API.Protobuf.RouteGuide
+
       Demo.Client.Cmdline
       Demo.Client.Util.DelayOr
       Demo.Common.Logging
@@ -298,6 +304,7 @@ executable demo-client
     , async                >= 2.2  && < 2.3
     , contra-tracer        >= 0.2  && < 0.3
     , data-default         >= 0.7  && < 0.8
+    , exceptions           >= 0.10 && < 0.11
     , lens                 >= 5.0  && < 5.3
     , network              >= 3.1  && < 3.2
     , optparse-applicative >= 0.16 && < 0.19
@@ -307,6 +314,7 @@ executable demo-client
     , proto-lens-runtime   >= 0.7  && < 0.8
     , stm                  >= 2.5  && < 2.6
     , text                 >= 1.2  && < 2.1
+    , transformers         >= 0.5  && < 0.7
 
   if !flag(build-demo)
     buildable:

--- a/interop/Interop/Client/Ping.hs
+++ b/interop/Interop/Client/Ping.hs
@@ -10,8 +10,7 @@ import Data.ProtoLens
 import Data.ProtoLens.Labels ()
 
 import Network.GRPC.Client
-import Network.GRPC.Client.StreamType
-import Network.GRPC.Common.StreamType
+import Network.GRPC.Client.StreamType.IO
 
 import Proto.Ping
 
@@ -23,7 +22,7 @@ ping cmdline = connect cmdline $ \conn ->
     forM_ [1..] $ \i -> do
       let msgPing :: PingMessage
           msgPing = defMessage & #id .~ i
-      msgPong <- nonStreaming (rpc @(Protobuf PingService "ping") conn) msgPing
+      msgPong <- nonStreaming conn (rpc @(Protobuf PingService "ping")) msgPing
       print msgPong
       threadDelay 1_000_000
 

--- a/interop/Interop/Server.hs
+++ b/interop/Interop/Server.hs
@@ -6,7 +6,6 @@ import Data.ProtoLens.Labels ()
 import Data.Proxy
 
 import Network.GRPC.Common
-import Network.GRPC.Common.StreamType
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
 import Network.GRPC.Server.Run

--- a/src/Network/GRPC/Client.hs
+++ b/src/Network/GRPC/Client.hs
@@ -56,6 +56,10 @@ module Network.GRPC.Client (
     -- * Common serialization formats
   , Protobuf
 
+    -- * Communication patterns
+  , rpc
+  , rpcWith
+
     -- * Exceptions
   , ServerDisconnected(..)
 
@@ -65,6 +69,7 @@ module Network.GRPC.Client (
 
 import Network.GRPC.Client.Call
 import Network.GRPC.Client.Connection
+import Network.GRPC.Client.StreamType (rpc, rpcWith)
 import Network.GRPC.Spec
 import Network.GRPC.Util.HTTP2.Stream (ServerDisconnected(..))
 import Network.GRPC.Util.TLS qualified as Util.TLS

--- a/src/Network/GRPC/Client/Binary.hs
+++ b/src/Network/GRPC/Client/Binary.hs
@@ -9,16 +9,8 @@ module Network.GRPC.Client.Binary (
   , sendFinalInput
   , recvOutput
   , recvFinalOutput
-
-    -- * Stream types
-  , nonStreaming
-  , clientStreaming
-  , serverStreaming
-  , biDiStreaming
   ) where
 
-import Control.Monad
-import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Data.Binary
 
@@ -26,19 +18,9 @@ import Network.GRPC.Client (Call)
 import Network.GRPC.Client qualified as Client
 import Network.GRPC.Common
 import Network.GRPC.Common.Binary
-import Network.GRPC.Common.StreamType qualified as StreamType
 
 {-------------------------------------------------------------------------------
   Convenience wrappers using @binary@ for serialization/deserialization
-
-  Unlike for the server, we do /not/ wrap the client handlers here, because they
-  are not a good match. The standard client streaming handlers expect a /single/
-  IO action that produces all inputs and/or a single IO action that handles all
-  outputs, but the raw binary protocol allows message types to be different at
-  each point in the communication.
-
-  These functions all have the type of the value sent or received as the /first/
-  argument, to facilitate the use of type arguments.
 -------------------------------------------------------------------------------}
 
 sendInput :: forall inp serv meth m.
@@ -71,47 +53,3 @@ recvFinalOutput call = liftIO $ do
     (out, md) <- Client.recvFinalOutput call
     (, md) <$> decodeOrThrow out
 
-{-------------------------------------------------------------------------------
-  Wrappers for common streaming types that handle encoding/decoding
--------------------------------------------------------------------------------}
-
--- | Wrapper for 'StreamType.nonStreaming' that handles encoding\/decoding of
--- input\/output.
-nonStreaming :: forall inp out serv meth m.
-     (Binary inp, Binary out, MonadThrow m)
-  => StreamType.NonStreamingHandler m (BinaryRpc serv meth)
-  -> inp -> m out
-nonStreaming h inp =
-    StreamType.nonStreaming h (encode inp) >>= decodeOrThrow
-
--- | Wrapper for 'StreamType.clientStreaming' that handles encoding\/decoding of
--- input\/output.
-clientStreaming :: forall inp out serv meth m.
-     (Binary inp, Binary out, MonadThrow m)
-  => StreamType.ClientStreamingHandler m (BinaryRpc serv meth)
-  -> m (StreamElem NoMetadata inp)
-  -> m out
-clientStreaming h f =
-    StreamType.clientStreaming h (fmap encode <$> f) >>= decodeOrThrow
-
--- | Wrapper for 'StreamType.serverStreaming' that handles encoding\/decoding of
--- input\/output.
-serverStreaming :: forall inp out serv meth m.
-     (Binary inp, Binary out, MonadThrow m)
-  => StreamType.ServerStreamingHandler m (BinaryRpc serv meth)
-  -> inp
-  -> (out -> m ())
-  -> m ()
-serverStreaming h inp f =
-    StreamType.serverStreaming h (encode inp) (f <=< decodeOrThrow)
-
--- | Wrapper for 'StreamType.biDiStreaming' that handles encoding\/decoding of
--- input\/output.
-biDiStreaming :: forall inp out serv meth m.
-     (Binary inp, Binary out, MonadThrow m)
-  => StreamType.BiDiStreamingHandler m (BinaryRpc serv meth)
-  -> m (StreamElem NoMetadata inp)
-  -> (out -> m ())
-  -> m ()
-biDiStreaming h inp f =
-    StreamType.biDiStreaming h (fmap encode <$> inp) (f <=< decodeOrThrow)

--- a/src/Network/GRPC/Client/StreamType.hs
+++ b/src/Network/GRPC/Client/StreamType.hs
@@ -1,60 +1,82 @@
+-- | Construct client handlers
+--
+-- This is an internal module only; see "Network.GRPC.Client.StreamType.IO"
+-- for the main public module.
 module Network.GRPC.Client.StreamType (
-    -- ** Obtain handler for specific RPC call
+    -- * Obtain handler for specific RPC call
     ClientHandler(..)
+  , CanCallRPC(..)
   , rpc
   ) where
 
 import Control.Monad.Catch
 import Control.Monad.IO.Class
+import Control.Monad.Reader
 import Data.Default
 import Data.Proxy
 
-import Network.GRPC.Client
+import Network.GRPC.Client.Call
+import Network.GRPC.Client.Connection
+import Network.GRPC.Common.StreamElem
 import Network.GRPC.Common.StreamType
 import Network.GRPC.Spec
 
 import Debug.Concurrent
 
 {-------------------------------------------------------------------------------
+  CanCallRPC
+-------------------------------------------------------------------------------}
+
+-- | Monads in which we make RPC calls
+--
+-- In order to be able to make an RPC call, we need
+--
+-- * 'MonadIO' (obviously)
+-- * 'MonadMask' in order to ensure that the RPC call is terminated cleanly
+-- * Access to the 'Connection' to the server
+class (MonadIO m, MonadMask m) => CanCallRPC m where
+  getConnection :: m Connection
+
+instance (MonadIO m, MonadMask m) => CanCallRPC (ReaderT Connection m) where
+  getConnection = ask
+
+{-------------------------------------------------------------------------------
   Obtain handler for specific RPC call
 -------------------------------------------------------------------------------}
 
 class ClientHandler h where
-  rpcWith :: IsRPC rpc => Connection -> CallParams -> Proxy rpc -> h rpc
+  rpcWith :: IsRPC rpc => CallParams -> Proxy rpc -> h rpc
 
 -- | Construct RPC handler
 --
 -- See 'nonStreaming' and friends for example usage.
 --
 -- If you want to use non-default 'CallParams', use 'rpcWith'.
-rpc :: forall rpc h. (ClientHandler h, IsRPC rpc)  => Connection -> h rpc
-rpc conn = rpcWith conn def (Proxy @rpc)
+rpc :: forall rpc h. (ClientHandler h, IsRPC rpc)  => h rpc
+rpc = rpcWith def (Proxy @rpc)
 
-instance ( MonadIO   m
-         , MonadMask m
-         ) => ClientHandler (NonStreamingHandler m) where
-  rpcWith conn params proxy =
-    UnsafeNonStreamingHandler $ \input ->
+instance CanCallRPC m => ClientHandler (NonStreamingHandler m) where
+  rpcWith params proxy =
+    UnsafeNonStreamingHandler $ \input -> do
+      conn <- getConnection
       withRPC conn params proxy $ \call -> do
         sendFinalInput call input
         (output, _trailers) <- recvFinalOutput call
         return output
 
-instance ( MonadIO   m
-         , MonadMask m
-         ) => ClientHandler (ClientStreamingHandler m) where
-  rpcWith conn params proxy =
-    UnsafeClientStreamingHandler $ \produceInput ->
+instance CanCallRPC m => ClientHandler (ClientStreamingHandler m) where
+  rpcWith params proxy =
+    UnsafeClientStreamingHandler $ \produceInput -> do
+      conn <- getConnection
       withRPC conn params proxy $ \call -> do
         sendAllInputs call produceInput
         (output, _trailers) <- recvFinalOutput call
         return output
 
-instance ( MonadIO   m
-         , MonadMask m
-         ) => ClientHandler (ServerStreamingHandler m) where
-  rpcWith conn params proxy =
-    UnsafeServerStreamingHandler $ \input processOutput ->
+instance CanCallRPC m => ClientHandler (ServerStreamingHandler m) where
+  rpcWith params proxy =
+    UnsafeServerStreamingHandler $ \input processOutput -> do
+      conn <- getConnection
       withRPC conn params proxy $ \call -> do
         sendFinalInput call input
         _trailers <- recvAllOutputs call processOutput
@@ -69,11 +91,23 @@ instance ( MonadIO   m
 -- function. Another indication that we should is that the corresponding
 -- function in "Network.GRPC.Protobuf.Pipes" cannot be defined in terms
 -- of this function, unlike for the other streaming functions.
-instance ClientHandler (BiDiStreamingHandler IO) where
-  rpcWith conn params proxy =
+instance ClientHandler (BiDiStreamingHandler (ReaderT Connection IO)) where
+  rpcWith :: forall rpc.
+       IsRPC rpc
+    => CallParams
+    -> Proxy rpc
+    -> BiDiStreamingHandler (ReaderT Connection IO) rpc
+  rpcWith params proxy =
     UnsafeBiDiStreamingHandler $ \produceInput processOutput ->
-      withRPC conn params proxy $ \call -> do
-        withAsync (sendAllInputs call produceInput) $ \_threadId -> do
-          _trailers <- recvAllOutputs call processOutput
-          return ()
+      ReaderT $ \conn -> do
 
+        let produceInput' :: IO (StreamElem NoMetadata (Input rpc))
+            produceInput' = flip runReaderT conn produceInput
+
+            processOutput' :: Output rpc -> IO ()
+            processOutput' = flip runReaderT conn . processOutput
+
+        withRPC conn params proxy $ \call -> do
+          withAsync (sendAllInputs call produceInput') $ \_threadId -> do
+            _trailers <- recvAllOutputs call processOutput'
+            return ()

--- a/src/Network/GRPC/Client/StreamType/CanCallRPC.hs
+++ b/src/Network/GRPC/Client/StreamType/CanCallRPC.hs
@@ -1,0 +1,15 @@
+-- | Like "Network.GRPC.Client.StreamType.IO", but with an implicit 'Connection'
+--
+-- These functions are useful in a monad stack in which the 'Connection' object
+-- is implicitly available; you must provide an instance of 'CanCallRPC'.
+module Network.GRPC.Client.StreamType.CanCallRPC (
+    module Network.GRPC.Client.StreamType
+    -- * Execution
+  , Spec.nonStreaming
+  , Spec.clientStreaming
+  , Spec.serverStreaming
+  , Spec.biDiStreaming
+  ) where
+
+import Network.GRPC.Client.StreamType
+import Network.GRPC.Spec as Spec

--- a/src/Network/GRPC/Client/StreamType/IO.hs
+++ b/src/Network/GRPC/Client/StreamType/IO.hs
@@ -1,0 +1,92 @@
+-- | Execute handlers for specific communication patterns
+--
+-- See also "Network.GRPC.Common.StreamType" as well as
+-- "Network.GRPC.Client.StreamType.CanCallRPC".
+module Network.GRPC.Client.StreamType.IO (
+    module Network.GRPC.Client.StreamType
+    -- * Execution
+  , nonStreaming
+  , clientStreaming
+  , serverStreaming
+  , biDiStreaming
+  ) where
+
+import Control.Monad.Reader
+
+import Network.GRPC.Client
+import Network.GRPC.Common.StreamElem
+import Network.GRPC.Common.StreamType
+import Network.GRPC.Spec (IsRPC(..), NoMetadata)
+import Network.GRPC.Spec qualified as Spec
+import Network.GRPC.Client.StreamType hiding (CanCallRPC(..))
+
+{-------------------------------------------------------------------------------
+  Execution
+-------------------------------------------------------------------------------}
+
+-- | Make a non-streaming RPC
+--
+-- Example usage:
+--
+-- > features <-
+-- >   nonStreaming conn (rpc @(Protobuf RouteGuide "getFeature")) point
+-- > logMsg features
+nonStreaming :: forall rpc m.
+     SupportsStreamingType rpc NonStreaming
+  => Connection
+  -> NonStreamingHandler (ReaderT Connection m) rpc
+  -> Input rpc
+  -> m (Output rpc)
+nonStreaming conn h input =
+    flip runReaderT conn $
+      Spec.nonStreaming h input
+
+-- | Make a client-side streaming RPC
+--
+-- Example usage:
+--
+-- > summary <-
+-- >   clientStreaming conn (rpc @(Protobuf RouteGuide "recordRoute")) getPoint
+clientStreaming :: forall rpc m.
+     (SupportsStreamingType rpc ClientStreaming, Monad m)
+  => Connection
+  -> ClientStreamingHandler (ReaderT Connection m) rpc
+  -> m (StreamElem NoMetadata (Input rpc))
+  -> m (Output rpc)
+clientStreaming conn h produceInput =
+    flip runReaderT conn $
+      Spec.clientStreaming h (lift produceInput)
+
+-- | Make a server-side streaming RPC
+--
+-- Example usage:
+--
+-- > serverStreaming conn (rpc @(Protobuf RouteGuide "listFeatures")) rect $
+-- >   logMsg
+serverStreaming :: forall rpc m.
+     (SupportsStreamingType rpc ServerStreaming, Monad m)
+  => Connection
+  -> ServerStreamingHandler (ReaderT Connection m) rpc
+  -> Input rpc
+  -> (Output rpc -> m ())
+  -> m ()
+serverStreaming conn h input processOutput =
+    flip runReaderT conn $
+      Spec.serverStreaming h input (lift . processOutput)
+
+-- | Make a bidirectional RPC
+--
+-- Example usage:
+--
+-- > biDiStreaming conn (rpc @(Protobuf RouteGuide "routeChat")) getNote $
+-- >   logMsg
+biDiStreaming :: forall rpc m.
+     (SupportsStreamingType rpc BiDiStreaming, Monad m)
+  => Connection
+  -> BiDiStreamingHandler (ReaderT Connection m) rpc
+  -> m (StreamElem NoMetadata (Input rpc))
+  -> (Output rpc -> m ())
+  -> m ()
+biDiStreaming conn h produceInput processOutput =
+    flip runReaderT conn $
+      Spec.biDiStreaming h (lift produceInput) (lift . processOutput)

--- a/src/Network/GRPC/Client/StreamType/IO/Binary.hs
+++ b/src/Network/GRPC/Client/StreamType/IO/Binary.hs
@@ -1,0 +1,72 @@
+-- | Wrap "Network.GRPC.Client.StreamType.IO" to handle binary serialization
+--
+-- **NOTE**: The custom binary gRPC format provided by @grapesy@ is designed
+-- so that the type of each message during communication can be different.
+-- The wrappers in this module lose this generalization: every input and every
+-- output must be of the same type. If this is too severe a limitaiton, you
+-- should use the functionality from "Network.GRPC.Client.Binary" instead.
+module Network.GRPC.Client.StreamType.IO.Binary (
+    module Network.GRPC.Client.StreamType
+    -- * Stream types
+  , nonStreaming
+  , clientStreaming
+  , serverStreaming
+  , biDiStreaming
+  ) where
+
+import Control.Monad
+import Control.Monad.Catch
+import Control.Monad.Reader
+import Data.Binary
+
+import Network.GRPC.Client (Connection)
+import Network.GRPC.Client.StreamType hiding (CanCallRPC(..))
+import Network.GRPC.Client.StreamType.IO qualified as IO
+import Network.GRPC.Common
+import Network.GRPC.Common.Binary
+import Network.GRPC.Common.StreamType
+
+{-------------------------------------------------------------------------------
+  Wrappers for common streaming types that handle encoding/decoding
+-------------------------------------------------------------------------------}
+
+-- | Wrapper for 'IO.nonStreaming' that handles binary serialization
+nonStreaming :: forall inp out serv meth m.
+     (Binary inp, Binary out, MonadThrow m)
+  => Connection
+  -> NonStreamingHandler (ReaderT Connection m) (BinaryRpc serv meth)
+  -> inp -> m out
+nonStreaming conn h inp =
+    IO.nonStreaming conn h (encode inp) >>= decodeOrThrow
+
+-- | Wrapper for 'IO.clientStreaming' that handles binary serialization
+clientStreaming :: forall inp out serv meth m.
+     (Binary inp, Binary out, MonadThrow m)
+  => Connection
+  -> ClientStreamingHandler (ReaderT Connection m) (BinaryRpc serv meth)
+  -> m (StreamElem NoMetadata inp)
+  -> m out
+clientStreaming conn h f =
+    IO.clientStreaming conn h (fmap encode <$> f) >>= decodeOrThrow
+
+-- | Wrapper for 'IO.serverStreaming' that binary serialization
+serverStreaming :: forall inp out serv meth m.
+     (Binary inp, Binary out, MonadThrow m)
+  => Connection
+  -> ServerStreamingHandler (ReaderT Connection m) (BinaryRpc serv meth)
+  -> inp
+  -> (out -> m ())
+  -> m ()
+serverStreaming conn h inp f =
+    IO.serverStreaming conn h (encode inp) (f <=< decodeOrThrow)
+
+-- | Wrapper for 'IO.biDiStreaming' that handles binary serialization
+biDiStreaming :: forall inp out serv meth m.
+     (Binary inp, Binary out, MonadThrow m)
+  => Connection
+  -> BiDiStreamingHandler (ReaderT Connection m) (BinaryRpc serv meth)
+  -> m (StreamElem NoMetadata inp)
+  -> (out -> m ())
+  -> m ()
+biDiStreaming conn h inp f =
+    IO.biDiStreaming conn h (fmap encode <$> inp) (f <=< decodeOrThrow)

--- a/src/Network/GRPC/Common/StreamType.hs
+++ b/src/Network/GRPC/Common/StreamType.hs
@@ -25,16 +25,6 @@ module Network.GRPC.Common.StreamType (
   , ClientStreamingHandler(..)
   , ServerStreamingHandler(..)
   , BiDiStreamingHandler(..)
-    -- * Execution
-  , nonStreaming
-  , clientStreaming
-  , serverStreaming
-  , biDiStreaming
-    -- * Construction
-  , mkNonStreaming
-  , mkClientStreaming
-  , mkServerStreaming
-  , mkBiDiStreaming
   ) where
 
 import Network.GRPC.Spec

--- a/src/Network/GRPC/Server/Binary.hs
+++ b/src/Network/GRPC/Server/Binary.hs
@@ -20,11 +20,12 @@ import Control.Monad.Catch
 import Data.Binary
 import GHC.Stack
 
-import Network.GRPC.Common.Binary
 import Network.GRPC.Common
-import Network.GRPC.Common.StreamType qualified as StreamType
+import Network.GRPC.Common.Binary
+import Network.GRPC.Common.StreamType
 import Network.GRPC.Server (Call)
 import Network.GRPC.Server qualified as Server
+import Network.GRPC.Server.StreamType qualified as StreamType
 
 {-------------------------------------------------------------------------------
   Convenience wrapers using @binary@ for serialization/deserialization
@@ -69,7 +70,7 @@ mkNonStreaming :: forall m inp out serv meth.
   => (    inp
        -> m out
      )
-  -> StreamType.NonStreamingHandler m (BinaryRpc serv meth)
+  -> NonStreamingHandler m (BinaryRpc serv meth)
 mkNonStreaming f = StreamType.mkNonStreaming $ \inp -> do
     inp' <- decodeOrThrow inp
     encode <$> f inp'
@@ -79,7 +80,7 @@ mkClientStreaming :: forall m out serv meth.
   => (    (forall inp. Binary inp => m (StreamElem NoMetadata inp))
        -> m out
      )
-  -> StreamType.ClientStreamingHandler m (BinaryRpc serv meth)
+  -> ClientStreamingHandler m (BinaryRpc serv meth)
 mkClientStreaming f = StreamType.mkClientStreaming $ \recv -> do
     out <- f (recv >>= traverse decodeOrThrow)
     return $ encode out
@@ -90,7 +91,7 @@ mkServerStreaming :: forall m inp serv meth.
        -> (forall out. Binary out => out -> m ())
        -> m ()
      )
-  -> StreamType.ServerStreamingHandler m (BinaryRpc serv meth)
+  -> ServerStreamingHandler m (BinaryRpc serv meth)
 mkServerStreaming f = StreamType.mkServerStreaming $ \inp send -> do
     inp' <- decodeOrThrow inp
     f inp' (send . encode)
@@ -101,7 +102,7 @@ mkBiDiStreaming :: forall m serv meth.
        -> (forall out. Binary out => out -> m ())
        -> m ()
      )
-  -> StreamType.BiDiStreamingHandler m (BinaryRpc serv meth)
+  -> BiDiStreamingHandler m (BinaryRpc serv meth)
 mkBiDiStreaming f = StreamType.mkBiDiStreaming $ \recv send ->
     f (recv >>= traverse decodeOrThrow) (send . encode)
 

--- a/src/Network/GRPC/Server/StreamType.hs
+++ b/src/Network/GRPC/Server/StreamType.hs
@@ -2,6 +2,11 @@ module Network.GRPC.Server.StreamType (
     -- * Construct 'RpcHandler' from streaming type specific handler
     StreamingRpcHandler(..)
   , streamingRpcHandler'
+    -- * Constructors
+  , mkNonStreaming
+  , mkClientStreaming
+  , mkServerStreaming
+  , mkBiDiStreaming
     -- * Server API
   , Methods(..)
   , Services(..)

--- a/src/Network/GRPC/Spec/RPC/StreamType.hs
+++ b/src/Network/GRPC/Spec/RPC/StreamType.hs
@@ -92,13 +92,6 @@ type family HandlerFor (typ :: StreamingType) :: (Type -> Type) -> Type -> Type 
   type of RPC.
 -------------------------------------------------------------------------------}
 
--- | Make a non-streaming RPC
---
--- Example usage:
---
--- > features <-
--- >   nonStreaming (rpc @(Protobuf RouteGuide "getFeature") conn) point
--- > logMsg features
 nonStreaming :: forall rpc m.
      SupportsStreamingType rpc NonStreaming
   => NonStreamingHandler m rpc
@@ -108,12 +101,6 @@ nonStreaming (UnsafeNonStreamingHandler h) = h
   where
     _ = addConstraint @(SupportsStreamingType rpc NonStreaming)
 
--- | Make a client-side streaming RPC
---
--- Example usage:
---
--- > summary <-
--- >   clientStreaming (rpc @(Protobuf RouteGuide "recordRoute") conn) getPoint
 clientStreaming :: forall rpc m.
      SupportsStreamingType rpc ClientStreaming
   => ClientStreamingHandler m rpc
@@ -123,12 +110,6 @@ clientStreaming (UnsafeClientStreamingHandler h) = h
   where
     _ = addConstraint @(SupportsStreamingType rpc ClientStreaming)
 
--- | Make a server-side streaming RPC
---
--- Example usage:
---
--- > serverStreaming (rpc @(Protobuf RouteGuide "listFeatures") conn) rect $
--- >   logMsg
 serverStreaming :: forall rpc m.
      SupportsStreamingType rpc ServerStreaming
   => ServerStreamingHandler m rpc
@@ -139,12 +120,6 @@ serverStreaming (UnsafeServerStreamingHandler h) = h
   where
     _ = addConstraint @(SupportsStreamingType rpc ServerStreaming)
 
--- | Make a bidirectional RPC
---
--- Example usage:
---
--- > biDiStreaming (rpc @(Protobuf RouteGuide "routeChat") conn) getNote $
--- >   logMsg
 biDiStreaming :: forall rpc m.
      SupportsStreamingType rpc BiDiStreaming
   => BiDiStreamingHandler m rpc

--- a/test-grapesy/Test/Sanity/Interop.hs
+++ b/test-grapesy/Test/Sanity/Interop.hs
@@ -18,11 +18,9 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import Network.GRPC.Client qualified as Client
-import Network.GRPC.Client.Binary qualified as Client.Binary
-import Network.GRPC.Client.StreamType qualified as Client
+import Network.GRPC.Client.StreamType.IO.Binary qualified as Client.Binary
 import Network.GRPC.Common
 import Network.GRPC.Common.StreamElem qualified as StreamElem
-import Network.GRPC.Common.StreamType qualified as StreamType
 import Network.GRPC.Internal
 import Network.GRPC.Server qualified as Server
 import Network.GRPC.Server.Binary qualified as Server.Binary
@@ -93,7 +91,7 @@ test_callAfterException =
     call conn =
         fmap (first (innerNestedException :: SomeException -> SomeException))
       . try
-      . Client.Binary.nonStreaming (Client.rpc @Ping conn)
+      . Client.Binary.nonStreaming conn (Client.rpc @Ping)
 
     expectInvalidArgument :: SomeException -> Maybe ()
     expectInvalidArgument e
@@ -128,7 +126,7 @@ test_emptyUnary =
               Just (envelope, _x :: Empty) -> verifyEnvelope envelope
       , server = [
             Server.streamingRpcHandler (Proxy @EmptyCall) $
-              StreamType.mkNonStreaming $ \(_ ::Empty) ->
+              Server.mkNonStreaming $ \(_ ::Empty) ->
                 return (defMessage :: Empty)
           ]
       }


### PR DESCRIPTION
Importantly, this enables the use of a monad stack to keep track of the `Connection`. See `Demo.Client.API.Protobuf.CanCallRPC.Greeter` for a demo.