### PR TITLE
Add Snappy compression

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -59,6 +59,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          apt-get update
+          apt-get install -y libsnappy-dev
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -162,10 +164,9 @@ jobs:
           cat >> cabal.project <<EOF
           package grapesy
             tests:       True
-            flags:       +build-demo +build-stress-test +build-interop
+            flags:       +build-demo +build-stress-test +build-interop +snappy
             ghc-options: -Werror
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(grapesy)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist-newstyle
 .envrc
 *.swp
 *.pcapng
+cabal.project.local

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -127,7 +127,7 @@ ghcup-jobs: >8.10.4 && <9 || >9.0.1
 ghcup-version: 0.1.19.2
 
 -- Additional apt packages to install
-apt:
+apt: libsnappy-dev
 
 travis-patches:
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -29,7 +29,7 @@ cache: True
 install-dependencies: True
 
 -- Specify 'constraint: ... installed' packages
-installed:
+installed: -all
 
 -- Build tests with
 tests: True

--- a/cabal.project
+++ b/cabal.project
@@ -2,4 +2,4 @@ packages: .
 
 package grapesy
   tests: True
-  flags: +build-demo +build-stress-test +build-interop +snappy
+  flags: +build-demo +build-stress-test +build-interop

--- a/cabal.project
+++ b/cabal.project
@@ -2,4 +2,4 @@ packages: .
 
 package grapesy
   tests: True
-  flags: +build-demo +build-stress-test +build-interop
+  flags: +build-demo +build-stress-test +build-interop +snappy

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -2,5 +2,5 @@ packages: .
 
 package grapesy
   tests: True
-  flags: +build-demo +build-stress-test +build-interop
+  flags: +build-demo +build-stress-test +build-interop +snappy
   ghc-options: -Werror

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -2,5 +2,7 @@ packages: .
 
 package grapesy
   tests: True
+  -- Force the snappy flag to true for CI
   flags: +build-demo +build-stress-test +build-interop +snappy
+  -- Insist on no warnings
   ghc-options: -Werror

--- a/demo-client/Demo/Client/Cmdline.hs
+++ b/demo-client/Demo/Client/Cmdline.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP              #-}
 {-# LANGUAGE OverloadedLabels #-}
 
 -- | Command line options
@@ -198,6 +199,12 @@ parseCompression = asum [
           Opt.long "deflate"
         , Opt.help "Use deflate compression for all messages"
         ]
+#ifdef SNAPPY
+    , Opt.flag' Compr.snappy $ mconcat [
+          Opt.long "snappy"
+        , Opt.help "Use snappy compression for all messages"
+        ]
+#endif
     ]
 
 parseAPI :: Opt.Parser API

--- a/docs/demo-client.md
+++ b/docs/demo-client.md
@@ -108,8 +108,9 @@ actually compress anything:
   https://github.com/grpc/grpc/blob/master/examples/python/compression/README.md
 * You need to send a "name" that is long enough that the server actually
   bothers with compression at all.
-* You can also use the `--gzip` or `--deflate` command line flag to tell the
-  server to *only* use GZip or Deflate compression, respectively.
+* You can also use the `--gzip`, `--deflate`, or `--snappy` command line flags
+  to tell the server to *only* use GZip, Deflate, or Snappy compression,
+  respectively.
 
 For example:
 

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -66,12 +66,14 @@ common lang
       TypeFamilies
       TypeOperators
       UndecidableInstances
+
   if impl(ghc >= 9.0)
     ghc-options:
       -- This was introduced in 8.10, but it does not work reliably until 9.0.
       -- In 8.10 you might get spurious warnings when using re-exported modules
       -- (e.g. in proto-lens-runtime).
       -Wunused-packages
+
   if flag(snappy)
     cpp-options: -DSNAPPY
 
@@ -182,10 +184,22 @@ library
     , utf8-string          >= 1.0   && < 1.1
     , zlib                 >= 0.6   && < 0.7
 
-
+  -- Snappy can be a bit tricky to install on some systems, so we make it an
+  -- optional dependency. Snappy support can be explicitly disabled by clearing
+  -- the @snappy@ flag manually
+  --
+  -- > package grapesy
+  -- >    flags: -snappy
+  --
+  -- or by setting an unsatisfiable constraint on @snappy-c@
+  --
+  -- > constraints: snappy-c<0
+  --
+  -- It can be explicitly /enabled/ by setting the @snappy@ flag manually.
   if flag(snappy)
     build-depends:
       , snappy-c >= 0.1 && < 0.2
+
   -- tls 1.7 starts using Kazu's forked versions of x509-* packages
   if flag(crypton)
     -- Lower bounds are the first version of these packages after forking.
@@ -443,5 +457,5 @@ Flag crypton
 
 Flag snappy
   description: Enable snappy compression capabilities
-  default: False
-  manual: True
+  default: True
+  manual: False

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -72,6 +72,8 @@ common lang
       -- In 8.10 you might get spurious warnings when using re-exported modules
       -- (e.g. in proto-lens-runtime).
       -Wunused-packages
+  if flag(snappy)
+    cpp-options: -DSNAPPY
 
 library
   import:
@@ -180,6 +182,10 @@ library
     , utf8-string          >= 1.0   && < 1.1
     , zlib                 >= 0.6   && < 0.7
 
+
+  if flag(snappy)
+    build-depends:
+      , snappy-c >= 0.1 && < 0.2
   -- tls 1.7 starts using Kazu's forked versions of x509-* packages
   if flag(crypton)
     -- Lower bounds are the first version of these packages after forking.
@@ -435,3 +441,7 @@ Flag crypton
   default: True
   manual: False
 
+Flag snappy
+  description: Enable snappy compression capabilities
+  default: False
+  manual: True

--- a/src/Network/GRPC/Common/Compression.hs
+++ b/src/Network/GRPC/Common/Compression.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | Public 'Compression' API
 --
 -- Intended for unqualified import.
@@ -12,6 +14,9 @@ module Network.GRPC.Common.Compression (
   , noCompression
   , gzip
   , deflate
+#ifdef SNAPPY
+  , snappy
+#endif
   , allSupportedCompression
     -- * Negotation
   , Negotation(..)

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | Pure implementation of the gRPC spec
 --
 -- Most code will not need to use this module directly.
@@ -45,6 +47,9 @@ module Network.GRPC.Spec (
   , noCompression
   , gzip
   , deflate
+#ifdef SNAPPY
+  , snappy
+#endif
   , allSupportedCompression
     -- * Requests
   , RequestHeaders(..)

--- a/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Sanity.StreamingType.NonStreaming (tests) where
@@ -90,6 +91,13 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
                     clientCompr = Compr.only Compr.deflate
                   , serverCompr = Compr.only Compr.deflate
                   }
+#ifdef SNAPPY
+            , testCase "snappy" $
+                test_increment def {
+                    clientCompr = Compr.only Compr.snappy
+                  , serverCompr = Compr.only Compr.snappy
+                  }
+#endif
             , testCase "clientChoosesUnsupported" $
                 test_increment def {
                     clientInitCompr = Just Compr.gzip


### PR DESCRIPTION
* `snappy` is now a supported encoding, via the [snappy-c](https://hackage.haskell.org/package/snappy-c) library.
* Add a `snappy` test to the `Test.Sanity.StreamingType.NonStreaming.compression` group.

Resolves #56