### PR TITLE
Finish interop testing

### DIFF
--- a/demo-server/Demo/Server/Service/Greeter.hs
+++ b/demo-server/Demo/Server/Service/Greeter.hs
@@ -42,7 +42,9 @@ sayHelloStreamReply =
   where
     go :: Call (Protobuf Greeter "sayHelloStreamReply") -> IO ()
     go call = do
-        setResponseMetadata call [AsciiHeader "initial-md" "initial-md-value"]
+        setResponseMetadata call [
+            ("initial-md", AsciiHeader "initial-md-value")
+          ]
 
         -- The client expects the metadata well before the first output
         _ <- initiateResponse call

--- a/dev/interop.md
+++ b/dev/interop.md
@@ -6,168 +6,56 @@ The gRPC repo defines a set of interoperability tests; relevant documentation:
 * https://github.com/grpc/grpc/blob/master/tools/interop_matrix/README.md
 * https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md
 
-In this document we describe how to setup and run these tests, and provide
-some suggestions for debugging.
+In this document we describe how to setup and run these tests.
 
-TODO: This document needs cleaning up.
+## Running grapesy against itself
 
-## Setup
-
-### Set up the git repo
-
-Clone the `grapesy` branch of the gRPC repo:
+To run the interop tests with a `grapesy` client against a `grapesy` server,
+there is no need for a checkout of the official gRPC repo. Simply start the
+server:
 
 ```bash
-git clone git@github.com:edsko/grpc -b grapesy ./grpc-repo
+grapesy$ cabal run grapesy-interop -- --server
 ```
 
-The `grapesy` branch is currently based off tag `v1.60.0`.
-
-Then get all submodules:
+and run the tests
 
 ```bash
+grapesy$ cabal run grapesy-interop -- --client
+```
+
+All tests should pass.
+
+## Running development `grapesy` against reference implementation
+
+> [!NOTE]
+> At the time of writing version
+> [v1.62.0](https://github.com/grpc/grpc/releases/tag/v1.62.0) is the most
+> recent (released Feb 20, 2024).
+
+In this section we will describe how to run a development `grapesy` server or
+client (that is, a local checkout of the git repository, run simply using
+`cabal run`) against a reference implementation. For this you will need a
+checkout of the [official gRPC repo](https://github.com/grpc/grpc/).
+
+```bash
+$ git clone https://github.com/grpc/grpc.git -b v1.62.0 ./grpc-repo
+grpc-repo$ git switch -c v1.62.0
 grpc-repo$ git submodule update --init --recursive
 ```
 
-Unlike the [official
-instructions](https://grpc.io/docs/languages/python/quickstart/), this does
-_not_ do a shallow checkout. This is important: the tests will fail otherwise
-with an error such as this one:
-
-```
-Submodule 'third_party/abseil-cpp' (https://github.com/abseil/abseil-cpp.git) registered for path 'third_party/abseil-cpp'
-Cloning into '/var/local/git/grpc/third_party/abseil-cpp'...
-fatal: reference repository '/var/local/jenkins/grpc/third_party/abseil-cpp' is shallow
-fatal: clone of 'https://github.com/abseil/abseil-cpp.git' into submodule path '/var/local/git/grpc/third_party/abseil-cpp' failed
-```
-
-### Install Python
+For some languages, the gRPC implementation lives in a separate repository.
 
 ```bash
-apt-get install python3 python3-pip python3-setuptools python3-yaml
+$ git clone https://github.com/grpc/grpc-java.git -b v1.62.0
+grpc-java$ git switch -c v1.62.0
+
+$ git clone https://github.com/grpc/grpc-go.git -b v1.62.0
+grpc-go$ git switch -c v1.62.0
 ```
 
-### Python virtual environment
-
-Create Python virtual environment (https://docs.python.org/3/library/venv.html)
-
-```bash
-grpc-repo$ python3 -m venv ./python-venv
-```
-
-Then activate the virtual environment by prepending `python-venv/bin` to your
-PATH (see https://docs.python.org/3/library/venv.html#how-venvs-work); one
-option is to create an `.envrc` file in `grpc-repo` with
-
-```bash
-export PATH=/path/to/grpc-repo/python-venv/bin:$PATH
-export MY_INSTALL_DIR=/path/to/grpc-repo/local
-```
-
-(the `MY_INSTALL_DIR` is only necessary to locally compile C++ programs;
-see https://grpc.io/docs/languages/cpp/quickstart/).
-
-### Dependencies
-
-Install the required Python dependencies:
-
-```bash
-python3 -m pip install --upgrade \
-  six==1.16.0 \
-  google-auth==1.23.0 \
-  google-api-python-client==1.12.8 \
-  oauth2client==4.1.0
-```
-
-(these version numbers match the ones used in
-`./tools/dockerfile/interoptest/grpc_interop_python/Dockerfile`).
-
-Note: the Docker file in the repo also pins `pip` itself, but to quite an old
-version (`python3 -m pip install --upgrade pip==19.3.1`); not sure if that is
-needed (and actually results in some errors).
-
-### IPv6
-
-The tests get confused when IPv4 is enabled on the host; you should disable IPv6
-and then restart the Docker daemon. On Linux this can be done with
-
-```bash
-grapesy$ sudo dev/disable-ipv6.sh
-```
-
-I have found no other way to solve this problem (some details in this script).
-
-### Check that it works
-
-```bash
-grpc_repo$ tools/run_tests/run_interop_tests.py -l python -s c++ --use_docker
-```
-
-Setting up the Docker containers takes something between 5-10 minutes.
-
-## Running the tests
-
-### Commit all changes
-
-Make sure all changes you want to test are committed:
-
-* Any changes to the `grpc-repo` must be committed (locally)
-* Make sure that the `grapesy` subrepo in the `grpc-repo` points to the
-  `grapesy` branch you want to test.
-
-### Server reachability
-
-To test whether the `grapesy` server can be reached at all, we can ping it:
-
-```bash
-cabal run grapesy-interop -- --ping
-```
-
-### TLS
-
-You can pass `--use_tls=false` to disable TLS; the official Interop tests
-support this command line argument also. To ping a server over TLS, run
-
-```bash
-cabal run grapesy-interop -- --ping \
-  --server_host_override=foo.test.google.fr \
-  --use_test_ca=true
-```
-
-The server respects the `SSLKEYLOGFILE` environment variable, which can be
-useful for Wireshark debugging; see [/dev/wireshark.md](/dev/wireshark.md) for
-some suggestions on how to setup Wireshark.
-
-### To rebuild the Docker image with the `grapesy` deps
-
-When the `grapesy` dependencies change (and especially when it requires newer
-versions of packages that aren't yet known in the cabal package database),
-you need to rebuild the Docker image.
-
-```bash
-grapesy/dev/grapesy-deps-docker$ docker build . -t edsko/grapesy-deps:latest
-```
-
-then upload it
-
-```bash
-$ docker push edsko/grapesy-deps:latest
-```
-
-## Testing `grapesy` as a server
-
-### Automatic execution
-
-To run the tests automatically:
-
-```bash
-tools/run_tests/run_interop_tests.py -l python -s grapesy --use_docker
-tools/run_tests/run_interop_tests.py -l c++    -s grapesy --use_docker
-tools/run_tests/run_interop_tests.py -l go     -s grapesy --use_docker
-tools/run_tests/run_interop_tests.py -l java   -s grapesy --use_docker
-```
-
-This will require a directory structure like this:
+These need to be checked out alongside `grpc-repo`, so that you end up with
+something like this:
 
 ```
 parent
@@ -179,151 +67,215 @@ parent
   \---- grpc-java    https://github.com/grpc/grpc-java
 ```
 
-### Manual execution
+> [!WARNING]
+> Unlike the [QuickCheck
+> instructions](https://grpc.io/docs/languages/python/quickstart/), this does
+> _not_ do a shallow checkout. This is important: the tests will fail otherwise
+> with an error such as this one:
 
-During development however it might be more convenient to use the `--manual`
-flag, which creates a bash script that executes the individual tests:
-
-Create the docker containers:
-
-```bash
-tools/run_tests/run_interop_tests.py -l go -s grapesy --use_docker --manual
+```
+Submodule 'third_party/abseil-cpp' (https://github.com/abseil/abseil-cpp.git) registered for path 'third_party/abseil-cpp'
+Cloning into '/var/local/git/grpc/third_party/abseil-cpp'...
+fatal: reference repository '/var/local/jenkins/grpc/third_party/abseil-cpp' is shallow
+fatal: clone of 'https://github.com/abseil/abseil-cpp.git' into submodule path '/var/local/git/grpc/third_party/abseil-cpp' failed
 ```
 
-(the `go` Interop tests are the quickest to build, by quite a margin).
+> [!WARNING]
+> The official interop tests fail when IPv6 is enabled on the host machine. For
+> convenience, there is a script in the `grapesy` repo at
+> [/dev/disable-ipv6.sh](/dev/disable-ipv6.sh) that can be used to disable IPv6
+> on Linux machines. If IPv6 is enabled, tests will fail with an error such as
+> the one below (this error is in the test _infrastructure_, independent from
+> the reference client or server):
 
-Start the server
-
-```bash
-bash interop_server_cmds.sh
+```
+Traceback (most recent call last):
+  File "../grpc-repo/tools/run_tests/run_interop_tests.py", line 1583, in <module>
+    job.mapped_port(_DEFAULT_SERVER_PORT),
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "../grpc-repo/tools/run_tests/python_utils/dockerjob.py", line 165, in mapped_port
+    return docker_mapped_port(self._container_name, port)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "../grpc-repo/tools/run_tests/python_utils/dockerjob.py", line 58, in docker_mapped_port
+    return int(output.split(":", 2)[1])
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ValueError: invalid literal for int() with base 10: '32768\n['
 ```
 
-Make a note of which port was exposed locally:
+### Test infrastructure dependencies
+
+The gRPC interop test infrastructure is written in Python, and requires some
+dependencies. For convenience, in this section we describe how to set this up
+on Linux. First, you will need Python:
 
 ```bash
-docker ps
+$ apt-get install python3 python3-pip python3-setuptools python3-yaml
 ```
 
-Then run the client commands:
+Create a Python virtual environment
+(https://docs.python.org/3/library/venv.html)
 
 ```bash
-SERVER_PORT=... bash interop_client_cmds.sh
+grpc-repo$ python3 -m venv ./python-venv
 ```
 
-If the tests fail, it may be more convenient to run the server directly on the
-host, bypassing docker:
+Activate the virtual environment by prepending `python-venv/bin` to your
+PATH (see https://docs.python.org/3/library/venv.html#how-venvs-work); one
+option is to create an `.envrc` file in `grpc-repo` with
 
 ```bash
-grapesy$ cabal run grapesy-interop -- --server
+export PATH=/path/to/grpc-repo/python-venv/bin:$PATH
 ```
 
-By default, the server will use TLS and run on port 50052.
+(you can also use `python-venv/bin/activate` but simply setting the path is
+enough, and if you use the `.envrc` file, it will be activated automatically).
 
-## Testing `grapesy` as a client
-
-### Automatic execution
-
-To run the tests automatically:
+Finally, install the required Python dependencies:
 
 ```bash
-grpc-repo$ tools/run_tests/run_interop_tests.py -l grapesy -s go     --use_docker
-grpc-repo$ tools/run_tests/run_interop_tests.py -l grapesy -s python --use_docker
-grpc-repo$ tools/run_tests/run_interop_tests.py -l grapesy -s c++    --use_docker
-grpc-repo$ tools/run_tests/run_interop_tests.py -l grapesy -s java   --use_docker
+grpc-repo$ python3 -m pip install --upgrade \
+  six==1.16.0 \
+  google-auth==1.23.0 \
+  google-api-python-client==1.12.8 \
+  oauth2client==4.1.0
 ```
 
-### Manual execution
+(these version numbers match the ones used in
+`tools/dockerfile/interoptest/grpc_interop_go/Dockerfile` and others).
 
-During development, manual execution is more convenient, and the `grapesy`
-client can be run outside of docker.
+> [!NOTE]
+> The Docker file in the repo also pins `pip` itself, but to quite an old
+> version (19.3.1). I found that this old version results in some errors, and
+> had no problems with the default version (23.2 at the time of writing).
+
+As a sanity check, you can try to run the Python reference client against the
+Python reference server:
 
 ```bash
-grpc-repo$ tools/run_tests/run_interop_tests.py -l grapesy -s java --use_docker --manual
+grpc_repo$ tools/run_tests/run_interop_tests.py -l python -s python --use_docker
 ```
 
-Start the server
+All tests should pass.
 
-```bash
-grpc-repo$ bash ./interop_server_cmds.sh
-```
+### Build all clients and servers
 
-Take a note of the port
-
-```bash
-$ docker ps
-CONTAINER ID   IMAGE               ..  PORTS
-833c9f2a84ea   grpc_interop_go:..  ..  0.0.0.0:32768->8080/tcp
-```
-
-and run the client:
-
-```bash
-grpc-repo$ SERVER_PORT=32768 bash ./interop_client_cmds.sh
-```
-
-Alternatively, you can also run the tests manually:
-
-```bash
-grapesy$ cabal run grapesy-interop -- \
-  --client \
-  --port=32768 \
-  --server_host_override=foo.test.google.fr \
-  --use_test_ca=true \
-  --test_case=empty_unary
-```
-
-Omit the `--test_case` argument to run all tests.
-
-
-## Testing against local grapesy build
-
-### Building the reference clients/servers
+You can now prepare all reference clients and servers:
 
 First prepare all the reference servers and clients by running the following
 in the `grpc-repo`:
 
 ```bash
-tools/run_tests/run_interop_tests.py -l java -s java --use_docker --manual &&
-  mv interop_server_cmds.sh java_server.sh &&
-  mv interop_client_cmds.sh java_client.sh
+grpc-repo$ tools/run_tests/run_interop_tests.py -l python -s python --use_docker --manual &&
+  mv interop_server_cmds.sh python_server.sh &&
+  mv interop_client_cmds.sh python_client.sh
 
-tools/run_tests/run_interop_tests.py -l c++ -s c++ --use_docker --manual &&
+grpc-repo$ tools/run_tests/run_interop_tests.py -l c++ -s c++ --use_docker --manual &&
   mv interop_server_cmds.sh cxx_server.sh &&
   mv interop_client_cmds.sh cxx_client.sh
 
-tools/run_tests/run_interop_tests.py -l go -s go --use_docker --manual &&
+grpc-repo$ tools/run_tests/run_interop_tests.py -l go -s go --use_docker --manual &&
   mv interop_server_cmds.sh go_server.sh &&
   mv interop_client_cmds.sh go_client.sh
 
-tools/run_tests/run_interop_tests.py -l python -s python --use_docker --manual &&
-  mv interop_server_cmds.sh python_server.sh &&
-  mv interop_client_cmds.sh python_client.sh
+grpc-repo$ tools/run_tests/run_interop_tests.py -l java -s java --use_docker --manual &&
+  mv interop_server_cmds.sh java_server.sh &&
+  mv interop_client_cmds.sh java_client.sh
 ```
 
-### Running the grapesy client
+### Running `grapesy` as a client
 
-Choose one of the servers to run
+Start the various servers (I find it useful to give each its own terminal):
 
 ```bash
+grpc-repo$ bash ./python_server.sh
 grpc-repo$ bash ./cxx_server.sh
+grpc-repo$ bash ./go_server.sh
+grpc-repo$ bash ./java_server.sh
 ```
 
-Take a note of the server port
+Take note of the port numbers that were assigned to them:
 
 ```bash
-docker ps
+$ docker ps --format 'table {{.Image}}\t{{.Ports}}'
+IMAGE                                                      PORTS
+grpc_interop_java:0ac5c6f1-9835-45ee-9664-ad9925a41680     0.0.0.0:32773->8080/tcp
+grpc_interop_go:b2a668d2-718c-4c66-b0e6-f7f6111974a6       0.0.0.0:32772->8080/tcp
+grpc_interop_cxx:288ee67a-f462-40d1-b5a2-a29be5562fb2      0.0.0.0:32771->8080/tcp
+grpc_interop_python:f558f1af-9ee5-41bc-8a6b-0b84a1a9e87a   0.0.0.0:32770->8080/tcp
 ```
 
-Can now run individual tests (you'll need to specify the right port):
+We can now run the `grapesy` client against each reference server:
 
 ```bash
-grapesy$ cabal run grapesy-interop -- \
-  --client \
-  --port=32770 \
-  --server_host_override=foo.test.google.fr \
-  --use_test_ca=true \
-  --test_case=empty_unary
+grapesy$ cabal run grapesy-interop -- --client \
+  --server_port=32770 \
+  --skip_compression # Python
+
+grapesy$ cabal run grapesy-interop -- --client \
+  --server_port=32771 # C++
+
+grapesy$ cabal run grapesy-interop -- --client \
+  --server_port=32772 \
+  --skip_compression # Go
+
+grapesy$ cabal run grapesy-interop -- --client \
+  --server_port=32773 \
+  --skip_client_compression \
+  --skip_test=server_compressed_streaming \
+  --skip_test=timeout_on_sleeping_server # Java
 ```
 
-or omit the `--test_case` argument to run al tests.
+All tests should pass.
 
+> [!NOTE]
+> Not all reference servers support all features, motivating the various
+> `--skip-xyz` command line flags. To verify which features are unsupported,
+> see `grpc-repo/tools/run_tests/run_interop_tests.py`, find the corresponding
+> language definition (for example, `class PythonLanguage`), and then look at
+> `unimplemented_test_cases_server`.
+>
+> The only exception is `timeout_on_sleeping_server` for Java: it seems that the
+> server does not conform to the gRPC specification here, and simply closes the
+> connection without sending `DEADLINE_EXCEEDED` to the client. The Java
+> _client_ does not notice this because (it seems) it imposes a _local_ timeout
+> also, and doesn't even _connect_ to the server: the test even passes without
+> the server running at all.
+
+It is also possible to only run one specific test case, for example:
+
+```bash
+grapesy$ cabal run grapesy-interop -- --client \
+  --server_port=32773 \
+  --test_case=timeout_on_sleeping_server
+```
+
+For Wireshark debugging it is sometimes useful to have the server run on the
+host's own network (rather than isolated in a Docker network) on a specific
+port. To do this, edit the corresponding script and replace the `-p 8080`
+Docker parameter by `--net=host` (and optionally change the server's `--port`
+flag also). You may also wish to disable TLS: the `grapesy` client and server
+support `SSLKEYLOGFILE` environment variable, but the reference implementations
+do not, making it impossible to debug any network traffic in Wireshark.
+
+### Running `grapesy` as a server
+
+To run `grapsey` as as server, run
+
+```bash
+grapesy$ cabal run grapesy-interop -- --server
+```
+
+By default, this will run the server on port 50052 (though this can be
+changed using `--port`).
+
+Then run the reference clients:
+
+```bash
+grpc-repo$ SERVER_PORT=50052 bash ./python_client.sh
+grpc-repo$ SERVER_PORT=50052 bash ./cxx_client.sh
+grpc-repo$ SERVER_PORT=50052 bash ./go_client.sh
+grpc-repo$ SERVER_PORT=50052 bash ./java_client.sh
+```
+
+Only the ORCA tests are expected to fail (you may wish to disable those by
+editing the client scripts).

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -127,6 +127,7 @@ library
       Network.GRPC.Spec.RPC.Binary
       Network.GRPC.Spec.RPC.Protobuf
       Network.GRPC.Spec.RPC.StreamType
+      Network.GRPC.Spec.RPC.Unknown
       Network.GRPC.Spec.Status
       Network.GRPC.Spec.Timeout
       Network.GRPC.Spec.TraceContext
@@ -181,6 +182,7 @@ library
     , stm                  >= 2.5   && < 2.6
     , text                 >= 1.2   && < 2.1
     , transformers         >= 0.5   && < 0.7
+    , unbounded-delays     >= 0.1.1 && < 0.2
     , unordered-containers >= 0.2   && < 0.3
     , utf8-string          >= 1.0   && < 1.1
     , zlib                 >= 0.6   && < 0.7
@@ -245,6 +247,7 @@ test-suite test-grapesy
       Test.Sanity.Interop
       Test.Sanity.StreamingType.CustomFormat
       Test.Sanity.StreamingType.NonStreaming
+      Test.Util.Awkward
 
       Paths_grapesy
 
@@ -256,24 +259,25 @@ test-suite test-grapesy
     , grapesy
   build-depends:
       -- External dependencies
-    , async              >= 2.2   && < 2.3
-    , base64-bytestring  >= 1.2   && < 1.3
-    , bytestring         >= 0.10  && < 0.12
-    , containers         >= 0.6   && < 0.7
-    , contra-tracer      >= 0.2   && < 0.3
-    , exceptions         >= 0.10  && < 0.11
-    , http-types         >= 0.12  && < 0.13
-    , http2              >= 5.1.2 && < 5.2
-    , mtl                >= 2.2   && < 2.4
-    , proto-lens-runtime >= 0.7   && < 0.8
-    , QuickCheck         >= 2.14  && < 2.15
-    , serialise          >= 0.2   && < 0.3
-    , stm                >= 2.5   && < 2.6
-    , tasty              >= 1.4   && < 1.6
-    , tasty-hunit        >= 0.10  && < 0.11
-    , tasty-quickcheck   >= 0.10  && < 0.11
-    , text               >= 1.2   && < 2.1
-    , tls                >= 1.5   && < 1.10
+    , async                >= 2.2   && < 2.3
+    , base64-bytestring    >= 1.2   && < 1.3
+    , bytestring           >= 0.10  && < 0.12
+    , containers           >= 0.6   && < 0.7
+    , contra-tracer        >= 0.2   && < 0.3
+    , exceptions           >= 0.10  && < 0.11
+    , http-types           >= 0.12  && < 0.13
+    , http2                >= 5.1.2 && < 5.2
+    , mtl                  >= 2.2   && < 2.4
+    , proto-lens-runtime   >= 0.7   && < 0.8
+    , QuickCheck           >= 2.14  && < 2.15
+    , quickcheck-instances >= 0.3   && < 0.4
+    , serialise            >= 0.2   && < 0.3
+    , stm                  >= 2.5   && < 2.6
+    , tasty                >= 1.4   && < 1.6
+    , tasty-hunit          >= 0.10  && < 0.11
+    , tasty-quickcheck     >= 0.10  && < 0.11
+    , text                 >= 1.2   && < 2.1
+    , tls                  >= 1.5   && < 1.10
 
 executable demo-client
   import:
@@ -450,14 +454,13 @@ executable grapesy-interop
   build-depends:
     , grapesy
   build-depends:
-    , ansi-terminal
-    , base
-    , bytestring
-    , exceptions
-    , network
-    , optparse-applicative
-    , proto-lens-runtime
-    , text
+    , ansi-terminal        >= 1.1  && < 1.2
+    , bytestring           >= 0.10 && < 0.12
+    , exceptions           >= 0.10 && < 0.11
+    , network              >= 3.1  && < 3.2
+    , optparse-applicative >= 0.16 && < 0.19
+    , proto-lens-runtime   >= 0.7  && < 0.8
+    , text                 >= 1.2  && < 2.1
 
   if !flag(build-interop)
     buildable:

--- a/interop/Interop/Client.hs
+++ b/interop/Interop/Client.hs
@@ -70,8 +70,23 @@ runTest CancelAfterBegin          = CancelAfterBegin.runTest
 runTest CancelAfterFirstResponse  = CancelAfterFirstResponse.runTest
 runTest TimeoutOnSleepingServer   = TimeoutOnSleepingServer.runTest
 
+skips :: Cmdline -> TestCase -> Bool
+skips cmdline test = or [
+      elem test (cmdSkipTest cmdline)
+    , cmdSkipCompression cmdline && elem test [
+          ClientCompressedUnary
+        , ServerCompressedUnary
+        , ClientCompressedStreaming
+        , ServerCompressedStreaming
+        ]
+    , cmdSkipClientCompression cmdline && elem test [
+          ClientCompressedUnary
+        , ClientCompressedStreaming
+        ]
+    ]
+
 testCase :: Cmdline -> IORef TestStats -> TestCase -> IO ()
-testCase cmdline stats test = do
+testCase cmdline stats test = unless (skips cmdline test) $ do
     result <- try $ runTest test cmdline
     case result of
       Right () ->

--- a/interop/Interop/Client/Common.hs
+++ b/interop/Interop/Client/Common.hs
@@ -131,10 +131,8 @@ verifyStreamingOutputs call verifyTrailers = go
 -- the inputs we sent it).
 --
 -- Also throws 'TestSkipped' is the server returns with 'GrpcUnimplemented'.
-expectInvalidArgument :: Either GrpcException (resp, [CustomMetadata]) -> IO ()
-expectInvalidArgument (Right _) =
-    throwIO $ TestSkipped "Server sent unexpected OK"
-expectInvalidArgument (Left exception) =
+expectInvalidArgument :: IO a -> IO ()
+expectInvalidArgument = assertThrows $ \exception ->
     case grpcError exception of
       GrpcInvalidArgument ->
         return ()

--- a/interop/Interop/Client/TestCase/CancelAfterBegin.hs
+++ b/interop/Interop/Client/TestCase/CancelAfterBegin.hs
@@ -1,8 +1,22 @@
 module Interop.Client.TestCase.CancelAfterBegin (runTest) where
 
+import Network.GRPC.Client
+import Network.GRPC.Common
+
+import Interop.API
+import Interop.Client.Connect
 import Interop.Cmdline
 import Interop.Util.Exceptions
 
 -- | <https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#cancel_after_begin>
+--
+-- This is not really testing anything about the server, but rather about how
+-- cancellation gets reported by the grapesy client library itself.
 runTest :: Cmdline -> IO ()
-runTest _ = throwIO TestUnimplemented
+runTest cmdline =
+    withConnection def (testServer cmdline) $ \conn -> do
+      assertThrows (assertEqual GrpcCancelled . grpcError) $
+        withRPC conn def (Proxy @StreamingInputCall) $ \_call ->
+          -- Immediately cancel request
+          return ()
+

--- a/interop/Interop/Client/TestCase/CancelAfterFirstResponse.hs
+++ b/interop/Interop/Client/TestCase/CancelAfterFirstResponse.hs
@@ -1,8 +1,25 @@
 module Interop.Client.TestCase.CancelAfterFirstResponse (runTest) where
 
+import Network.GRPC.Client
+import Network.GRPC.Common
+
+import Interop.API
+import Interop.Client.Connect
 import Interop.Cmdline
 import Interop.Util.Exceptions
+import Interop.Client.Common (mkStreamingOutputCallRequest)
 
 -- | <https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#cancel_after_first_response>
 runTest :: Cmdline -> IO ()
-runTest _ = throwIO TestUnimplemented
+runTest cmdline =
+    withConnection def (testServer cmdline) $ \conn -> do
+      assertThrows (assertEqual GrpcCancelled . grpcError) $
+        withRPC conn def (Proxy @FullDuplexCall) $ \call -> do
+          sendNextInput call req
+          -- Cancel request after receiving a response
+          _resp <- recvNextOutput call
+          return ()
+  where
+    req :: StreamingOutputCallRequest
+    req = mkStreamingOutputCallRequest [(False, 31415)] (Just 27182)
+

--- a/interop/Interop/Client/TestCase/ClientCompressedStreaming.hs
+++ b/interop/Interop/Client/TestCase/ClientCompressedStreaming.hs
@@ -1,7 +1,5 @@
 module Interop.Client.TestCase.ClientCompressedStreaming (runTest) where
 
-import Control.Exception
-
 import Network.GRPC.Client
 import Network.GRPC.Common
 import Network.GRPC.Spec
@@ -52,8 +50,7 @@ checkServerSupportsCompressedRequest :: Connection -> IO ()
 checkServerSupportsCompressedRequest conn =
     withRPC conn def (Proxy @StreamingInputCall) $ \call -> do
       sendInputWithEnvelope call $ FinalElem featureProbe NoMetadata
-      mResp <- try $ recvFinalOutput call
-      expectInvalidArgument mResp
+      expectInvalidArgument $ recvFinalOutput call
   where
     -- Expect compressed, but is /not/ actually compressed
     featureProbe :: (OutboundEnvelope, StreamingInputCallRequest)

--- a/interop/Interop/Client/TestCase/ClientCompressedUnary.hs
+++ b/interop/Interop/Client/TestCase/ClientCompressedUnary.hs
@@ -2,8 +2,6 @@
 
 module Interop.Client.TestCase.ClientCompressedUnary (runTest) where
 
-import Control.Exception
-
 import Network.GRPC.Client
 import Network.GRPC.Common
 import Network.GRPC.Spec
@@ -53,8 +51,7 @@ checkServerSupportsCompressedRequest :: Connection -> IO ()
 checkServerSupportsCompressedRequest conn =
     withRPC conn def (Proxy @UnaryCall) $ \call -> do
       sendInputWithEnvelope call $ FinalElem featureProbe NoMetadata
-      mResp <- try $ recvFinalOutput call
-      expectInvalidArgument mResp
+      expectInvalidArgument $ recvFinalOutput call
   where
     -- Expect compressed, but is /not/ actually compressed
     featureProbe :: (OutboundEnvelope, SimpleRequest)

--- a/interop/Interop/Client/TestCase/CustomMetadata.hs
+++ b/interop/Interop/Client/TestCase/CustomMetadata.hs
@@ -45,12 +45,14 @@ runTest cmdline = do
         }
 
     metadataInit, metadataFinal :: CustomMetadata
-    metadataInit  = AsciiHeader
-                      "x-grpc-test-echo-initial"
-                      "test_initial_metadata_value"
-    metadataFinal = BinaryHeader
-                      "x-grpc-test-echo-trailing"
-                      (BinaryValue $ BS.Strict.pack [0xab, 0xab, 0xab])
+    metadataInit  = ( "x-grpc-test-echo-initial"
+                    , AsciiHeader $
+                        "test_initial_metadata_value"
+                    )
+    metadataFinal = ( "x-grpc-test-echo-trailing"
+                    , BinaryHeader . BinaryValue $
+                        BS.Strict.pack [0xab, 0xab, 0xab]
+                    )
 
     simpleRequest :: SimpleRequest
     simpleRequest =

--- a/interop/Interop/Client/TestCase/TimeoutOnSleepingServer.hs
+++ b/interop/Interop/Client/TestCase/TimeoutOnSleepingServer.hs
@@ -1,8 +1,33 @@
 module Interop.Client.TestCase.TimeoutOnSleepingServer (runTest) where
 
+import Network.GRPC.Client
+import Network.GRPC.Common
+
+import Interop.API
+import Interop.Client.Common
+import Interop.Client.Connect
 import Interop.Cmdline
 import Interop.Util.Exceptions
 
 -- | <https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md#timeout_on_sleeping_server>
 runTest :: Cmdline -> IO ()
-runTest _ = throwIO TestUnimplemented
+runTest cmdline =
+    withConnection def (testServer cmdline) $ \conn -> do
+      assertThrows (assertEqual GrpcDeadlineExceeded . grpcError) $
+        assertTerminatesWithinSeconds 1 $
+          withRPC conn callParams (Proxy @FullDuplexCall) $ \call -> do
+            sendNextInput call req
+            -- We wait for a response, but we didn't request any, so we never
+            -- get one; meanwhile, the server is waiting for the /next/
+            -- 'StreamingOutputCallRequest'. Therefore, the call is only closed
+            -- once the timeout is reached.
+            _resp <- recvNextOutput call
+            return ()
+  where
+    callParams :: CallParams
+    callParams = def {
+          callTimeout = Just $ Timeout Millisecond (TimeoutValue 1)
+        }
+
+    req :: StreamingOutputCallRequest
+    req = mkStreamingOutputCallRequest [] (Just 27182)

--- a/interop/Interop/Client/TestCase/UnimplementedMethod.hs
+++ b/interop/Interop/Client/TestCase/UnimplementedMethod.hs
@@ -1,7 +1,5 @@
 module Interop.Client.TestCase.UnimplementedMethod (runTest) where
 
-import Control.Exception
-
 import Network.GRPC.Client
 import Network.GRPC.Common
 import Network.GRPC.Client.StreamType.IO
@@ -15,9 +13,5 @@ import Interop.Util.Exceptions
 runTest :: Cmdline -> IO ()
 runTest cmdline =
     withConnection def (testServer cmdline) $ \conn -> do
-      resp <- try $ nonStreaming conn (rpc @UnimplementedCall) defMessage
-      case resp of
-        Right _empty ->
-          assertFailure "Expected UNIMPLEMENTED"
-        Left err ->
-          assertEqual GrpcUnimplemented $ grpcError err
+      assertThrows (assertEqual GrpcUnimplemented . grpcError) $
+        nonStreaming conn (rpc @UnimplementedCall) defMessage

--- a/interop/Interop/Client/TestCase/UnimplementedService.hs
+++ b/interop/Interop/Client/TestCase/UnimplementedService.hs
@@ -1,7 +1,5 @@
 module Interop.Client.TestCase.UnimplementedService (runTest) where
 
-import Control.Exception
-
 import Network.GRPC.Client
 import Network.GRPC.Common
 import Network.GRPC.Common.Protobuf
@@ -19,9 +17,5 @@ type UnimplementedCall = Protobuf UnimplementedService "unimplementedCall"
 runTest :: Cmdline -> IO ()
 runTest cmdline =
     withConnection def (testServer cmdline) $ \conn -> do
-      resp <- try $ nonStreaming conn (rpc @UnimplementedCall) defMessage
-      case resp of
-        Right _empty ->
-          assertFailure "Expected UNIMPLEMENTED"
-        Left err ->
-          assertEqual GrpcUnimplemented $ grpcError err
+      assertThrows (assertEqual GrpcUnimplemented . grpcError) $
+        nonStreaming conn (rpc @UnimplementedCall) defMessage

--- a/interop/Interop/Server/Common.hs
+++ b/interop/Interop/Server/Common.hs
@@ -29,20 +29,20 @@ constructResponseMetadata :: Call rpc -> IO [CustomMetadata]
 constructResponseMetadata call = do
     requestMetadata <- getRequestMetadata call
     initialResponseMetadata <-
-      case lookupCustomMetadata nameMetadataInitial requestMetadata of
+      case lookup nameMetadataInitial requestMetadata of
         Nothing ->
           return []
-        Just (Left binaryValue) ->
+        Just (BinaryHeader binaryValue) ->
           assertUnrecognized (nameMetadataInitial, binaryValue)
-        Just (Right asciiValue) ->
-          return [AsciiHeader nameMetadataInitial asciiValue]
+        Just (AsciiHeader asciiValue) ->
+          return [(nameMetadataInitial, AsciiHeader asciiValue)]
     trailingResponseMetadata <-
-      case lookupCustomMetadata nameMetadataTrailing requestMetadata of
+      case lookup nameMetadataTrailing requestMetadata of
         Nothing ->
           return []
-        Just (Left binaryValue) ->
-          return [BinaryHeader nameMetadataTrailing binaryValue]
-        Just (Right asciiValue) ->
+        Just (BinaryHeader binaryValue) ->
+          return [(nameMetadataTrailing, BinaryHeader binaryValue)]
+        Just (AsciiHeader asciiValue) ->
           assertUnrecognized (nameMetadataTrailing, asciiValue)
 
     -- Send initial metadata

--- a/src/Network/GRPC/Common.hs
+++ b/src/Network/GRPC/Common.hs
@@ -16,12 +16,12 @@ module Network.GRPC.Common (
     -- Clients can include custom metadata in the initial request to the server,
     -- and servers can include custom metadata boh in the initial response to
     -- the client as well as in the response trailers.
-  , CustomMetadata(..)
+  , CustomMetadata
+  , HeaderValue(..)
   , HeaderName(HeaderName)
   , AsciiValue(AsciiValue)
   , BinaryValue(..)
   , NoMetadata(..)
-  , customHeaderName
 
     -- * Configuration
   , SslKeyLog(..)

--- a/src/Network/GRPC/Server/Context.hs
+++ b/src/Network/GRPC/Server/Context.hs
@@ -18,7 +18,6 @@ import Control.Exception
 import Control.Monad.XIO (NeverThrows)
 import Control.Monad.XIO qualified as XIO
 import Control.Tracer
-import Data.ByteString qualified as Strict (ByteString)
 import Data.Default
 import System.IO
 
@@ -69,8 +68,9 @@ data ServerParams = ServerParams {
 
       -- | Override content-type for response to client.
       --
-      -- If not defined, the default @application/grpc+format@ is used.
-    , serverContentType :: Maybe Strict.ByteString
+      -- Set to 'Nothing' to omit the content-type header completely
+      -- (this is not conform the gRPC spec).
+    , serverContentType :: Maybe ContentType
     }
 
 instance Default ServerParams where
@@ -78,7 +78,7 @@ instance Default ServerParams where
         serverCompression = def
       , serverDebugTracer = nullTracer
       , serverTopLevel    = defaultServerTopLevel
-      , serverContentType = Nothing
+      , serverContentType = Just ContentTypeDefault
       }
 
 defaultServerTopLevel ::

--- a/src/Network/GRPC/Server/Handler.hs
+++ b/src/Network/GRPC/Server/Handler.hs
@@ -38,6 +38,34 @@ import Network.GRPC.Spec
   "Network.GRPC.Server.Protobuf".
 -------------------------------------------------------------------------------}
 
+-- | Handler for an RPC request
+--
+-- To construct an 'RpcHandler', you have two options:
+--
+-- * Use the \"raw\" API by calling 'mkRpcHandler'; this gives you full control
+--   over the interaction with the client.
+-- * Use the API from "Network.GRPC.Server.StreamType" to define handlers that
+--   use the Protobuf stream types. This API is more convenient, and can be used
+--   to guarantee at compile-time  that you have a handler for every method of
+--   the services you support, but provides less flexibility (although it offers
+--   an \"escape\" to the full API through
+--   'Network.GRPC.Server.StreamType.RawMethod').
+--
+-- __Note on cancellation.__ The GRPC spec allows clients to \"cancel\" a
+-- request (<https://grpc.io/docs/guides/cancellation/>). This does not
+-- correspond to any specific message being sent across the network; instead,
+-- the client simply disappears. The spec is quite clear that it is the
+-- responsibility of the handler /itself/ to monitor for this. In @grapesy@ this
+-- works as follows:
+--
+-- * Handlers are /not/ terminated when a client disappears. This allows the
+--   handler to finish what it's doing, and terminate cleanly.
+-- * When a handler tries to receive a message from the client ('recvInput'), or
+--   send a message to the client ('sendOutput'), and the client disappeared,
+--   this will result in a 'Network.GRPC.Server.ClientDisconnected' exception,
+--   which the handler can catch and deal with.
+--
+-- TODO: What if the /handler/ wants to terminate?
 data RpcHandler m = forall rpc. IsRPC rpc => RpcHandler {
       -- | Handler proper
       runRpcHandler :: Call rpc -> m ()

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -8,9 +8,11 @@
 module Network.GRPC.Spec (
     -- * RPC
     IsRPC(..)
+  , defaultRpcContentType
     -- ** Instances
   , Protobuf
   , BinaryRpc
+  , UnknownRpc
     -- ** Messages
     -- *** Parsing
   , InboundEnvelope(..)
@@ -77,6 +79,10 @@ module Network.GRPC.Spec (
   , TimeoutValue(..)
   , TimeoutUnit(..)
   , timeoutToMicro
+  , isValidTimeoutValue
+    -- ** Serialization
+  , buildTimeout
+  , parseTimeout
     -- * Responses
     -- ** Headers
   , ResponseHeaders(..)
@@ -85,26 +91,29 @@ module Network.GRPC.Spec (
     -- ** Trailers
   , ProperTrailers(..)
   , TrailersOnly(..)
+    -- ** Serialization
   , parseProperTrailers
   , parseTrailersOnly
   , buildProperTrailers
   , buildTrailersOnly
+  , properTrailersToTrailersOnly
+  , trailersOnlyToProperTrailers
     -- *** Status
   , GrpcStatus(..)
   , GrpcError(..)
   , fromGrpcStatus
   , toGrpcStatus
-    -- *** Classificaiton
+    -- *** gRPC exceptions
   , GrpcException(..)
   , grpcExceptionToTrailers
   , grpcExceptionFromTrailers
     -- * Metadata
-  , CustomMetadata(..)
+  , CustomMetadata
+  , HeaderValue(..)
   , HeaderName(..)
   , BinaryValue(..)
   , AsciiValue(..)
   , NoMetadata(..)
-  , customHeaderName
     -- ** Serialization
   , buildBinaryValue
   , parseBinaryValue
@@ -113,8 +122,8 @@ module Network.GRPC.Spec (
     -- ** Validation
   , safeHeaderName
   , safeAsciiValue
-    -- ** Convenience
-  , lookupCustomMetadata
+    -- * Content type
+  , ContentType(..)
     -- * OpenTelemetry
   , TraceContext(..)
   , TraceId(..)
@@ -125,6 +134,7 @@ module Network.GRPC.Spec (
   ) where
 
 import Network.GRPC.Spec.Call
+import Network.GRPC.Spec.Common
 import Network.GRPC.Spec.Compression
 import Network.GRPC.Spec.CustomMetadata
 import Network.GRPC.Spec.LengthPrefixed
@@ -135,6 +145,7 @@ import Network.GRPC.Spec.RPC
 import Network.GRPC.Spec.RPC.Binary
 import Network.GRPC.Spec.RPC.Protobuf
 import Network.GRPC.Spec.RPC.StreamType
+import Network.GRPC.Spec.RPC.Unknown
 import Network.GRPC.Spec.Status
 import Network.GRPC.Spec.Timeout
 import Network.GRPC.Spec.TraceContext

--- a/src/Network/GRPC/Spec/Call.hs
+++ b/src/Network/GRPC/Spec/Call.hs
@@ -9,7 +9,9 @@ import Network.GRPC.Spec.CustomMetadata
 import Network.GRPC.Spec.Timeout
 
 {-------------------------------------------------------------------------------
-  Parameteres
+  Parameters
+
+  NOTE: 'CallParams' is re-exported as is in the Client API.
 -------------------------------------------------------------------------------}
 
 -- | RPC parameters that can be chosen on a per-call basis

--- a/src/Network/GRPC/Spec/LengthPrefixed.hs
+++ b/src/Network/GRPC/Spec/LengthPrefixed.hs
@@ -88,7 +88,7 @@ buildInput ::
   -> Compression
   -> (OutboundEnvelope, Input rpc)
   -> Builder
-buildInput = buildMsg . serializeInput
+buildInput = buildMsg . rpcSerializeInput
 
 -- | Serialize RPC output
 buildOutput ::
@@ -97,7 +97,7 @@ buildOutput ::
   -> Compression
   -> (OutboundEnvelope, Output rpc)
   -> Builder
-buildOutput = buildMsg . serializeOutput
+buildOutput = buildMsg . rpcSerializeOutput
 
 -- | Generalization of 'buildInput' and 'buildOutput'
 buildMsg ::
@@ -160,14 +160,14 @@ parseInput ::
   => Proxy rpc
   -> Compression
   -> Parser (InboundEnvelope, Input rpc)
-parseInput = parseMsg . deserializeInput
+parseInput = parseMsg . rpcDeserializeInput
 
 parseOutput ::
      IsRPC rpc
   => Proxy rpc
   -> Compression
   -> Parser (InboundEnvelope, Output rpc)
-parseOutput = parseMsg . deserializeOutput
+parseOutput = parseMsg . rpcDeserializeOutput
 
 parseMsg :: forall x.
      (Lazy.ByteString -> Either String x)

--- a/src/Network/GRPC/Spec/PseudoHeaders.hs
+++ b/src/Network/GRPC/Spec/PseudoHeaders.hs
@@ -161,7 +161,7 @@ buildResourceHeaders ResourceHeaders{resourcePath, resourceMethod} =
       }
 
 rpcPath :: IsRPC rpc => Proxy rpc -> Path
-rpcPath proxy = Path (serviceName proxy) (methodName proxy)
+rpcPath proxy = Path (rpcServiceName proxy) (rpcMethodName proxy)
 
 data InvalidResourceHeaders =
     InvalidMethod Strict.ByteString

--- a/src/Network/GRPC/Spec/RPC/Binary.hs
+++ b/src/Network/GRPC/Spec/RPC/Binary.hs
@@ -30,14 +30,14 @@ instance ( KnownSymbol serv
   type Input  (BinaryRpc serv meth) = Lazy.ByteString
   type Output (BinaryRpc serv meth) = Lazy.ByteString
 
-  serializationFormat _ = "binary"
-  serviceName         _ = Text.pack $ symbolVal (Proxy @serv)
-  methodName          _ = Text.pack $ symbolVal (Proxy @meth)
-  messageType         _ = "bytestring"
-  serializeInput      _ = id
-  serializeOutput     _ = id
-  deserializeInput    _ = return
-  deserializeOutput   _ = return
+  rpcContentType         _ = defaultRpcContentType "binary"
+  rpcServiceName         _ = Text.pack $ symbolVal (Proxy @serv)
+  rpcMethodName          _ = Text.pack $ symbolVal (Proxy @meth)
+  rpcMessageType         _ = "bytestring"
+  rpcSerializeInput      _ = id
+  rpcSerializeOutput     _ = id
+  rpcDeserializeInput    _ = return
+  rpcDeserializeOutput   _ = return
 
 -- | For the binary protocol we do not check communication protocols
 instance SupportsStreamingType (BinaryRpc serv meth) styp

--- a/src/Network/GRPC/Spec/RPC/Protobuf.hs
+++ b/src/Network/GRPC/Spec/RPC/Protobuf.hs
@@ -39,19 +39,20 @@ instance ( Typeable           serv
   type Input  (Protobuf serv meth) = MethodInput  serv meth
   type Output (Protobuf serv meth) = MethodOutput serv meth
 
-  serializationFormat _ = "proto"
-  serviceName         _ = Text.pack $ concat [
-                              symbolVal $ Proxy @(ServicePackage serv)
-                            , "."
-                            , symbolVal $ Proxy @(ServiceName serv)
-                            ]
-  methodName          _ = Text.pack $
-                              symbolVal $ Proxy @(MethodName serv meth)
-  messageType         _ = Protobuf.messageName $ Proxy @(MethodInput serv meth)
-  serializeInput      _ = Builder.toLazyByteString . Protobuf.buildMessage
-  serializeOutput     _ = Builder.toLazyByteString . Protobuf.buildMessage
-  deserializeInput    _ = Protobuf.runParser parseMessage . BS.Lazy.toStrict
-  deserializeOutput   _ = Protobuf.runParser parseMessage . BS.Lazy.toStrict
+  rpcContentType         _ = defaultRpcContentType "proto"
+  rpcServiceName         _ = Text.pack $ concat [
+                                 symbolVal $ Proxy @(ServicePackage serv)
+                               , "."
+                               , symbolVal $ Proxy @(ServiceName serv)
+                               ]
+  rpcMethodName          _ = Text.pack . symbolVal $
+                               Proxy @(MethodName serv meth)
+  rpcMessageType         _ = Protobuf.messageName $
+                               Proxy @(MethodInput serv meth)
+  rpcSerializeInput      _ = Builder.toLazyByteString . Protobuf.buildMessage
+  rpcSerializeOutput     _ = Builder.toLazyByteString . Protobuf.buildMessage
+  rpcDeserializeInput    _ = Protobuf.runParser parseMessage . BS.Lazy.toStrict
+  rpcDeserializeOutput   _ = Protobuf.runParser parseMessage . BS.Lazy.toStrict
 
 instance styp ~ MethodStreamingType serv meth
       => SupportsStreamingType (Protobuf serv meth) styp

--- a/src/Network/GRPC/Spec/RPC/Unknown.hs
+++ b/src/Network/GRPC/Spec/RPC/Unknown.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Network.GRPC.Spec.RPC.Unknown (UnknownRpc) where
+
+import Data.Text qualified as Text
+import Data.Typeable
+import Data.Void
+import GHC.Stack
+import GHC.TypeLits
+
+import Network.GRPC.Spec.RPC
+
+-- | Unknown RPC
+--
+-- When a request comes in a gRPC server for an unknown method, the server is
+-- supposed to respond with a @Trailers-Only@ message, with an @UNIMPLEMENTED@
+-- error code. Frustratingly, @Trailers-Only@ requires a @Content-Type@ header,
+-- /even though there is no content/. This @Content-Type@ header normally
+-- indicates the serialization format (e.g., @application/grpc+proto@), but this
+-- format depends on the specific method, which was not found!
+--
+-- To resolve this catch-22 the @Content-Type@ for 'UnknownRpc' is simply
+-- @application/grpc@, with no format specifier. Fortunately, this is allowed
+-- by the spec.
+data UnknownRpc (serv :: Maybe Symbol) (meth :: Maybe Symbol)
+
+instance ( MaybeKnown serv
+         , MaybeKnown meth
+         ) => IsRPC (UnknownRpc serv meth) where
+  type Input  (UnknownRpc serv meth) = Void
+  type Output (UnknownRpc serv meth) = Void
+
+  rpcContentType         = const "application/grpc"
+  rpcServiceName         = const $ Text.pack $ maybeSymbolVal (Proxy @serv)
+  rpcMethodName          = const $ Text.pack $ maybeSymbolVal (Proxy @meth)
+  rpcMessageType         = const "Void"
+  rpcSerializeInput      = const absurd
+  rpcSerializeOutput     = const absurd
+  rpcDeserializeInput    = const $ \_ -> Left "absurd"
+  rpcDeserializeOutput   = const $ \_ -> Left "absurd"
+
+class Typeable msym => MaybeKnown (msym :: Maybe Symbol) where
+  maybeSymbolVal :: HasCallStack => Proxy msym -> String
+
+instance MaybeKnown Nothing where
+  maybeSymbolVal = error "unknown"
+
+instance KnownSymbol sym => MaybeKnown (Just sym) where
+  maybeSymbolVal _ = symbolVal (Proxy @sym)
+

--- a/src/Network/GRPC/Spec/Timeout.hs
+++ b/src/Network/GRPC/Spec/Timeout.hs
@@ -1,12 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Network.GRPC.Spec.Timeout (
     -- * Timeouts
     Timeout(..)
   , TimeoutValue(TimeoutValue, getTimeoutValue)
   , TimeoutUnit(..)
+  , isValidTimeoutValue
     -- * Translation
   , timeoutToMicro
+    -- * Serialization
+  , buildTimeout
+  , parseTimeout
   ) where
 
+import Control.Monad.Except
+import Data.ByteString qualified as BS.Strict
+import Data.ByteString qualified as Strict (ByteString)
+import Data.ByteString.Char8 qualified as BS.Strict.C8
+import Data.Char (isDigit)
 import GHC.Show
 
 {-------------------------------------------------------------------------------
@@ -56,6 +67,12 @@ data TimeoutUnit =
 -- | Translate 'Timeout' to microseconds
 --
 -- For 'Nanosecond' timeout we round up.
+--
+-- Note: the choice of 'Integer' for the result is important: timeouts can be
+-- quite long, and might easily exceed the range of a 32-bit int: @2^31@
+-- microseconds is roughly 35 minutes (on 64-bit architectures this is much less
+-- important; @2^63@ microseconds is 292,277.2 /years/). We could use @Int64@ or
+-- @Word64@, but 'Integer' works nicely with the @unbounded-delays@ package.
 timeoutToMicro :: Timeout -> Integer
 timeoutToMicro = \case
     Timeout Hour        (TimeoutValue n) -> mult n $ 1 * 1_000 * 1_000 * 60 * 24
@@ -73,4 +90,65 @@ timeoutToMicro = \case
         mu + if n' == 0 then 0 else 1
       where
         (mu, n') = divMod n 1_000
+
+{-------------------------------------------------------------------------------
+  Serialization
+
+  > Timeout      → "grpc-timeout" TimeoutValue TimeoutUnit
+  > TimeoutValue → {positive integer as ASCII string of at most 8 digits}
+  > TimeoutUnit  → Hour / Minute / Second / Millisecond / Microsecond / Nanosecond
+  > Hour         → "H"
+  > Minute       → "M"
+  > Second       → "S"
+  > Millisecond  → "m"
+  > Microsecond  → "u"
+  > Nanosecond   → "n"
+-------------------------------------------------------------------------------}
+
+buildTimeout :: Timeout -> Strict.ByteString
+buildTimeout (Timeout unit val) = mconcat [
+      BS.Strict.C8.pack $ show $ getTimeoutValue val
+    , case unit of
+        Hour        -> "H"
+        Minute      -> "M"
+        Second      -> "S"
+        Millisecond -> "m"
+        Microsecond -> "u"
+        Nanosecond  -> "n"
+    ]
+
+parseTimeout :: forall m.
+     MonadError String m
+  => Strict.ByteString -> m Timeout
+parseTimeout bs = do
+    let (bsVal, bsUnit) = BS.Strict.C8.span isDigit bs
+
+    val <-
+      if BS.Strict.length bsVal < 1 || BS.Strict.length bsVal > 8
+        then invalid
+        else return . TimeoutValue $ read (BS.Strict.C8.unpack bsVal)
+
+    charUnit <-
+      case BS.Strict.C8.uncons bsUnit of
+        Nothing ->
+          invalid
+        Just (u, remainder) ->
+          if BS.Strict.null remainder
+            then return u
+            else invalid
+
+    unit <-
+      case charUnit of
+        'H' -> return Hour
+        'M' -> return Minute
+        'S' -> return Second
+        'm' -> return Millisecond
+        'u' -> return Microsecond
+        'n' -> return Nanosecond
+        _   -> invalid
+
+    return $ Timeout unit val
+  where
+    invalid :: m a
+    invalid = throwError $ "Could not parse timeout " ++ show bs
 

--- a/test-grapesy/Test/Driver/Dialogue/Definition.hs
+++ b/test-grapesy/Test/Driver/Dialogue/Definition.hs
@@ -18,7 +18,7 @@ module Test.Driver.Dialogue.Definition (
 
 import Control.Exception
 import Data.Bifunctor
-import Data.Set (Set)
+import Data.Map.Strict (Map)
 import GHC.Generics qualified as GHC
 
 import Network.GRPC.Common
@@ -70,10 +70,7 @@ data RPC = RPC1 | RPC2 | RPC3
   deriving stock (Show, Eq, GHC.Generic)
 
 -- | Metadata
---
--- We use 'Set' for 'CustomMetadata' rather than a list, because we do not
--- want to test that the /order/ of the metadata is matched.
-type Metadata = Set CustomMetadata
+type Metadata = Map HeaderName HeaderValue
 
 {-------------------------------------------------------------------------------
   Many channels (bird's-eye view)

--- a/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
@@ -19,9 +19,9 @@ import Network.GRPC.Client.StreamType.IO (rpc)
 import Network.GRPC.Client.StreamType.IO qualified as Client
 import Network.GRPC.Common
 import Network.GRPC.Common.StreamElem qualified as StreamElem
-import Network.GRPC.Common.StreamType (SupportsStreamingType, StreamingType(..))
 import Network.GRPC.Server qualified as Server
 import Network.GRPC.Server.StreamType qualified as Server
+import Network.GRPC.Spec
 
 import Test.Driver.ClientServer
 
@@ -96,14 +96,14 @@ instance CalculatorFunction fun => IsRPC (Calc fun) where
   type Input  (Calc fun) = CalcInput  fun
   type Output (Calc fun) = CalcOutput fun
 
-  serializationFormat _ = "cbor"
-  messageType         _ = "cbor"
-  serviceName         _ = "calculator"
-  methodName          _ = calculatorMethod (Proxy @fun)
-  serializeInput      _ = Cbor.serialise @(CalcInput  fun)
-  serializeOutput     _ = Cbor.serialise @(CalcOutput fun)
-  deserializeInput    _ = first show . Cbor.deserialiseOrFail @(CalcInput  fun)
-  deserializeOutput   _ = first show . Cbor.deserialiseOrFail @(CalcOutput fun)
+  rpcContentType         _ = defaultRpcContentType "cbor"
+  rpcMessageType         _ = "cbor"
+  rpcServiceName         _ = "calculator"
+  rpcMethodName          _ = calculatorMethod (Proxy @fun)
+  rpcSerializeInput      _ = Cbor.serialise @(CalcInput  fun)
+  rpcSerializeOutput     _ = Cbor.serialise @(CalcOutput fun)
+  rpcDeserializeInput    _ = first show . Cbor.deserialiseOrFail @(CalcInput  fun)
+  rpcDeserializeOutput   _ = first show . Cbor.deserialiseOrFail @(CalcOutput fun)
 
 {-------------------------------------------------------------------------------
   Tests proper

--- a/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -16,6 +16,7 @@ import Network.GRPC.Server.Binary qualified as Binary
 import Network.GRPC.Server.StreamType
 
 import Test.Driver.ClientServer
+import Network.GRPC.Spec (ContentType(ContentTypeOverride))
 
 tests :: TestTree
 tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
@@ -27,30 +28,30 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
                   -- Without the +format part
                   testCase "application/grpc" $
                     test_increment def {
-                        clientContentType =
-                          ValidOverride "application/grpc"
+                        clientContentType = ValidOverride $
+                          ContentTypeOverride "application/grpc"
                       }
 
                   -- Random other format
                   -- See discussion in 'parseContentType'
                 , testCase "application/grpc+gibberish" $
                     test_increment def {
-                        clientContentType =
-                          ValidOverride "application/grpc+gibberish"
+                        clientContentType = ValidOverride $
+                          ContentTypeOverride "application/grpc+gibberish"
                       }
                 ]
             , testGroup "fail" [
                   testCase "application/invalid-subtype" $
                     test_increment def {
-                        clientContentType =
-                          InvalidOverride "application/invalid-subtype"
+                        clientContentType = InvalidOverride $
+                           ContentTypeOverride "application/invalid-subtype"
                       }
 
                   -- gRPC spec does not allow parameters
                 , testCase "charset" $
                     test_increment def {
-                        clientContentType =
-                          InvalidOverride "application/grpc; charset=us-ascii"
+                        clientContentType = InvalidOverride $
+                           ContentTypeOverride "application/grpc; charset=us-ascii"
                       }
                 ]
             ]

--- a/test-grapesy/Test/Util/Awkward.hs
+++ b/test-grapesy/Test/Util/Awkward.hs
@@ -1,0 +1,91 @@
+module Test.Util.Awkward (
+    Awkward(..)
+    -- * Support for defining instances
+  , awkward
+  , arbitraryAwkward
+  , shrinkAwkward
+  ) where
+
+import Data.ByteString qualified as BS.Strict
+import Data.ByteString qualified as Strict (ByteString)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()
+
+{-------------------------------------------------------------------------------
+  \"Awkward\" instances
+-------------------------------------------------------------------------------}
+
+-- | Newtype wrapper for \"awkward\" 'Arbitrary' instances
+--
+-- In most property tests we don't explore edge cases, preferring for example
+-- to use only simple header names, rather than check encoding issues. But in
+-- these serialization tests the edge cases are of course important.
+newtype Awkward a = Awkward { getAwkward :: a }
+  deriving stock (Show, Functor)
+
+awkward :: Arbitrary (Awkward a) => Gen a
+awkward = getAwkward <$> arbitrary
+
+arbitraryAwkward :: Arbitrary (Awkward a) => (a -> b) -> Gen (Awkward b)
+arbitraryAwkward f = Awkward . f <$> awkward
+
+shrinkAwkward ::
+     Arbitrary (Awkward a)
+  => (a -> b)
+  -> (b -> a)
+  -> Awkward b -> [Awkward b]
+shrinkAwkward f g =
+      map (Awkward . f . getAwkward)
+    . shrink
+    . Awkward . g . getAwkward
+
+{-------------------------------------------------------------------------------
+  Standard instances
+-------------------------------------------------------------------------------}
+
+distrib :: Functor f => f (Awkward a) -> Awkward (f a)
+distrib = Awkward . fmap getAwkward
+
+undistrib :: Functor f => Awkward (f a) -> f (Awkward a)
+undistrib = fmap Awkward . getAwkward
+
+instance Arbitrary (Awkward a) => Arbitrary (Awkward (Maybe a)) where
+  arbitrary = distrib <$> arbitrary
+  shrink    = map distrib . shrink . undistrib
+
+instance Arbitrary (Awkward a) => Arbitrary (Awkward [a]) where
+  arbitrary = distrib <$> arbitrary
+  shrink    = map distrib . shrink . undistrib
+
+instance Arbitrary (Awkward a) => Arbitrary (Awkward (NonEmpty a)) where
+  arbitrary = distrib <$> arbitrary
+  shrink    = map distrib . shrink . undistrib
+
+instance ( Arbitrary (Awkward a)
+         , Arbitrary (Awkward b)
+         ) => Arbitrary (Awkward (a, b)) where
+  arbitrary = fmap Awkward $ (,) <$> awkward <*> awkward
+  shrink pair@(Awkward (x, y)) = concat [
+        shrinkAwkward (\x' -> (x', y )) fst pair
+      , shrinkAwkward (\y' -> (x , y')) snd pair
+      ]
+
+instance ( Arbitrary (Awkward k)
+         , Arbitrary (Awkward v)
+         , Ord k
+         ) => Arbitrary (Awkward (Map k v)) where
+  arbitrary = arbitraryAwkward Map.fromList
+  shrink    = shrinkAwkward    Map.fromList Map.toList
+
+instance Arbitrary (Awkward Strict.ByteString) where
+  arbitrary = Awkward <$> BS.Strict.pack <$> arbitrary
+  shrink    = map (Awkward . BS.Strict.pack)
+            . shrink
+            . BS.Strict.unpack . getAwkward
+
+instance {-# OVERLAPPING #-} Arbitrary (Awkward String) where
+  arbitrary = Awkward <$> arbitrary
+  shrink    = map Awkward . shrink . getAwkward


### PR DESCRIPTION
This PR completes interop testing, at least outside of Docker (see `interop.md` for details); inside of Docker there are still some TLS handshake problems.

* ✅ passed
* ❔ not supported by the reference

#### `grapesy` server versus official reference client

| Test                          | Python | C++  | Go | Java | grapesy |
| ----------------------------- | ------ | ---- | -- | ---- | ------- |
| `cancel_after_begin`          | ✅      | ✅    | ✅  | ✅    | ✅       |
| `cancel_after_first_response` | ✅      | ✅    | ✅  | ✅    | ✅       |
| `client_compressed_streaming` | ❔      | ✅    | ❔  | ✅    | ✅       |
| `client_compressed_unary`     | ❔      | ✅    | ❔  | ✅    | ✅       |
| `client_streaming`            | ✅      | ✅    | ✅  | ✅    | ✅       |
| `custom_metadata`             | ✅      | ✅    | ✅  | ✅    | ✅       |
| `empty_stream`                | ✅      | ✅    | ✅  | ✅    | ✅       |
| `empty_unary`                 | ✅      | ✅    | ✅  | ✅    | ✅       |
| `large_unary`                 | ✅      | ✅    | ✅  | ✅    | ✅       |
| `ping_pong`                   | ✅      | ✅    | ✅  | ✅    | ✅       |
| `server_compressed_streaming` | ❔      | ✅    | ❔  | ✅    | ✅       |
| `server_compressed_unary`     | ❔      | ✅    | ❔  | ✅    | ✅       |
| `server_streaming`            | ✅      | ✅    | ✅  | ✅    | ✅       |
| `special_status_message`      | ✅      | ❔    | ✅  | ✅    | ✅       |
| `status_code_and_message`     | ✅      | ✅    | ✅  | ✅    | ✅       |
| `timeout_on_sleeping_server`  | ✅      | ✅    | ✅  | ✅    | ✅       |
| `unimplemented_method`        | ✅      | ✅    | ✅  | ✅    | ✅       |
| `unimplemented_service`       | ✅      | ✅    | ✅  | ✅    | ✅       |

#### `grapesy` client versus reference server

| Test                          | Python | C++  | Go | Java | grapesy |
| ----------------------------- | ------ | ---- | -- | ---- | ------- |
| `cancel_after_begin`          | ✅      | ✅    | ✅  | ✅    | ✅       |
| `cancel_after_first_response` | ✅      | ✅    | ✅  | ✅    | ✅       |
| `client_compressed_streaming` | ❔      | ✅    | ❔  | ❔    | ✅       |
| `client_compressed_unary`     | ❔      | ✅    | ❔  | ❔    | ✅       |
| `client_streaming`            | ✅      | ✅    | ✅  | ✅    | ✅       |
| `custom_metadata`             | ✅      | ✅    | ✅  | ✅    | ✅       |
| `empty_stream`                | ✅      | ✅    | ✅  | ✅    | ✅       |
| `empty_unary`                 | ✅      | ✅    | ✅  | ✅    | ✅       |
| `large_unary`                 | ✅      | ✅    | ✅  | ✅    | ✅       |
| `ping_pong`                   | ✅      | ✅    | ✅  | ✅    | ✅       |
| `server_compressed_streaming` | ❔      | ✅    | ❔  | ❔    | ✅       |
| `server_compressed_unary`     | ❔      | ✅    | ❔  | ✅    | ✅       |
| `server_streaming`            | ✅      | ✅    | ✅  | ✅    | ✅       |
| `special_status_message`      | ✅      | ✅    | ✅  | ✅    | ✅       |
| `status_code_and_message`     | ✅      | ✅    | ✅  | ✅    | ✅       |
| `timeout_on_sleeping_server`  | ✅      | ✅    | ✅  | ❔    | ✅       |
| `unimplemented_method`        | ✅      | ✅    | ✅  | ✅    | ✅       |
| `unimplemented_service`       | ✅      | ✅    | ✅  | ✅    | ✅       |



