### PR TITLE
Remove TODO from the test suite

### DIFF
--- a/src/Network/GRPC/Client.hs
+++ b/src/Network/GRPC/Client.hs
@@ -187,3 +187,7 @@ import Network.GRPC.Util.TLS qualified as Util.TLS
 -- The specialized functions from "Network.GRPC.Client.StreamType" take care of
 -- this; if these functions are not applicable, users may wish to use
 -- 'recvFinalOutput'.
+--
+-- **KNOWN LIMITATION**: for _incoming_ messages @grapesy@ cannot currently
+-- make this distinction. For detailed discussion, see
+-- <https://github.com/well-typed/grapesy/issues/114>.

--- a/src/Network/GRPC/Util/Session/Channel.hs
+++ b/src/Network/GRPC/Util/Session/Channel.hs
@@ -497,9 +497,8 @@ sendMessageLoop sess st stream = do
 
 -- | Receive all messages sent by the node's peer
 --
--- TODO: This is wrong, we are never marking the final element as final.
--- (But fixing this requires a patch to http2.) This is only relevent for
--- server-side; see discussion in "Network.GRPC.Client".
+-- TODO: <https://github.com/well-typed/grapesy/issues/114>.
+-- We are never marking the final element as final.
 recvMessageLoop :: forall sess.
      IsSession sess
   => sess

--- a/test-grapesy/Test/Driver/Dialogue/Definition.hs
+++ b/test-grapesy/Test/Driver/Dialogue/Definition.hs
@@ -29,6 +29,7 @@ import Network.GRPC.Common
 
 import Test.Driver.Dialogue.TestClock qualified as TestClock
 import Control.Monad.Catch
+import GHC.Show (appPrec1, showCommaSpace)
 
 {-------------------------------------------------------------------------------
   Single RPC
@@ -74,7 +75,31 @@ data TestMetadata = TestMetadata {
     , metadataBin3 :: Maybe Strict.ByteString
     , metadataBin4 :: Maybe Strict.ByteString
     }
-  deriving (Show, Eq)
+  deriving (Eq)
+
+-- | Hand-written 'Show' instance which shows @def :: TestMetadata@ as @def@
+--
+-- This is by far the most common value that shows up in test failures, so this
+-- improves readability.
+instance Show TestMetadata where
+  showsPrec _ (TestMetadata Nothing Nothing Nothing Nothing) = showString "def"
+  showsPrec p (TestMetadata asc1 asc2 bin3 bin4) = showParen (p >= appPrec1) $
+        showString "TestMetadata {"
+      . showString "metadataAsc1 = "
+      . showVal asc1
+      . showCommaSpace
+      . showString "metadataAsc2 = "
+      . showVal asc2
+      . showCommaSpace
+      . showString "metadataBin3 = "
+      . showVal bin3
+      . showCommaSpace
+      . showString "metadataBin4 = "
+      . showVal bin4
+      . showString "}"
+    where
+      showVal Nothing  = showString "def"
+      showVal (Just x) = showsPrec 0 (Just x)
 
 instance Default TestMetadata where
   def = TestMetadata {


### PR DESCRIPTION
I thought I had discovered a very annoying problem with the test suite, that many important test cases were not being generated. This fortunately turned out not to be the case. See detailed discussion in the code itself.