### PR TITLE
Move `Input` and `Output` out of `IsRPC`

### DIFF
--- a/src/Network/GRPC/Client/StreamType/IO.hs
+++ b/src/Network/GRPC/Client/StreamType/IO.hs
@@ -16,7 +16,7 @@ import Control.Monad.Reader
 import Network.GRPC.Client
 import Network.GRPC.Common.StreamElem
 import Network.GRPC.Common.StreamType
-import Network.GRPC.Spec (IsRPC(..), NoMetadata)
+import Network.GRPC.Spec (Input, Output, NoMetadata)
 import Network.GRPC.Spec qualified as Spec
 import Network.GRPC.Client.StreamType hiding (CanCallRPC(..))
 

--- a/src/Network/GRPC/Common.hs
+++ b/src/Network/GRPC/Common.hs
@@ -4,6 +4,8 @@
 module Network.GRPC.Common (
     -- * Abstraction over different serialization formats
     IsRPC(..)
+  , Input
+  , Output
   , SupportsClientRpc(..)
   , SupportsServerRpc(..)
 

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -8,6 +8,8 @@
 module Network.GRPC.Spec (
     -- * RPC
     IsRPC(..)
+  , Input
+  , Output
   , SupportsClientRpc(..)
   , SupportsServerRpc(..)
   , defaultRpcContentType

--- a/src/Network/GRPC/Spec/RPC.hs
+++ b/src/Network/GRPC/Spec/RPC.hs
@@ -2,6 +2,8 @@
 
 module Network.GRPC.Spec.RPC (
     IsRPC(..)
+  , Input
+  , Output
   , SupportsServerRpc(..)
   , SupportsClientRpc(..)
   , defaultRpcContentType
@@ -19,6 +21,12 @@ import Network.GRPC.Spec.CustomMetadata.Typed
 {-------------------------------------------------------------------------------
   RPC call
 -------------------------------------------------------------------------------}
+
+-- | Messages from the client to the server
+type family Input (rpc :: k) :: Type
+
+-- | Messages from the server to the client
+type family Output (rpc :: k) :: Type
 
 -- | Abstract definition of an RPC
 --
@@ -41,12 +49,6 @@ class ( -- Debug constraints
       , Show (ResponseInitialMetadata rpc)
       , Show (ResponseTrailingMetadata rpc)
       ) => IsRPC (rpc :: k) where
-  -- | Messages from the client to the server
-  type Input rpc :: Type
-
-  -- | Messages from the server to the client
-  type Output rpc :: Type
-
   -- | Content-type
   --
   -- gRPC is agnostic to the message format; the spec defines the @Content-Type@

--- a/src/Network/GRPC/Spec/RPC/Binary.hs
+++ b/src/Network/GRPC/Spec/RPC/Binary.hs
@@ -25,6 +25,9 @@ import Network.GRPC.Spec.RPC.StreamType
 -- permits).
 data BinaryRpc (serv :: Symbol) (meth :: Symbol)
 
+type instance Input  (BinaryRpc serv meth) = Lazy.ByteString
+type instance Output (BinaryRpc serv meth) = Lazy.ByteString
+
 instance ( KnownSymbol serv
          , KnownSymbol meth
 
@@ -33,9 +36,6 @@ instance ( KnownSymbol serv
          , Show (ResponseInitialMetadata (BinaryRpc serv meth))
          , Show (ResponseTrailingMetadata (BinaryRpc serv meth))
          ) => IsRPC (BinaryRpc serv meth) where
-  type Input  (BinaryRpc serv meth) = Lazy.ByteString
-  type Output (BinaryRpc serv meth) = Lazy.ByteString
-
   rpcContentType _ = defaultRpcContentType "binary"
   rpcServiceName _ = Text.pack $ symbolVal (Proxy @serv)
   rpcMethodName  _ = Text.pack $ symbolVal (Proxy @meth)

--- a/src/Network/GRPC/Spec/RPC/Protobuf.hs
+++ b/src/Network/GRPC/Spec/RPC/Protobuf.hs
@@ -28,6 +28,9 @@ import Network.GRPC.Util.Protobuf qualified as Protobuf
 -- This exists only as a type-level marker
 data Protobuf (serv :: Type) (meth :: Symbol)
 
+type instance Input  (Protobuf serv meth) = MethodInput  serv meth
+type instance Output (Protobuf serv meth) = MethodOutput serv meth
+
 instance ( HasMethodImpl      serv meth
          , Show (MethodInput  serv meth)
          , Show (MethodOutput serv meth)
@@ -37,9 +40,6 @@ instance ( HasMethodImpl      serv meth
          , Show (ResponseInitialMetadata (Protobuf serv meth))
          , Show (ResponseTrailingMetadata (Protobuf serv meth))
          ) => IsRPC (Protobuf serv meth) where
-  type Input  (Protobuf serv meth) = MethodInput  serv meth
-  type Output (Protobuf serv meth) = MethodOutput serv meth
-
   rpcContentType _ = defaultRpcContentType "proto"
   rpcServiceName _ = Text.pack $ concat [
                          symbolVal $ Proxy @(ServicePackage serv)

--- a/src/Network/GRPC/Spec/RPC/Unknown.hs
+++ b/src/Network/GRPC/Spec/RPC/Unknown.hs
@@ -26,6 +26,9 @@ import Network.GRPC.Spec.RPC
 -- by the spec.
 data UnknownRpc (serv :: Maybe Symbol) (meth :: Maybe Symbol)
 
+type instance Input  (UnknownRpc serv meth) = Void
+type instance Output (UnknownRpc serv meth) = Void
+
 type instance RequestMetadata          (UnknownRpc serv meth) = NoMetadata
 type instance ResponseInitialMetadata  (UnknownRpc serv meth) = NoMetadata
 type instance ResponseTrailingMetadata (UnknownRpc serv meth) = NoMetadata
@@ -33,9 +36,6 @@ type instance ResponseTrailingMetadata (UnknownRpc serv meth) = NoMetadata
 instance ( MaybeKnown serv
          , MaybeKnown meth
          ) => IsRPC (UnknownRpc serv meth) where
-  type Input  (UnknownRpc serv meth) = Void
-  type Output (UnknownRpc serv meth) = Void
-
   rpcContentType = const "application/grpc"
   rpcServiceName = const $ Text.pack $ maybeSymbolVal (Proxy @serv)
   rpcMethodName  = const $ Text.pack $ maybeSymbolVal (Proxy @meth)

--- a/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
@@ -92,14 +92,14 @@ instance CalculatorFunction SumChat where
   type CalcOutput SumChat = Int
   calculatorMethod _ = "sumChat"
 
+type instance Input  (Calc fun) = CalcInput  fun
+type instance Output (Calc fun) = CalcOutput fun
+
 type instance RequestMetadata          (Calc fun) = NoMetadata
 type instance ResponseInitialMetadata  (Calc fun) = NoMetadata
 type instance ResponseTrailingMetadata (Calc fun) = NoMetadata
 
 instance CalculatorFunction fun => IsRPC (Calc fun) where
-  type Input  (Calc fun) = CalcInput  fun
-  type Output (Calc fun) = CalcOutput fun
-
   rpcContentType _ = defaultRpcContentType "cbor"
   rpcMessageType _ = "cbor"
   rpcServiceName _ = "calculator"


### PR DESCRIPTION
This makes it possible to omit definitions of these type families for the `IsRPC JsonRpc` instance.