### PR TITLE
Update http2, http2-tls, time-manager

### DIFF
--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -180,38 +180,38 @@ library
       xio
       proto
   build-depends:
-    , async                >= 2.2   && < 2.3
-    , base16-bytestring    >= 1.0   && < 1.1
-    , base64-bytestring    >= 1.2   && < 1.3
-    , binary               >= 0.8   && < 0.9
-    , bytestring           >= 0.10  && < 0.13
-    , case-insensitive     >= 1.2   && < 1.3
-    , containers           >= 0.6   && < 0.8
-    , data-default         >= 0.7   && < 0.8
-    , deepseq              >= 1.4   && < 1.6
-    , exceptions           >= 0.10  && < 0.11
-    , hashable             >= 1.3   && < 1.5
-    , http-types           >= 0.12  && < 0.13
-    , http2                >= 5.1.2 && < 5.2
-    , http2-tls            >= 0.2.6 && < 0.3
-    , lens                 >= 5.0   && < 5.3
-    , mtl                  >= 2.2   && < 2.4
-    , network              >= 3.1   && < 3.2
-    , network-byte-order   >= 0.1   && < 0.2
-    , network-run          >= 0.2.7 && < 0.3
-    , pipes                >= 4.3   && < 4.4
-    , pipes-safe           >= 2.3   && < 2.4
-    , proto-lens           >= 0.7   && < 0.8
-    , proto-lens-runtime   >= 0.7   && < 0.8
-    , random               >= 1.2   && < 1.3
-    , stm                  >= 2.5   && < 2.6
-    , text                 >= 1.2   && < 2.2
-    , time-manager         >= 0.0   && < 0.1
-    , transformers         >= 0.5   && < 0.7
-    , unbounded-delays     >= 0.1.1 && < 0.2
-    , unordered-containers >= 0.2   && < 0.3
-    , utf8-string          >= 1.0   && < 1.1
-    , zlib                 >= 0.6   && < 0.7
+    , async                >= 2.2    && < 2.3
+    , base16-bytestring    >= 1.0    && < 1.1
+    , base64-bytestring    >= 1.2    && < 1.3
+    , binary               >= 0.8    && < 0.9
+    , bytestring           >= 0.10   && < 0.13
+    , case-insensitive     >= 1.2    && < 1.3
+    , containers           >= 0.6    && < 0.8
+    , data-default         >= 0.7    && < 0.8
+    , deepseq              >= 1.4    && < 1.6
+    , exceptions           >= 0.10   && < 0.11
+    , hashable             >= 1.3    && < 1.5
+    , http-types           >= 0.12   && < 0.13
+    , http2                >= 5.2.1  && < 5.3
+    , http2-tls            >= 0.2.11 && < 0.3
+    , lens                 >= 5.0    && < 5.3
+    , mtl                  >= 2.2    && < 2.4
+    , network              >= 3.1    && < 3.2
+    , network-byte-order   >= 0.1    && < 0.2
+    , network-run          >= 0.2.7  && < 0.3
+    , pipes                >= 4.3    && < 4.4
+    , pipes-safe           >= 2.3    && < 2.4
+    , proto-lens           >= 0.7    && < 0.8
+    , proto-lens-runtime   >= 0.7    && < 0.8
+    , random               >= 1.2    && < 1.3
+    , stm                  >= 2.5    && < 2.6
+    , text                 >= 1.2    && < 2.2
+    , time-manager         >= 0.1    && < 0.2
+    , transformers         >= 0.5    && < 0.7
+    , unbounded-delays     >= 0.1.1  && < 0.2
+    , unordered-containers >= 0.2    && < 0.3
+    , utf8-string          >= 1.0    && < 1.1
+    , zlib                 >= 0.6    && < 0.7
 
   -- Snappy can be a bit tricky to install on some systems, so we make it an
   -- optional dependency. Snappy support can be explicitly disabled by clearing
@@ -302,7 +302,7 @@ test-suite test-grapesy
     , containers           >= 0.6   && < 0.8
     , exceptions           >= 0.10  && < 0.11
     , http-types           >= 0.12  && < 0.13
-    , http2                >= 5.1.2 && < 5.2
+    , http2                >= 5.2.1 && < 5.3
     , mtl                  >= 2.2   && < 2.4
     , network              >= 3.1   && < 3.2
     , proto-lens-runtime   >= 0.7   && < 0.8

--- a/util/Network/GRPC/Util/HTTP2.hs
+++ b/util/Network/GRPC/Util/HTTP2.hs
@@ -18,7 +18,7 @@ import System.TimeManager qualified as TimeoutManager
   General auxiliary
 -------------------------------------------------------------------------------}
 
-fromHeaderTable :: HPACK.HeaderTable -> [HTTP.Header]
+fromHeaderTable :: HPACK.TokenHeaderTable -> [HTTP.Header]
 fromHeaderTable = map (first HPACK.tokenKey) . fst
 
 {-------------------------------------------------------------------------------

--- a/util/Network/GRPC/Util/Session/API.hs
+++ b/util/Network/GRPC/Util/Session/API.hs
@@ -18,9 +18,8 @@ import Data.ByteString.Lazy qualified as Lazy (ByteString)
 import Data.Kind
 import Network.HTTP.Types qualified as HTTP
 
--- We import from @.Internal@ to avoid biasing towards @.Server@ or @.Client@
--- (this is actually defined in a hidden module @Network.HTTP2.Arch.Types@).
-import Network.HTTP2.Internal qualified as HTTP2
+-- Doesn't really matter if we import this from .Client or .Server
+import Network.HTTP2.Client qualified as HTTP2 (Path)
 
 import Network.GRPC.Util.Parser
 

--- a/util/Network/GRPC/Util/Session/Channel.hs
+++ b/util/Network/GRPC/Util/Session/Channel.hs
@@ -38,7 +38,12 @@ import Control.Monad.Catch (ExitCase(..))
 import Data.Bifunctor
 import Data.ByteString.Builder (Builder)
 import GHC.Stack
-import Network.HTTP2.Internal qualified as HTTP2
+
+-- Doesn't really matter if we import from .Client or .Server
+import Network.HTTP2.Client qualified as HTTP2 (
+    TrailersMaker
+  , NextTrailersMaker(..)
+  )
 
 import Network.GRPC.Common.StreamElem (StreamElem(..))
 import Network.GRPC.Common.StreamElem qualified as StreamElem


### PR DESCRIPTION
This updates the http2 and time-manager dependencies to include the latest eager handle deletion changes in time-manager. I also migrated grapesy to use http-semantics, since http2 ≥ 5.2 had some types extracted from it.