### PR TITLE
Re-exports of frequently used functionality from other packages

### DIFF
--- a/demo-client/Demo/Client/API/Core/Greeter.hs
+++ b/demo-client/Demo/Client/API/Core/Greeter.hs
@@ -2,10 +2,9 @@ module Demo.Client.API.Core.Greeter (
     sayHelloStreamReply
   ) where
 
-import Data.Default
-import Data.Proxy
-
 import Network.GRPC.Client
+import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 
 import Proto.Helloworld
 

--- a/demo-client/Demo/Client/API/Core/NoFinal/Greeter.hs
+++ b/demo-client/Demo/Client/API/Core/NoFinal/Greeter.hs
@@ -2,11 +2,9 @@ module Demo.Client.API.Core.NoFinal.Greeter (
     sayHello
   ) where
 
-import Data.Default
-import Data.Proxy
-
 import Network.GRPC.Client
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 
 import Proto.Helloworld
 

--- a/demo-client/Demo/Client/API/Core/RouteGuide.hs
+++ b/demo-client/Demo/Client/API/Core/RouteGuide.hs
@@ -2,10 +2,9 @@ module Demo.Client.API.Core.RouteGuide (
     listFeatures
   ) where
 
-import Data.Default
-import Data.Proxy
-
 import Network.GRPC.Client
+import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 
 import Proto.RouteGuide
 

--- a/demo-client/Demo/Client/API/Protobuf/CanCallRPC/Greeter.hs
+++ b/demo-client/Demo/Client/API/Protobuf/CanCallRPC/Greeter.hs
@@ -10,6 +10,7 @@ import Control.Monad.Trans.Reader
 
 import Network.GRPC.Client
 import Network.GRPC.Client.StreamType.CanCallRPC
+import Network.GRPC.Common.Protobuf
 
 import Proto.Helloworld
 

--- a/demo-client/Demo/Client/API/Protobuf/IO/Greeter.hs
+++ b/demo-client/Demo/Client/API/Protobuf/IO/Greeter.hs
@@ -5,6 +5,7 @@ module Demo.Client.API.Protobuf.IO.Greeter (
 
 import Network.GRPC.Client
 import Network.GRPC.Client.StreamType.IO
+import Network.GRPC.Common.Protobuf
 
 import Proto.Helloworld
 

--- a/demo-client/Demo/Client/API/Protobuf/IO/RouteGuide.hs
+++ b/demo-client/Demo/Client/API/Protobuf/IO/RouteGuide.hs
@@ -8,6 +8,7 @@ module Demo.Client.API.Protobuf.IO.RouteGuide (
 import Network.GRPC.Client
 import Network.GRPC.Client.StreamType.IO
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 
 import Proto.RouteGuide
 

--- a/demo-client/Demo/Client/API/Protobuf/Pipes/RouteGuide.hs
+++ b/demo-client/Demo/Client/API/Protobuf/Pipes/RouteGuide.hs
@@ -4,8 +4,6 @@ module Demo.Client.API.Protobuf.Pipes.RouteGuide (
   , routeChat
   ) where
 
-import Data.Default
-import Data.Proxy
 import Pipes hiding (Proxy)
 import Pipes.Prelude qualified as Pipes
 import Pipes.Safe
@@ -13,6 +11,7 @@ import Pipes.Safe
 import Network.GRPC.Client
 import Network.GRPC.Client.StreamType.Pipes
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 
 import Proto.RouteGuide
 

--- a/demo-client/Demo/Client/Cmdline.hs
+++ b/demo-client/Demo/Client/Cmdline.hs
@@ -16,15 +16,10 @@ module Demo.Client.Cmdline (
 
 import Prelude
 
-import Control.Lens ((.~))
-import Data.Default
 import Data.Foldable (asum)
-import Data.Function ((&))
 import Data.Int
 import Data.Kind
 import Data.Maybe (fromMaybe)
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
 import Data.Text (Text)
 import GHC.TypeLits (Symbol)
 import Network.Socket (HostName, PortNumber)
@@ -32,8 +27,10 @@ import Options.Applicative ((<**>))
 import Options.Applicative qualified as Opt
 
 import Network.GRPC.Client qualified as Client
+import Network.GRPC.Common
 import Network.GRPC.Common.Compression (Compression)
 import Network.GRPC.Common.Compression qualified as Compr
+import Network.GRPC.Common.Protobuf
 
 import Paths_grapesy
 

--- a/demo-client/Main.hs
+++ b/demo-client/Main.hs
@@ -5,11 +5,11 @@ module Main (main) where
 
 import Control.Exception
 import Control.Tracer
-import Data.Default
 import System.IO
 import System.Mem (performMajorGC)
 
 import Network.GRPC.Client
+import Network.GRPC.Common
 import Network.GRPC.Common.Compression qualified as Compr
 
 import Debug.Concurrent

--- a/demo-server/Demo/Server/Aux/RouteGuide.hs
+++ b/demo-server/Demo/Server/Aux/RouteGuide.hs
@@ -10,16 +10,14 @@ module Demo.Server.Aux.RouteGuide (
   , distance
   ) where
 
-import Control.Lens ((.~), (^.))
 import Data.Aeson
-import Data.Function ((&))
 import Data.Int
 import Data.Maybe (listToMaybe)
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
 import Data.Time
 
 import Proto.RouteGuide
+
+import Network.GRPC.Common.Protobuf
 
 {-------------------------------------------------------------------------------
   Pure functions that implement that basic Route Guide functionality

--- a/demo-server/Demo/Server/Service/Greeter.hs
+++ b/demo-server/Demo/Server/Service/Greeter.hs
@@ -3,16 +3,12 @@
 
 module Demo.Server.Service.Greeter (handlers) where
 
-import Control.Lens ((.~), (^.))
 import Control.Monad
-import Data.Default
-import Data.Function ((&))
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
 import Data.Proxy
 import Data.Text (Text)
 
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
 import Network.GRPC.Server.StreamType

--- a/demo-server/Main.hs
+++ b/demo-server/Main.hs
@@ -4,8 +4,8 @@ module Main (main) where
 
 import Control.Tracer
 import Data.Aeson
-import Data.Default
 
+import Network.GRPC.Common
 import Network.GRPC.Common.Compression qualified as Compression
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -87,6 +87,7 @@ library
       Network.GRPC.Common
       Network.GRPC.Common.Binary
       Network.GRPC.Common.Compression
+      Network.GRPC.Common.Protobuf
       Network.GRPC.Common.StreamElem
       Network.GRPC.Common.StreamType
       Network.GRPC.Internal
@@ -164,6 +165,7 @@ library
     , http-types           >= 0.12  && < 0.13
     , http2                >= 5.1.1 && < 5.2
     , http2-tls            >= 0.2.2 && < 0.3
+    , lens                 >= 5.0   && < 5.3
     , mtl                  >= 2.2   && < 2.4
     , network              >= 3.1   && < 3.2
     , network-byte-order   >= 0.1   && < 0.2
@@ -247,12 +249,9 @@ test-suite test-grapesy
     , bytestring         >= 0.10 && < 0.12
     , containers         >= 0.6  && < 0.7
     , contra-tracer      >= 0.2  && < 0.3
-    , data-default       >= 0.7  && < 0.8
     , exceptions         >= 0.10 && < 0.11
-    , lens               >= 5.0  && < 5.3
     , mtl                >= 2.2  && < 2.4
     , pretty-show        >= 1.10 && < 1.11
-    , proto-lens         >= 0.7  && < 0.8
     , proto-lens-runtime >= 0.7  && < 0.8
     , QuickCheck         >= 2.14 && < 2.15
     , serialise          >= 0.2  && < 0.3
@@ -303,14 +302,11 @@ executable demo-client
       -- External dependencies
     , async                >= 2.2  && < 2.3
     , contra-tracer        >= 0.2  && < 0.3
-    , data-default         >= 0.7  && < 0.8
     , exceptions           >= 0.10 && < 0.11
-    , lens                 >= 5.0  && < 5.3
     , network              >= 3.1  && < 3.2
     , optparse-applicative >= 0.16 && < 0.19
     , pipes                >= 4.3  && < 4.4
     , pipes-safe           >= 2.3  && < 2.4
-    , proto-lens           >= 0.7  && < 0.8
     , proto-lens-runtime   >= 0.7  && < 0.8
     , stm                  >= 2.5  && < 2.6
     , text                 >= 1.2  && < 2.1
@@ -356,12 +352,9 @@ executable demo-server
     , async                >= 2.2  && < 2.3
     , containers           >= 0.6  && < 0.7
     , contra-tracer        >= 0.2  && < 0.3
-    , data-default         >= 0.7  && < 0.8
-    , lens                 >= 5.0  && < 5.3
     , mtl                  >= 2.2  && < 2.4
     , network              >= 3.1  && < 3.2
     , optparse-applicative >= 0.16 && < 0.19
-    , proto-lens           >= 0.7  && < 0.8
     , proto-lens-runtime   >= 0.7  && < 0.8
     , stm                  >= 2.5  && < 2.6
     , text                 >= 1.2  && < 2.1
@@ -400,7 +393,6 @@ executable test-stress
     , bytestring           >= 0.10 && < 0.12
     , containers           >= 0.6  && < 0.7
     , contra-tracer        >= 0.2  && < 0.3
-    , data-default         >= 0.7  && < 0.8
     , optparse-applicative >= 0.16 && < 0.19
     , pretty-show          >= 1.10 && < 1.11
     , stm                  >= 2.5  && < 2.6
@@ -443,12 +435,9 @@ executable grapesy-interop
   build-depends:
     , base
     , bytestring
-    , data-default
     , exceptions
-    , lens
     , network
     , optparse-applicative
-    , proto-lens
     , proto-lens-runtime
     , text
 

--- a/interop/Interop/Client/Connect.hs
+++ b/interop/Interop/Client/Connect.hs
@@ -1,7 +1,5 @@
 module Interop.Client.Connect (connect) where
 
-import Data.Default
-
 import Network.GRPC.Client
 import Network.GRPC.Common
 

--- a/interop/Interop/Client/Ping.hs
+++ b/interop/Interop/Client/Ping.hs
@@ -3,14 +3,11 @@
 module Interop.Client.Ping (ping) where
 
 import Control.Concurrent
-import Control.Lens ((.~))
 import Control.Monad
-import Data.Function ((&))
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
 
 import Network.GRPC.Client
 import Network.GRPC.Client.StreamType.IO
+import Network.GRPC.Common.Protobuf
 
 import Proto.Ping
 

--- a/interop/Interop/Server.hs
+++ b/interop/Interop/Server.hs
@@ -1,8 +1,6 @@
 module Interop.Server (server) where
 
 import Control.Monad.Catch (generalBracket, ExitCase(..))
-import Data.Default
-import Data.ProtoLens.Labels ()
 import Data.Proxy
 
 import Network.GRPC.Common

--- a/interop/Interop/Server/PingService/Ping.hs
+++ b/interop/Interop/Server/PingService/Ping.hs
@@ -2,10 +2,7 @@
 
 module Interop.Server.PingService.Ping (handlePing) where
 
-import Control.Lens ((.~), (^.))
-import Data.Function ((&))
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
+import Network.GRPC.Common.Protobuf
 
 import Proto.Ping
 

--- a/interop/Interop/Server/TestService/EmptyCall.hs
+++ b/interop/Interop/Server/TestService/EmptyCall.hs
@@ -1,6 +1,6 @@
 module Interop.Server.TestService.EmptyCall (handleEmptyCall) where
 
-import Data.ProtoLens
+import Network.GRPC.Common.Protobuf
 
 import Proto.Src.Proto.Grpc.Testing.Empty
 

--- a/interop/Interop/Server/TestService/FullDuplexCall.hs
+++ b/interop/Interop/Server/TestService/FullDuplexCall.hs
@@ -2,10 +2,8 @@
 
 module Interop.Server.TestService.FullDuplexCall (handleFullDuplexCall) where
 
-import Control.Lens ((^.))
-import Data.ProtoLens.Labels ()
-
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 import Network.GRPC.Server
 
 import Proto.Src.Proto.Grpc.Testing.Messages

--- a/interop/Interop/Server/TestService/StreamingInputCall.hs
+++ b/interop/Interop/Server/TestService/StreamingInputCall.hs
@@ -3,13 +3,10 @@
 
 module Interop.Server.TestService.StreamingInputCall (handleStreamingInputCall) where
 
-import Control.Lens ((^.), (.~))
 import Data.ByteString qualified as BS.Strict
-import Data.Function ((&))
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
 
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 import Network.GRPC.Server
 import Network.GRPC.Spec
 

--- a/interop/Interop/Server/TestService/StreamingOutputCall.hs
+++ b/interop/Interop/Server/TestService/StreamingOutputCall.hs
@@ -6,15 +6,10 @@ module Interop.Server.TestService.StreamingOutputCall (
   ) where
 
 import Control.Concurrent
-import Control.Lens ((.~), (^.))
 import Control.Monad
-import Data.Default
-import Data.Function ((&))
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
-import Data.ProtoLens.Service.Types
 
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 import Network.GRPC.Server
 import Network.GRPC.Spec
 
@@ -38,7 +33,7 @@ handleStreamingOutputCall call = do
 --
 -- Abstracted out because also used in the @fullDuplexCall@ test.
 handleStreamingOutputCallRequest :: forall meth.
-     (MethodOutput TestService meth ~ StreamingOutputCallResponse)
+     (Output (Protobuf TestService meth) ~ StreamingOutputCallResponse)
   => Call (Protobuf TestService meth)
   -> StreamingOutputCallRequest
   -> IO ()

--- a/interop/Interop/Server/TestService/UnaryCall.hs
+++ b/interop/Interop/Server/TestService/UnaryCall.hs
@@ -3,13 +3,8 @@
 
 module Interop.Server.TestService.UnaryCall (handleUnaryCall) where
 
-import Control.Lens ((.~), (^.))
-import Data.Default
-import Data.Function ((&))
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
-
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 import Network.GRPC.Common.StreamElem qualified as StreamElem
 import Network.GRPC.Server
 import Network.GRPC.Spec

--- a/interop/Interop/Server/Util.hs
+++ b/interop/Interop/Server/Util.hs
@@ -13,16 +13,13 @@ module Interop.Server.Util (
   ) where
 
 import Control.Exception
-import Control.Lens ((&), (.~), (^.))
 import Data.ByteString qualified as BS.Strict
 import Data.ByteString qualified as Strict (ByteString)
 import Data.ByteString.Char8 qualified as BS.Strict.Char8
-import Data.ProtoLens
-import Data.ProtoLens.Field (HasField)
-import Data.ProtoLens.Labels ()
 import Data.Text qualified as Text
 
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 import Network.GRPC.Server
 import Network.GRPC.Spec
 

--- a/src/Network/GRPC/Client.hs
+++ b/src/Network/GRPC/Client.hs
@@ -53,9 +53,6 @@ module Network.GRPC.Client (
   , sendInputWithEnvelope
   , recvOutputWithEnvelope
 
-    -- * Common serialization formats
-  , Protobuf
-
     -- * Communication patterns
   , rpc
   , rpcWith

--- a/src/Network/GRPC/Client/StreamType/Pipes.hs
+++ b/src/Network/GRPC/Client/StreamType/Pipes.hs
@@ -10,7 +10,6 @@ module Network.GRPC.Client.StreamType.Pipes (
 
 import Control.Monad.Reader
 import Data.ProtoLens.Service.Types
-import Data.Proxy
 import Pipes hiding (Proxy)
 import Pipes.Safe
 

--- a/src/Network/GRPC/Common.hs
+++ b/src/Network/GRPC/Common.hs
@@ -35,7 +35,14 @@ module Network.GRPC.Common (
     -- ** Low-level
   , Session.ChannelDiscarded(..)
   , Session.PeerException(..)
+
+    -- * Convenience re-exports
+  , Proxy(..)
+  , Default(..)
   ) where
+
+import Data.Default
+import Data.Proxy
 
 import Control.Exception
 

--- a/src/Network/GRPC/Common/Protobuf.hs
+++ b/src/Network/GRPC/Common/Protobuf.hs
@@ -1,0 +1,22 @@
+-- | Common functionality for working with Protobuf
+module Network.GRPC.Common.Protobuf (
+    Protobuf
+
+    -- * Re-exports
+    -- ** "Data.Function"
+  , (&)
+    -- ** "Control.Lens"
+  , (.~)
+  , (^.)
+    -- ** "Data.ProtoLens"
+  , HasField(..)
+  , defMessage
+  ) where
+
+import Control.Lens ((.~), (^.))
+import Data.Function ((&))
+import Data.ProtoLens (defMessage)
+import Data.ProtoLens.Field (HasField(..))
+import Data.ProtoLens.Labels () -- provides instances for OverloadedLabels
+
+import Network.GRPC.Spec (Protobuf)

--- a/src/Network/GRPC/Server.hs
+++ b/src/Network/GRPC/Server.hs
@@ -33,9 +33,6 @@ module Network.GRPC.Server (
   , sendOutputWithEnvelope
   , getRequestTraceContext
 
-    -- * Common serialization formats
-  , Protobuf
-
     -- * Exceptions
   , ClientDisconnected(..)
 
@@ -51,7 +48,6 @@ import Network.GRPC.Server.Context (ServerParams(..))
 import Network.GRPC.Server.Context qualified as Context
 import Network.GRPC.Server.Handler (RpcHandler(..))
 import Network.GRPC.Server.Handler qualified as Handler
-import Network.GRPC.Spec
 import Network.GRPC.Util.HTTP2.Stream (ClientDisconnected(..))
 
 {-------------------------------------------------------------------------------

--- a/test-common/Test/Util/ClientServer.hs
+++ b/test-common/Test/Util/ClientServer.hs
@@ -25,7 +25,6 @@ import Control.Exception
 import Control.Monad.IO.Class
 import Control.Tracer
 import Data.ByteString qualified as Strict (ByteString)
-import Data.Default
 import Data.List qualified as List
 import Data.Map (Map)
 import Data.Map qualified as Map

--- a/test-grapesy/Test/Driver/ClientServer.hs
+++ b/test-grapesy/Test/Driver/ClientServer.hs
@@ -12,16 +12,16 @@ module Test.Driver.ClientServer (
 
 import Control.Exception
 import Control.Monad.IO.Class
-import Data.Default
+import Data.Void
 import Test.QuickCheck.Monadic qualified as QuickCheck
 import Test.Tasty.QuickCheck qualified as QuickCheck
+import Text.Show.Pretty
 
 import Network.GRPC.Client qualified as Client
+import Network.GRPC.Common
 import Network.GRPC.Server qualified as Server
 
 import Test.Util.ClientServer
-import Text.Show.Pretty
-import Data.Void
 
 {-------------------------------------------------------------------------------
   Basic client-server test

--- a/test-grapesy/Test/Driver/Dialogue/Execution.hs
+++ b/test-grapesy/Test/Driver/Dialogue/Execution.hs
@@ -8,7 +8,6 @@ import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.State
 import Data.Bifunctor
-import Data.Default
 import Data.List (sortBy)
 import Data.Ord (comparing)
 import Data.Proxy

--- a/test-grapesy/Test/Sanity/HalfClosedLocal.hs
+++ b/test-grapesy/Test/Sanity/HalfClosedLocal.hs
@@ -2,8 +2,6 @@
 module Test.Sanity.HalfClosedLocal (tests) where
 
 import Control.Monad
-import Data.Default
-import Data.Proxy
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/test-grapesy/Test/Sanity/Interop.hs
+++ b/test-grapesy/Test/Sanity/Interop.hs
@@ -5,14 +5,9 @@
 module Test.Sanity.Interop (tests) where
 
 import Control.Exception
-import Control.Lens ((^.), (.~))
 import Control.Monad
 import Data.Bifunctor
 import Data.ByteString qualified as BS.Strict
-import Data.Default
-import Data.Function ((&))
-import Data.ProtoLens
-import Data.ProtoLens.Labels ()
 import Data.Proxy
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -20,6 +15,7 @@ import Test.Tasty.HUnit
 import Network.GRPC.Client qualified as Client
 import Network.GRPC.Client.StreamType.IO.Binary qualified as Client.Binary
 import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
 import Network.GRPC.Common.StreamElem qualified as StreamElem
 import Network.GRPC.Internal
 import Network.GRPC.Server qualified as Server

--- a/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
@@ -5,7 +5,6 @@ module Test.Sanity.StreamingType.CustomFormat (tests) where
 import Codec.Serialise qualified as Cbor
 import Control.Monad
 import Data.Bifunctor
-import Data.Default
 import Data.IORef
 import Data.Kind
 import Data.List

--- a/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -2,14 +2,13 @@
 
 module Test.Sanity.StreamingType.NonStreaming (tests) where
 
-import Data.Default
-import Data.Proxy
 import Data.Word
 import Test.Tasty
 import Test.Tasty.HUnit
 
 import Network.GRPC.Client qualified as Client
 import Network.GRPC.Client.Binary qualified as Binary
+import Network.GRPC.Common
 import Network.GRPC.Common.Binary (BinaryRpc)
 import Network.GRPC.Common.Compression qualified as Compr
 import Network.GRPC.Server.Binary qualified as Binary

--- a/test-stress/Main.hs
+++ b/test-stress/Main.hs
@@ -2,11 +2,11 @@ module Main (main) where
 
 import Control.Exception
 import Control.Monad
-import Data.Default
 import Data.Proxy
 
 import Network.GRPC.Client qualified as Client
 import Network.GRPC.Client.Binary qualified as Binary
+import Network.GRPC.Common
 import Network.GRPC.Common.Binary
 import Network.GRPC.Server.Binary qualified as Binary
 import Network.GRPC.Server.StreamType


### PR DESCRIPTION
`.Common` now exports `Proxy` as well as `def`, which are frequently required, and `.Common.Protobuf` now exports the most commonly required functionality for working with `Protobuf` messages; the essential lens operators, `defMessage`, some instances, etc.