### PR TITLE
Disable orphan warnings when declaring metadata

### DIFF
--- a/demo-common/Demo/Common/API.hs
+++ b/demo-common/Demo/Common/API.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Demo.Common.API (
     -- * Greeter

--- a/interop/Interop/API.hs
+++ b/interop/Interop/API.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Interop.API (
     -- * TestService

--- a/test-grapesy/Test/Driver/Dialogue/Execution.hs
+++ b/test-grapesy/Test/Driver/Dialogue/Execution.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Driver.Dialogue.Execution (
     execGlobalSteps

--- a/test-grapesy/Test/Sanity/Interop.hs
+++ b/test-grapesy/Test/Sanity/Interop.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedLabels  #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | Test functionality required by the gRPC interop tests
 module Test.Sanity.Interop (tests) where

--- a/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Sanity.StreamingType.NonStreaming (tests) where
 

--- a/test-stress/Test/Stress/Server/API.hs
+++ b/test-stress/Test/Stress/Server/API.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Test.Stress.Server.API (
     ManyShortLived
   ) where


### PR DESCRIPTION
Metadata instances are declared with something like

```haskell
type instance RequestMetadata          (Protobuf Greeter meth) = NoMetadata
type instance ResponseInitialMetadata  (Protobuf Greeter meth) = GreeterResponseInitialMetadata meth
type instance ResponseTrailingMetadata (Protobuf Greeter meth) = NoMetadata
```

In ghc 9.8 this results in orphan warnings. This is somewhat unfortunate, but for now we simply disable these warnings.