### PR TITLE
Update http2 lower bound

### DIFF
--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -194,7 +194,7 @@ library
     , exceptions           >= 0.10   && < 0.11
     , hashable             >= 1.3    && < 1.5
     , http-types           >= 0.12   && < 0.13
-    , http2                >= 5.2.3  && < 5.3
+    , http2                >= 5.2.4  && < 5.3
     , http2-tls            >= 0.2.11 && < 0.3
     , lens                 >= 5.0    && < 5.4
     , mtl                  >= 2.2    && < 2.4
@@ -339,7 +339,7 @@ test-suite test-grapesy
     , containers           >= 0.6   && < 0.8
     , exceptions           >= 0.10  && < 0.11
     , http-types           >= 0.12  && < 0.13
-    , http2                >= 5.2.3 && < 5.3
+    , http2                >= 5.2.4 && < 5.3
     , mtl                  >= 2.2   && < 2.4
     , network              >= 3.1   && < 3.3
     , proto-lens-runtime   >= 0.7   && < 0.8


### PR DESCRIPTION
The latest http2 release includes the important [http-semantics patch](https://github.com/kazu-yamamoto/http-semantics/pull/3) to avoid segfaults and the like. This updates our lower bound to that version.