### PR TITLE
Fix the connection watch thread

### DIFF
--- a/src/Network/GRPC/Client/Connection.hs
+++ b/src/Network/GRPC/Client/Connection.hs
@@ -348,9 +348,10 @@ startRPC Connection{connMetaVar, connParams, connStateVar} _ callParams = do
     -- the (normal) case that the channel is closed before the connection is.
     _ <- forkIO $ do
       status <- atomically $ do
-            (Left <$> waitForThread (Session.channelOutbound channel))
-          `orElse`
-            (Right <$> readTMVar connClosed)
+          (Left <$> waitForNormalOrAbnormalThreadTermination
+                      (Session.channelOutbound channel))
+        `orElse`
+          (Right <$> readTMVar connClosed)
       case status of
         Left _ -> return () -- Channel closed before the connection
         Right mErr -> do

--- a/src/Network/GRPC/Util/Session/Channel.hs
+++ b/src/Network/GRPC/Util/Session/Channel.hs
@@ -332,7 +332,7 @@ data RecvAfterFinal =
 -- See 'close' for discussion.
 waitForOutbound :: Channel sess -> IO (FlowState (Outbound sess))
 waitForOutbound Channel{channelOutbound} = atomically $
-    waitForThread channelOutbound
+    waitForNormalThreadTermination channelOutbound
 
 -- | Close the channel
 --

--- a/test-grapesy/Main.hs
+++ b/test-grapesy/Main.hs
@@ -1,5 +1,9 @@
 module Main (main) where
 
+import Control.Concurrent
+import Control.Exception
+import GHC.Conc (setUncaughtExceptionHandler)
+import System.IO
 import Test.Tasty
 
 import Test.Prop.Dialogue                     qualified as Dialogue
@@ -9,16 +13,29 @@ import Test.Sanity.StreamingType.CustomFormat qualified as StreamingType.CustomF
 import Test.Sanity.StreamingType.NonStreaming qualified as StreamingType.NonStreaming
 
 main :: IO ()
-main = defaultMain $ testGroup "grapesy" [
-      testGroup "Sanity" [
-          testGroup "StreamingType" [
-              StreamingType.NonStreaming.tests
-            , StreamingType.CustomFormat.tests
-            ]
-        , Interop.tests
-        ]
-    , testGroup "Prop" [
-          Serialization.tests
-        , Dialogue.tests
-        ]
-    ]
+main = do
+    setUncaughtExceptionHandler uncaughtExceptionHandler
+
+    defaultMain $ testGroup "grapesy" [
+        testGroup "Sanity" [
+            testGroup "StreamingType" [
+                StreamingType.NonStreaming.tests
+              , StreamingType.CustomFormat.tests
+              ]
+          , Interop.tests
+          ]
+      , testGroup "Prop" [
+            Serialization.tests
+          , Dialogue.tests
+          ]
+      ]
+
+uncaughtExceptionHandler :: SomeException -> IO ()
+uncaughtExceptionHandler e = do
+    tid <- myThreadId
+    hPutStrLn stderr $ concat [
+         "Uncaught exception in "
+      , show tid
+      , ": "
+      , displayException e
+      ]


### PR DESCRIPTION
We were calling `waitForThread`, which actually only waits for _normal_ thread termination, and throws an exception otherwise. This resulted in uncaught exceptions. We are now more explicit about this.

/cc @FinleyMcIlwaine 