### PR TITLE
Catch pure exceptions when calling `buildMetadata`

### DIFF
--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -38,6 +38,7 @@ common lang
       DeriveAnyClass
       DeriveFoldable
       DeriveFunctor
+      DeriveGeneric
       DeriveTraversable
       DerivingStrategies
       DerivingVia
@@ -171,6 +172,7 @@ library
     , case-insensitive     >= 1.2   && < 1.3
     , containers           >= 0.6   && < 0.7
     , data-default         >= 0.7   && < 0.8
+    , deepseq              >= 1.4   && < 1.5
     , exceptions           >= 0.10  && < 0.11
     , hashable             >= 1.3   && < 1.5
     , http-types           >= 0.12  && < 0.13
@@ -369,7 +371,7 @@ executable demo-server
     , grapesy
   build-depends:
       -- External dependencies
-    , aeson                >= 1.5  && < 2.2
+    , aeson                >= 1.5  && < 2.3
     , bytestring           >= 0.10 && < 0.12
     , containers           >= 0.6  && < 0.7
     , contra-tracer        >= 0.2  && < 0.3

--- a/interop/Interop/API.hs
+++ b/interop/Interop/API.hs
@@ -164,8 +164,6 @@ instance BuildMetadata InteropRespInitMeta where
 
 instance BuildMetadata InteropRespTrailMeta where
   buildMetadata md = concat [
-        -- TODO: If we use the wrong header name here, we get a test failure
-        -- (that's good) with a very unhelpful exception.
         [ CustomMetadata grpcTestEchoTrailingBin val
         | Just val <- [interopActualTrail md]
         ]

--- a/interop/Main.hs
+++ b/interop/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import GHC.Conc (setUncaughtExceptionHandler)
 import System.IO
 
 import Interop.Client (runInteropClient)
@@ -14,6 +15,14 @@ import Interop.Server (runInteropServer)
 
 main :: IO ()
 main = do
+    -- TODO: <https://github.com/well-typed/grapesy/issues/123>
+    --
+    -- Under some circumstances we can see a "Thread killed" exception when a
+    -- test fails. By setting this handler, we can at least confirm that this
+    -- exception is coming from an uncaught exception in a thread.
+    setUncaughtExceptionHandler $ \err ->
+      hPutStrLn stderr $ "Uncaught exception: " ++ show err
+
     -- Ensure we see server output when running inside docker
     hSetBuffering stdout NoBuffering
     hSetBuffering stderr NoBuffering
@@ -24,4 +33,3 @@ main = do
       Client   -> runInteropClient cmdline
       Ping     -> ping cmdline
       SelfTest -> selfTest cmdline
-

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -146,6 +146,7 @@ module Network.GRPC.Spec (
   , BuildMetadata(..)
   , ParseMetadata(..)
   , StaticMetadata(..)
+  , buildMetadataIO
     -- * Content type
   , ContentType(..)
     -- * OpenTelemetry

--- a/src/Network/GRPC/Spec/CustomMetadata/Raw.hs
+++ b/src/Network/GRPC/Spec/CustomMetadata/Raw.hs
@@ -24,6 +24,7 @@ module Network.GRPC.Spec.CustomMetadata.Raw (
   , parseCustomMetadata
   ) where
 
+import Control.DeepSeq (NFData)
 import Control.Monad
 import Control.Monad.Except (MonadError(throwError))
 import Data.ByteString qualified as BS.Strict
@@ -37,6 +38,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String
 import Data.Word
+import GHC.Generics (Generic)
 import GHC.Show
 import GHC.Stack
 import Network.HTTP.Types qualified as HTTP
@@ -71,7 +73,8 @@ data CustomMetadata = UnsafeCustomMetadata {
       customMetadataName  :: HeaderName
     , customMetadataValue :: Strict.ByteString
     }
-  deriving stock (Eq)
+  deriving stock (Eq, Generic)
+  deriving anyclass (NFData)
 
 -- | 'Show' instance relies on the 'CustomMetadata' pattern synonym
 instance Show CustomMetadata where
@@ -166,7 +169,8 @@ data HeaderName =
     -- but the ABNF spec defines it as "space and horizontal tab"
     -- <https://www.rfc-editor.org/rfc/rfc5234#section-3.1>.
   | UnsafeAsciiHeader Strict.ByteString
-  deriving stock (Eq, Ord)
+  deriving stock (Eq, Ord, Generic)
+  deriving anyclass (NFData)
 
 pattern BinaryHeader :: HasCallStack => Strict.ByteString -> HeaderName
 pattern BinaryHeader name <- UnsafeBinaryHeader name


### PR DESCRIPTION
This can be helpful when there are bugs constructing the metadata, for example constructing an ASCII header with a non-ASCII value. Prior to this commit this would result in the server disconnecting without any kind of helpful error message, because the exception was actually triggered deep in the bowels of `http2`. We now trigger it earlier, so that we throw the appropriate exception. For example:

```haskell
CustomMetadata "x-wrong-header" "\x00"
```

will result in

```
Invalid: CustomMetadata "x-wrong-header" "\NUL" at <callstack>
```

on the server, which will then propagate to the client as

```haskell
GrpcException {
    grpcError = GrpcUnknown
  , grpcErrorMessage = Just "Invalid: CustomMetadata \"x-wrong-header\" \"\\NUL\" at <callstack>"
  , grpcErrorMetadata = []
}
```