### PR TITLE
Disable HTTP-level timeouts

### DIFF
--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -188,6 +188,7 @@ library
     , random               >= 1.2   && < 1.3
     , stm                  >= 2.5   && < 2.6
     , text                 >= 1.2   && < 2.1
+    , time-manager         >= 0.0   && < 0.1
     , transformers         >= 0.5   && < 0.7
     , unbounded-delays     >= 0.1.1 && < 0.2
     , unordered-containers >= 0.2   && < 0.3

--- a/src/Network/GRPC/Server.hs
+++ b/src/Network/GRPC/Server.hs
@@ -78,4 +78,3 @@ mkGrpcServer params@ServerParams{serverTopLevel} handlers = do
   where
     handlerMap :: HandlerMap IO
     handlerMap = HandlerMap.fromList handlers
-

--- a/src/Network/GRPC/Util/HTTP2.hs
+++ b/src/Network/GRPC/Util/HTTP2.hs
@@ -1,12 +1,18 @@
 module Network.GRPC.Util.HTTP2 (
     -- * General auxiliary
     fromHeaderTable
+    -- * Configuration
+  , allocConfigWithTimeout
   ) where
 
 import Data.Bifunctor
+import Network.HPACK (BufferSize)
 import Network.HPACK qualified as HPACK
 import Network.HPACK.Token qualified as HPACK
 import Network.HTTP.Types qualified as HTTP
+import Network.HTTP2.Server qualified as Server
+import Network.Socket
+import System.TimeManager qualified as TimeoutManager
 
 {-------------------------------------------------------------------------------
   General auxiliary
@@ -14,3 +20,18 @@ import Network.HTTP.Types qualified as HTTP
 
 fromHeaderTable :: HPACK.HeaderTable -> [HTTP.Header]
 fromHeaderTable = map (first HPACK.tokenKey) . fst
+
+{-------------------------------------------------------------------------------
+  Configuration
+-------------------------------------------------------------------------------}
+
+-- | Adaptation of 'allocSimpleConfig' that allows to specify a timeout
+allocConfigWithTimeout :: Socket -> BufferSize -> Int -> IO Server.Config
+allocConfigWithTimeout sock confBufferSize timeout = do
+    -- Since 'allocSimpleConfig' calls some functions that are not exported,
+    -- we use it as-is, and then throw away the 'TimeManager' it created and
+    -- override it with our own. We can only do this because none of the other
+    -- values in this record depend on the time manager.
+    config <- Server.allocSimpleConfig sock confBufferSize
+    timeoutManager <- TimeoutManager.initialize $ timeout * 1_000_000
+    return config{Server.confTimeoutManager = timeoutManager}


### PR DESCRIPTION
We can still see `TimeoutThread` exceptions if a server is terminated before our worker gets a chance to install its own exception handler. This is not a big deal, but can lead to some confusing error messages for example in the `interop` tests: if a test fails, and the server is terminated very quickly, then this exception may be shown (we could hide it by calling `setUncaughtExceptionHandler`).