### PR TITLE
Make the `grpc-message-type` header optional

### DIFF
--- a/src/Network/GRPC/Client/Connection.hs
+++ b/src/Network/GRPC/Client/Connection.hs
@@ -398,7 +398,7 @@ startRPC Connection{connMetaVar, connParams, connStateVar} _ callParams = do
         , requestContentType =
             connContentType connParams
         , requestMessageType =
-            True
+            Just MessageTypeDefault
         , requestUserAgent = Just $
             mconcat [
                 "grpc-haskell-grapesy/"

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -153,8 +153,9 @@ module Network.GRPC.Spec (
   , ParseMetadata(..)
   , StaticMetadata(..)
   , buildMetadataIO
-    -- * Content type
+    -- * Common types
   , ContentType(..)
+  , MessageType(..)
     -- * OpenTelemetry
   , TraceContext(..)
   , TraceId(..)

--- a/src/Network/GRPC/Spec/PercentEncoding.hs
+++ b/src/Network/GRPC/Spec/PercentEncoding.hs
@@ -75,7 +75,14 @@ data DecodeException =
     -- | Hex-decoding was fine, but encoded string was not valid UTF8
   | InvalidUtf8 Text.UnicodeException
   deriving stock (Show)
-  deriving anyclass (Exception)
+
+instance Exception DecodeException where
+  displayException (InvalidHexDigit w) =
+      "invalid hex digit '" ++ show w ++ "'"
+  displayException MissingHexDigits =
+      "'%' not followed by two hex digits"
+  displayException (InvalidUtf8 err) =
+      displayException err
 
 decode :: Strict.ByteString -> Either DecodeException Text
 decode =

--- a/src/Network/GRPC/Spec/RPC.hs
+++ b/src/Network/GRPC/Spec/RPC.hs
@@ -62,10 +62,6 @@ class ( -- Debug constraints
   -- 'defaultRpcContentType' can be used in the case that the format (such as
   -- @proto@) is known.
   --
-  -- See <https://grpc.io/blog/grpc-with-json/> for a discussion of gRPC with
-  -- JSON. TODO: We don't currently support this, but it should just be an
-  -- alternative 'RPC' instance.
-  --
   -- Note on terminology: throughout this codebase we avoid the terms "encoding"
   -- and "decoding", which can be ambiguous. Instead we use
   -- \"serialize\"\/\"deserialize\" and \"compress\"\/\"decompress\".
@@ -81,10 +77,11 @@ class ( -- Debug constraints
   -- For Protobuf, this is /just/ the method name (no qualifier required).
   rpcMethodName :: HasCallStack => Proxy rpc -> Text
 
-  -- | Message type
+  -- | Message type, if specified
   --
+  -- This is used to set the (optional) @grpc-message-type@ header.
   -- For Protobuf, this is the fully qualified message type.
-  rpcMessageType :: HasCallStack => Proxy rpc -> Text
+  rpcMessageType :: HasCallStack => Proxy rpc -> Maybe Text
 
 defaultRpcContentType :: Strict.ByteString -> Strict.ByteString
 defaultRpcContentType format = "application/grpc+" <> format

--- a/src/Network/GRPC/Spec/RPC/Protobuf.hs
+++ b/src/Network/GRPC/Spec/RPC/Protobuf.hs
@@ -65,7 +65,7 @@ instance ( HasMethodImpl      serv meth
                        , symbolVal $ Proxy @(ServiceName serv)
                        ]
   rpcMethodName  _ = Text.pack . symbolVal $ Proxy @(MethodName  serv meth)
-  rpcMessageType _ = messageName  $ Proxy @(MethodInput serv meth)
+  rpcMessageType _ = Just . messageName  $ Proxy @(MethodInput serv meth)
 
 instance ( IsRPC (Protobuf serv meth)
          , HasMethodImpl serv meth

--- a/src/Network/GRPC/Spec/RPC/Raw.hs
+++ b/src/Network/GRPC/Spec/RPC/Raw.hs
@@ -40,7 +40,7 @@ instance ( KnownSymbol serv
   rpcContentType _ = defaultRpcContentType "grapesy-raw"
   rpcServiceName _ = Text.pack $ symbolVal (Proxy @serv)
   rpcMethodName  _ = Text.pack $ symbolVal (Proxy @meth)
-  rpcMessageType _ = "bytestring"
+  rpcMessageType _ = Nothing
 
 instance ( IsRPC (RawRpc serv meth)
 

--- a/src/Network/GRPC/Spec/RPC/Unknown.hs
+++ b/src/Network/GRPC/Spec/RPC/Unknown.hs
@@ -36,10 +36,10 @@ type instance ResponseTrailingMetadata (UnknownRpc serv meth) = NoMetadata
 instance ( MaybeKnown serv
          , MaybeKnown meth
          ) => IsRPC (UnknownRpc serv meth) where
-  rpcContentType = const "application/grpc"
+  rpcContentType = const $ "application/grpc"
   rpcServiceName = const $ Text.pack $ maybeSymbolVal (Proxy @serv)
   rpcMethodName  = const $ Text.pack $ maybeSymbolVal (Proxy @meth)
-  rpcMessageType = const "Void"
+  rpcMessageType = const $ Nothing
 
 instance ( MaybeKnown serv
          , MaybeKnown meth

--- a/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
@@ -100,9 +100,9 @@ type instance ResponseTrailingMetadata (Calc fun) = NoMetadata
 
 instance CalculatorFunction fun => IsRPC (Calc fun) where
   rpcContentType _ = defaultRpcContentType "cbor"
-  rpcMessageType _ = "cbor"
   rpcServiceName _ = "calculator"
   rpcMethodName  _ = calculatorMethod (Proxy @fun)
+  rpcMessageType _ = Nothing
 
 instance CalculatorFunction fun => SupportsClientRpc (Calc fun) where
   rpcSerializeInput    _ = Cbor.serialise @(CalcInput  fun)


### PR DESCRIPTION
This is useful for some RPC instances (like JSON).