### PR TITLE
Don't wrap exceptions

### DIFF
--- a/debug/Debug/NestedException.hs
+++ b/debug/Debug/NestedException.hs
@@ -1,4 +1,4 @@
-module Network.GRPC.Internal.NestedException (
+module Debug.NestedException (
     -- * Wrapping exceptions
     HasNestedException(..)
   , maybeNestedException
@@ -35,6 +35,10 @@ import GHC.Stack
 --
 -- In this case, we refer to @e@ as a /nested/ exception and to
 -- 'WrapWithCallStack' as an exception /wrapper/.
+--
+-- We use this exclusively for debugging, because this kind of wrapping makes
+-- it impossible for client code to /catch/ the exception (since wrapping an
+-- exception changes its type).
 class Exception e => HasNestedException e where
   getNestedException :: e -> SomeException
 

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -88,7 +88,6 @@ library
       Network.GRPC.Common.Protobuf
       Network.GRPC.Common.StreamElem
       Network.GRPC.Common.StreamType
-      Network.GRPC.Internal
       Network.GRPC.Server
       Network.GRPC.Server.Binary
       Network.GRPC.Server.Protobuf
@@ -101,7 +100,6 @@ library
       Network.GRPC.Client.Meta
       Network.GRPC.Client.Session
       Network.GRPC.Client.StreamType
-      Network.GRPC.Internal.NestedException
       Network.GRPC.Server.Call
       Network.GRPC.Server.Context
       Network.GRPC.Server.Handler
@@ -144,6 +142,13 @@ library
       Paths_grapesy
 
       Debug.Concurrent
+
+  if flag(debug)
+    other-modules:
+      Debug.NestedException
+    cpp-options:
+      -DDEBUG
+
   hs-source-dirs:
       src
       debug
@@ -462,4 +467,9 @@ Flag crypton
   description: Use the crypton-x509-* package family instead of x509-*
   default: True
   manual: False
+
+Flag debug
+  description: Enable grapesy internal debugging
+  default: False
+  manual: True
 

--- a/src/Network/GRPC/Client/Call.hs
+++ b/src/Network/GRPC/Client/Call.hs
@@ -37,7 +37,6 @@ import Network.GRPC.Common
 import Network.GRPC.Common.StreamElem qualified as StreamElem
 import Network.GRPC.Spec
 import Network.GRPC.Util.Session qualified as Session
-import Network.GRPC.Util.Session.Channel (ChannelUncleanClose(..))
 
 import Debug.Concurrent
 
@@ -60,7 +59,7 @@ withRPC conn callParams proxy k =
         (\call -> liftIO . closeRPC call)
         k
   where
-    throwUnclean :: (a, Maybe ChannelUncleanClose) -> m a
+    throwUnclean :: (a, Maybe SomeException) -> m a
     throwUnclean (_, Just err) = throwM err
     throwUnclean (x, Nothing)  = return x
 
@@ -71,7 +70,7 @@ withRPC conn callParams proxy k =
 -- See 'Session.close' for detailed discussion.
 closeRPC ::
      HasCallStack
-  => Call rpc -> ExitCase a -> IO (Maybe ChannelUncleanClose)
+  => Call rpc -> ExitCase a -> IO (Maybe SomeException)
 closeRPC = Session.close . callChannel
 
 {-------------------------------------------------------------------------------

--- a/src/Network/GRPC/Client/Connection.hs
+++ b/src/Network/GRPC/Client/Connection.hs
@@ -271,8 +271,7 @@ data Server =
 -- specification of "Wait for ready" semantics. You may wish to override this
 -- default.
 withConnection ::
-     HasCallStack
-  => ConnParams
+     ConnParams
   -> Server
   -> (Connection -> IO a)
   -> IO a

--- a/src/Network/GRPC/Internal.hs
+++ b/src/Network/GRPC/Internal.hs
@@ -1,7 +1,0 @@
--- | Functions and types exported mostly for testing and debugging of
--- @grapesy@ itself
-module Network.GRPC.Internal (
-    module X
-  ) where
-
-import Network.GRPC.Internal.NestedException as X

--- a/src/Network/GRPC/Util/Session.hs
+++ b/src/Network/GRPC/Util/Session.hs
@@ -35,9 +35,7 @@ module Network.GRPC.Util.Session (
     -- ** Closing
   , waitForOutbound
   , close
-  , ChannelUncleanClose(..)
   , ChannelDiscarded(..)
-  , ChannelException(..)
   , ChannelAborted(..)
     -- ** Construction
     -- *** Client

--- a/src/Network/GRPC/Util/Session/Server.hs
+++ b/src/Network/GRPC/Util/Session/Server.hs
@@ -6,7 +6,6 @@ module Network.GRPC.Util.Session.Server (
   ) where
 
 import Control.Tracer
-import GHC.Stack
 import Network.HTTP.Types qualified as HTTP
 import Network.HTTP2.Server qualified as Server
 
@@ -54,7 +53,7 @@ determineFlowStart sess req
 --
 -- Does not throw any exceptions.
 setupResponseChannel :: forall sess.
-     (AcceptSession sess, HasCallStack)
+     AcceptSession sess
   => sess
   -> Tracer IO (DebugMsg sess)
   -> ConnectionToClient

--- a/test-grapesy/Test/Driver/Dialogue/Definition.hs
+++ b/test-grapesy/Test/Driver/Dialogue/Definition.hs
@@ -24,7 +24,6 @@ import GHC.Generics qualified as GHC
 import Text.Show.Pretty
 
 import Network.GRPC.Common
-import Network.GRPC.Internal
 
 import Test.Driver.Dialogue.TestClock
 import Test.Util.PrettyVal
@@ -134,12 +133,8 @@ data AnnotatedServerException = AnnotatedServerException {
      , serverGlobalExceptionCallStack :: PrettyCallStack
      }
   deriving stock (GHC.Generic)
-  deriving anyclass (PrettyVal)
+  deriving anyclass (PrettyVal, Exception)
   deriving Show via ShowAsPretty AnnotatedServerException
-  deriving Exception via ExceptionWrapper AnnotatedServerException
-
-instance HasNestedException AnnotatedServerException where
-  getNestedException = serverGlobalException
 
 {-------------------------------------------------------------------------------
   Utility

--- a/test-grapesy/Test/Driver/Dialogue/Execution.hs
+++ b/test-grapesy/Test/Driver/Dialogue/Execution.hs
@@ -341,15 +341,15 @@ clientLocal testClock mode call = \(LocalSteps steps) ->
            case serverHealth of
              Failed err ->
                case result of
-                 Left (GrpcException GrpcUnknown msg [])
-                   | msg == Just (Text.pack $ show err)
+                 Left (GrpcException GrpcUnknown mMsg [])
+                   | Just msg <- mMsg
+                   , (Text.pack $ show err) `Text.isInfixOf` msg
                    -> True
                  _otherwise -> False
              Disappeared ->
-               -- TODO: Not really sure what exception we get here actually
                case result of
                  Left (GrpcException GrpcUnknown msg [])
-                   | msg == Just "TODO"
+                   | msg == Just "HandlerTerminated"
                    -> True
                  _otherwise -> False
              Alive () ->

--- a/test-grapesy/Test/Sanity/Interop.hs
+++ b/test-grapesy/Test/Sanity/Interop.hs
@@ -6,7 +6,6 @@ module Test.Sanity.Interop (tests) where
 
 import Control.Exception
 import Control.Monad
-import Data.Bifunctor
 import Data.ByteString qualified as BS.Strict
 import Data.Proxy
 import Test.Tasty
@@ -17,7 +16,6 @@ import Network.GRPC.Client.StreamType.IO.Binary qualified as Client.Binary
 import Network.GRPC.Common
 import Network.GRPC.Common.Protobuf
 import Network.GRPC.Common.StreamElem qualified as StreamElem
-import Network.GRPC.Internal
 import Network.GRPC.Server qualified as Server
 import Network.GRPC.Server.Binary qualified as Server.Binary
 import Network.GRPC.Server.StreamType qualified as Server
@@ -84,10 +82,7 @@ test_callAfterException =
       }
   where
     call :: Client.Connection -> Word -> IO (Either SomeException Word)
-    call conn =
-        fmap (first (innerNestedException :: SomeException -> SomeException))
-      . try
-      . Client.Binary.nonStreaming conn (Client.rpc @Ping)
+    call conn = try . Client.Binary.nonStreaming conn (Client.rpc @Ping)
 
     expectInvalidArgument :: SomeException -> Maybe ()
     expectInvalidArgument e


### PR DESCRIPTION
Wrapping exceptions makes it possible to catch them, as their type changes. We now wrap only when the `debug` cabal flag is enabled.