### PR TITLE
Make sure we can parse padded headers

### DIFF
--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -134,18 +134,18 @@ library
       Network.GRPC.Server.Session
       Network.GRPC.Spec.Base64
       Network.GRPC.Spec.Call
-      Network.GRPC.Spec.Common
       Network.GRPC.Spec.Compression
       Network.GRPC.Spec.CustomMetadata.Map
       Network.GRPC.Spec.CustomMetadata.NoMetadata
       Network.GRPC.Spec.CustomMetadata.Raw
       Network.GRPC.Spec.CustomMetadata.Typed
+      Network.GRPC.Spec.Headers.Common
+      Network.GRPC.Spec.Headers.PseudoHeaders
+      Network.GRPC.Spec.Headers.Request
+      Network.GRPC.Spec.Headers.Response
       Network.GRPC.Spec.LengthPrefixed
       Network.GRPC.Spec.OrcaLoadReport
       Network.GRPC.Spec.PercentEncoding
-      Network.GRPC.Spec.PseudoHeaders
-      Network.GRPC.Spec.Request
-      Network.GRPC.Spec.Response
       Network.GRPC.Spec.RPC
       Network.GRPC.Spec.RPC.JSON
       Network.GRPC.Spec.RPC.Protobuf

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -186,39 +186,39 @@ library
       xio
       proto
   build-depends:
-    , aeson                >= 1.5    && < 2.3
-    , async                >= 2.2    && < 2.3
-    , base16-bytestring    >= 1.0    && < 1.1
-    , base64-bytestring    >= 1.2    && < 1.3
-    , binary               >= 0.8    && < 0.9
-    , bytestring           >= 0.10   && < 0.13
-    , case-insensitive     >= 1.2    && < 1.3
-    , conduit              >= 1.3    && < 1.4
-    , containers           >= 0.6    && < 0.8
-    , data-default         >= 0.7    && < 0.8
-    , deepseq              >= 1.4    && < 1.6
-    , exceptions           >= 0.10   && < 0.11
-    , hashable             >= 1.3    && < 1.5
-    , http-types           >= 0.12   && < 0.13
-    , http2                >= 5.2.4  && < 5.3
-    , http2-tls            >= 0.2.11 && < 0.3
-    , lens                 >= 5.0    && < 5.4
-    , mtl                  >= 2.2    && < 2.4
-    , network              >= 3.1    && < 3.3
-    , network-byte-order   >= 0.1    && < 0.2
-    , network-run          >= 0.2.7  && < 0.3
-    , proto-lens           >= 0.7    && < 0.8
-    , proto-lens-runtime   >= 0.7    && < 0.8
-    , random               >= 1.2    && < 1.3
-    , record-hasfield      >= 1.0    && < 1.1
-    , stm                  >= 2.5    && < 2.6
-    , text                 >= 1.2    && < 2.2
-    , time-manager         >= 0.1    && < 0.2
-    , unbounded-delays     >= 0.1.1  && < 0.2
-    , unordered-containers >= 0.2    && < 0.3
-    , utf8-string          >= 1.0    && < 1.1
-    , vector               >= 0.13   && < 0.14
-    , zlib                 >= 0.6    && < 0.8
+    , aeson                >= 1.5     && < 2.3
+    , async                >= 2.2     && < 2.3
+    , base16-bytestring    >= 1.0     && < 1.1
+    , base64-bytestring    >= 1.2     && < 1.3
+    , binary               >= 0.8     && < 0.9
+    , bytestring           >= 0.10.12 && < 0.13
+    , case-insensitive     >= 1.2     && < 1.3
+    , conduit              >= 1.3     && < 1.4
+    , containers           >= 0.6     && < 0.8
+    , data-default         >= 0.7     && < 0.8
+    , deepseq              >= 1.4     && < 1.6
+    , exceptions           >= 0.10    && < 0.11
+    , hashable             >= 1.3     && < 1.5
+    , http-types           >= 0.12    && < 0.13
+    , http2                >= 5.2.4   && < 5.3
+    , http2-tls            >= 0.2.11  && < 0.3
+    , lens                 >= 5.0     && < 5.4
+    , mtl                  >= 2.2     && < 2.4
+    , network              >= 3.1     && < 3.3
+    , network-byte-order   >= 0.1     && < 0.2
+    , network-run          >= 0.2.7   && < 0.3
+    , proto-lens           >= 0.7     && < 0.8
+    , proto-lens-runtime   >= 0.7     && < 0.8
+    , random               >= 1.2     && < 1.3
+    , record-hasfield      >= 1.0     && < 1.1
+    , stm                  >= 2.5     && < 2.6
+    , text                 >= 1.2     && < 2.2
+    , time-manager         >= 0.1     && < 0.2
+    , unbounded-delays     >= 0.1.1   && < 0.2
+    , unordered-containers >= 0.2     && < 0.3
+    , utf8-string          >= 1.0     && < 1.1
+    , vector               >= 0.13    && < 0.14
+    , zlib                 >= 0.6     && < 0.8
 
   -- Snappy can be a bit tricky to install on some systems, so we make it an
   -- optional dependency. Snappy support can be explicitly disabled by clearing
@@ -318,6 +318,8 @@ test-suite test-grapesy
       Test.Sanity.StreamingType.NonStreaming
       Test.Util
       Test.Util.Awkward
+      Test.Util.Orphans
+      Test.Util.Protobuf
 
       -- Internals we're testing
       Network.GRPC.Util.Parser
@@ -334,27 +336,32 @@ test-suite test-grapesy
     , grapesy
   build-depends:
       -- External dependencies
-    , async                >= 2.2   && < 2.3
-    , base64-bytestring    >= 1.2   && < 1.3
-    , binary               >= 0.8   && < 0.9
-    , bytestring           >= 0.10  && < 0.13
-    , case-insensitive     >= 1.2   && < 1.3
-    , containers           >= 0.6   && < 0.8
-    , exceptions           >= 0.10  && < 0.11
-    , http-types           >= 0.12  && < 0.13
-    , http2                >= 5.2.4 && < 5.3
-    , mtl                  >= 2.2   && < 2.4
-    , network              >= 3.1   && < 3.3
-    , proto-lens-runtime   >= 0.7   && < 0.8
-    , QuickCheck           >= 2.14  && < 2.16
-    , quickcheck-instances >= 0.3   && < 0.4
-    , serialise            >= 0.2   && < 0.3
-    , stm                  >= 2.5   && < 2.6
-    , tasty                >= 1.4   && < 1.6
-    , tasty-hunit          >= 0.10  && < 0.11
-    , tasty-quickcheck     >= 0.10  && < 0.11
-    , text                 >= 1.2   && < 2.2
-    , tls                  >= 1.5   && < 2.1
+    , async                       >= 2.2   && < 2.3
+    , base64-bytestring           >= 1.2   && < 1.3
+    , binary                      >= 0.8   && < 0.9
+    , bytestring                  >= 0.10  && < 0.13
+    , case-insensitive            >= 1.2   && < 1.3
+    , containers                  >= 0.6   && < 0.8
+    , exceptions                  >= 0.10  && < 0.11
+    , http-types                  >= 0.12  && < 0.13
+    , http2                       >= 5.2.4 && < 5.3
+    , lens                        >= 5.0   && < 5.4
+    , mtl                         >= 2.2   && < 2.4
+    , network                     >= 3.1   && < 3.3
+    , prettyprinter               >= 1.7   && < 1.8
+    , prettyprinter-ansi-terminal >= 1.1   && < 1.2
+    , proto-lens                  >= 0.7   && < 0.8
+    , proto-lens-runtime          >= 0.7   && < 0.8
+    , QuickCheck                  >= 2.14  && < 2.16
+    , quickcheck-instances        >= 0.3   && < 0.4
+    , serialise                   >= 0.2   && < 0.3
+    , stm                         >= 2.5   && < 2.6
+    , tasty                       >= 1.4   && < 1.6
+    , tasty-hunit                 >= 0.10  && < 0.11
+    , tasty-quickcheck            >= 0.10  && < 0.11
+    , text                        >= 1.2   && < 2.2
+    , tls                         >= 1.5   && < 2.1
+    , tree-diff                   >= 0.3   && < 0.4
 
 executable demo-client
   import:

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -176,17 +176,17 @@ module Network.GRPC.Spec (
   ) where
 
 import Network.GRPC.Spec.Call
-import Network.GRPC.Spec.Common
 import Network.GRPC.Spec.Compression
 import Network.GRPC.Spec.CustomMetadata.Map
 import Network.GRPC.Spec.CustomMetadata.NoMetadata
 import Network.GRPC.Spec.CustomMetadata.Raw
 import Network.GRPC.Spec.CustomMetadata.Typed
+import Network.GRPC.Spec.Headers.Common
+import Network.GRPC.Spec.Headers.PseudoHeaders
+import Network.GRPC.Spec.Headers.Request
+import Network.GRPC.Spec.Headers.Response
 import Network.GRPC.Spec.LengthPrefixed
 import Network.GRPC.Spec.OrcaLoadReport
-import Network.GRPC.Spec.PseudoHeaders
-import Network.GRPC.Spec.Request
-import Network.GRPC.Spec.Response
 import Network.GRPC.Spec.RPC
 import Network.GRPC.Spec.RPC.JSON
 import Network.GRPC.Spec.RPC.Protobuf

--- a/src/Network/GRPC/Spec/Compression.hs
+++ b/src/Network/GRPC/Spec/Compression.hs
@@ -30,6 +30,7 @@ import Data.ByteString.UTF8 qualified as BS.Strict.UTF8
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.String
+import GHC.Generics (Generic)
 
 #ifdef SNAPPY
 import Codec.Compression.SnappyC.Framed qualified as Snappy
@@ -92,7 +93,7 @@ data CompressionId =
   | Deflate
   | Snappy
   | Custom String
-  deriving stock (Eq, Ord)
+  deriving stock (Eq, Ord, Generic)
 
 serializeCompressionId :: CompressionId -> Strict.ByteString
 serializeCompressionId Identity   = "identity"

--- a/src/Network/GRPC/Spec/CustomMetadata/Map.hs
+++ b/src/Network/GRPC/Spec/CustomMetadata/Map.hs
@@ -14,6 +14,7 @@ import Data.ByteString qualified as Strict (ByteString)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
+import GHC.Generics (Generic)
 
 import Network.GRPC.Spec.CustomMetadata.Raw
 
@@ -35,7 +36,7 @@ import Network.GRPC.Spec.CustomMetadata.Raw
 newtype CustomMetadataMap = CustomMetadataMap {
       getCustomMetadataMap :: Map HeaderName Strict.ByteString
     }
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
 
 {-------------------------------------------------------------------------------
   Dealing with duplicates

--- a/src/Network/GRPC/Spec/Headers/Common.hs
+++ b/src/Network/GRPC/Spec/Headers/Common.hs
@@ -14,7 +14,7 @@
 -- same.
 --
 -- Intended for unqualified import.
-module Network.GRPC.Spec.Common (
+module Network.GRPC.Spec.Headers.Common (
     -- * Content type
     ContentType(..)
   , buildContentType

--- a/src/Network/GRPC/Spec/Headers/PseudoHeaders.hs
+++ b/src/Network/GRPC/Spec/Headers/PseudoHeaders.hs
@@ -3,7 +3,7 @@
 -- | Part of the gRPC spec that maps to HTTP2 pseudo-headers
 --
 -- Intended for unqualified import.
-module Network.GRPC.Spec.PseudoHeaders (
+module Network.GRPC.Spec.Headers.PseudoHeaders (
     -- * Definition
     ServerHeaders(..)
   , ResourceHeaders(..)

--- a/src/Network/GRPC/Spec/Headers/Request.hs
+++ b/src/Network/GRPC/Spec/Headers/Request.hs
@@ -5,7 +5,7 @@
 -- Intended for qualified import.
 --
 -- > import Network.GRPC.Spec.Request qualified as Req
-module Network.GRPC.Spec.Request (
+module Network.GRPC.Spec.Headers.Request (
     -- * Inputs (message sent to the peer)
     RequestHeaders_(..)
   , RequestHeaders
@@ -28,10 +28,10 @@ import Data.Proxy
 import Network.HTTP.Types qualified as HTTP
 import Text.Read (readMaybe)
 
-import Network.GRPC.Spec.Common
 import Network.GRPC.Spec.Compression (CompressionId)
 import Network.GRPC.Spec.CustomMetadata.Map
 import Network.GRPC.Spec.CustomMetadata.Raw
+import Network.GRPC.Spec.Headers.Common
 import Network.GRPC.Spec.RPC
 import Network.GRPC.Spec.Timeout
 import Network.GRPC.Spec.TraceContext

--- a/src/Network/GRPC/Spec/Headers/Response.hs
+++ b/src/Network/GRPC/Spec/Headers/Response.hs
@@ -5,7 +5,7 @@
 -- Intended for qualified import.
 --
 -- > import Network.GRPC.Spec.Response qualified as Resp
-module Network.GRPC.Spec.Response (
+module Network.GRPC.Spec.Headers.Response (
     -- * Headers
     ResponseHeaders_(..)
   , ResponseHeaders
@@ -49,11 +49,11 @@ import GHC.Stack
 import Network.HTTP.Types qualified as HTTP
 import Text.Read (readMaybe)
 
-import Network.GRPC.Spec.Common
 import Network.GRPC.Spec.Compression (CompressionId)
 import Network.GRPC.Spec.CustomMetadata.Map
 import Network.GRPC.Spec.CustomMetadata.Raw
 import Network.GRPC.Spec.CustomMetadata.Typed
+import Network.GRPC.Spec.Headers.Common
 import Network.GRPC.Spec.OrcaLoadReport
 import Network.GRPC.Spec.PercentEncoding qualified as PercentEncoding
 import Network.GRPC.Spec.RPC

--- a/src/Network/GRPC/Spec/RPC/Unknown.hs
+++ b/src/Network/GRPC/Spec/RPC/Unknown.hs
@@ -39,7 +39,7 @@ instance ( MaybeKnown serv
   rpcContentType = const $ "application/grpc"
   rpcServiceName = const $ BS.Char8.pack $ maybeSymbolVal (Proxy @serv)
   rpcMethodName  = const $ BS.Char8.pack $ maybeSymbolVal (Proxy @meth)
-  rpcMessageType = const $ Nothing
+  rpcMessageType = const $ Just "Void"
 
 instance ( MaybeKnown serv
          , MaybeKnown meth

--- a/src/Network/GRPC/Spec/Status.hs
+++ b/src/Network/GRPC/Spec/Status.hs
@@ -7,6 +7,7 @@ module Network.GRPC.Spec.Status (
   ) where
 
 import Control.Exception
+import GHC.Generics (Generic)
 
 {-------------------------------------------------------------------------------
   gRPC status
@@ -18,7 +19,7 @@ import Control.Exception
 data GrpcStatus =
     GrpcOk
   | GrpcError GrpcError
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
 
 -- | gRPC error code
 --
@@ -166,7 +167,7 @@ data GrpcError =
     -- The request does not have valid authentication credentials for the
     -- operation.
   | GrpcUnauthenticated
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
   deriving anyclass (Exception)
 
 fromGrpcStatus :: GrpcStatus -> Word

--- a/src/Network/GRPC/Spec/Timeout.hs
+++ b/src/Network/GRPC/Spec/Timeout.hs
@@ -18,6 +18,7 @@ import Data.ByteString qualified as BS.Strict
 import Data.ByteString qualified as Strict (ByteString)
 import Data.ByteString.Char8 qualified as BS.Strict.C8
 import Data.Char (isDigit)
+import GHC.Generics (Generic)
 import GHC.Show
 
 {-------------------------------------------------------------------------------
@@ -25,13 +26,14 @@ import GHC.Show
 -------------------------------------------------------------------------------}
 
 data Timeout = Timeout TimeoutUnit TimeoutValue
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
 
 -- | Positive integer with ASCII representation of at most 8 digits
 newtype TimeoutValue = UnsafeTimeoutValue {
       getTimeoutValue :: Word
     }
   deriving newtype (Eq)
+  deriving stock (Generic)
 
 -- | 'Show' instance relies on the 'TimeoutValue' pattern synonym
 instance Show TimeoutValue where
@@ -58,7 +60,7 @@ data TimeoutUnit =
   | Millisecond
   | Microsecond
   | Nanosecond
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
 
 {-------------------------------------------------------------------------------
   Translation

--- a/src/Network/GRPC/Spec/TraceContext.hs
+++ b/src/Network/GRPC/Spec/TraceContext.hs
@@ -26,6 +26,7 @@ import Data.Default
 import Data.Maybe (maybeToList)
 import Data.String
 import Data.Word
+import GHC.Generics (Generic)
 
 {-------------------------------------------------------------------------------
   Definition
@@ -67,7 +68,7 @@ data TraceContext = TraceContext {
     , traceContextSpanId   :: Maybe SpanId
     , traceContextOptions  :: Maybe TraceOptions
     }
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
 
 instance Default TraceContext where
   def = TraceContext {
@@ -82,7 +83,7 @@ instance Default TraceContext where
 newtype TraceId = TraceId {
       getTraceId :: Strict.ByteString
     }
-  deriving stock (Eq)
+  deriving stock (Eq, Generic)
 
 -- | Span ID
 --
@@ -90,7 +91,7 @@ newtype TraceId = TraceId {
 newtype SpanId = SpanId {
       getSpanId :: Strict.ByteString
     }
-  deriving stock (Eq)
+  deriving stock (Eq, Generic)
 
 -- | Tracing options
 --
@@ -108,7 +109,7 @@ data TraceOptions = TraceOptions {
       -- unset, the caller did not record trace data out-of-band.
       traceOptionsSampled :: Bool
     }
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Generic)
 
 {-------------------------------------------------------------------------------
   Show instances for IDs

--- a/test-grapesy/Test/Prop/Serialization.hs
+++ b/test-grapesy/Test/Prop/Serialization.hs
@@ -18,8 +18,14 @@ import Data.Char (isSpace)
 import Data.Function (on)
 import Data.List (nubBy, uncons, intersperse)
 import Data.Maybe (mapMaybe)
+import Data.Text.Lazy qualified as Text.Lazy
+import Data.TreeDiff (ToExpr, ediff, ansiWlEditExpr)
 import Data.Void (Void)
 import Network.HTTP.Types qualified as HTTP
+import Prettyprinter (Doc)
+import Prettyprinter qualified as PP
+import Prettyprinter.Render.Terminal (AnsiStyle)
+import Prettyprinter.Render.Terminal qualified as PP.Ansi
 import Test.Tasty hiding (Timeout)
 import Test.Tasty.QuickCheck
 
@@ -29,6 +35,7 @@ import Network.GRPC.Common.Protobuf
 import Network.GRPC.Spec
 
 import Test.Util.Awkward
+import Test.Util.Orphans ()
 
 tests :: TestTree
 tests = testGroup "Test.Prop.Serialization" [
@@ -86,6 +93,28 @@ tests = testGroup "Test.Prop.Serialization" [
               (showIntermediate .*. labelDups)
               (introduceDups dups . buildTrailersOnly unknown)
               (                     parseTrailersOnly unknown)
+        ]
+    , testGroup "Padding" [
+          testProperty "RequestHeaders" $ \padding ->
+            roundtripWith
+              (showIntermediate .*. labelPadding)
+              (introducePadding padding . buildRequestHeaders unknown)
+              (                           parseRequestHeaders unknown)
+        , testProperty "ResponseHeaders" $ \padding ->
+            roundtripWith
+              (showIntermediate .*. labelPadding)
+              (introducePadding padding . buildResponseHeaders unknown)
+              (                           parseResponseHeaders unknown)
+        , testProperty "ProperTrailers" $ \padding ->
+            roundtripWith
+              (showIntermediate .*. labelPadding)
+              (introducePadding padding . buildProperTrailers)
+              (                           parseProperTrailers unknown)
+        , testProperty "TrailersOnly" $ \padding ->
+            roundtripWith
+              (showIntermediate .*. labelPadding)
+              (introducePadding padding . buildTrailersOnly unknown)
+              (                           parseTrailersOnly unknown)
         ]
     ]
   where
@@ -232,21 +261,29 @@ labelDups (_a, headers) =
 -------------------------------------------------------------------------------}
 
 roundtrip :: forall e a b.
-     (Eq a, Eq e, Show a, Show b, Show e)
+     (Eq a, ToExpr a, Show b, Show e)
   => (a -> b)             -- ^ There
   -> (b -> Except e a)    -- ^ and back again
   -> Awkward a -> Property
 roundtrip = roundtripWith showIntermediate
 
 roundtripWith :: forall e a b.
-     (Eq a, Eq e, Show a, Show e)
+     (Eq a, ToExpr a, Show e)
   => ((a, b) -> Property -> Property) -- ^ Statistics, metadata, ..
   -> (a -> b)             -- ^ There
   -> (b -> Except e a)    -- ^ and back again
   -> Awkward a -> Property
 roundtripWith modProp there back (Awkward a) =
     modProp (a, b) $
-       runExcept (back b) === Right a
+      let ma' = runExcept (back b)
+      in case ma' of
+           Left err ->
+                 counterexample (show err) False
+           Right a'
+             | a == a' ->
+                 property True
+             | otherwise ->
+                 counterexample (renderDoc $ ansiWlEditExpr $ ediff a a') False
    where
      b :: b
      b = there a
@@ -259,6 +296,74 @@ showIntermediate (_, b) = counterexample (show b)
   -> ((a, b) -> Property -> Property)
   -> ((a, b) -> Property -> Property)
 (.*.) f g (a, b) = f (a, b) . g (a, b)
+
+{-------------------------------------------------------------------------------
+  Padding
+-------------------------------------------------------------------------------}
+
+newtype Padding = Padding {
+      getPadding :: Strict.ByteString
+    }
+  deriving Show
+
+instance Arbitrary Padding where
+  arbitrary = do
+      n <- choose (0, 5)
+      Padding . BS.Strict.Char8.pack <$> replicateM n (elements " \t")
+  shrink =
+        map (Padding . BS.Strict.pack)
+      . shrinkList (const []) -- only remove elements from the list
+      . BS.Strict.unpack
+      . getPadding
+
+newtype PaddingPerHeader = PaddingPerHeader {
+      -- | Left and right padding for each header
+      getPaddingPerHeader :: [(Padding, Padding)]
+    }
+  deriving stock (Show)
+
+instance Arbitrary PaddingPerHeader where
+  arbitrary = sized $ \sz -> do
+      n      <- choose (0, sz)
+      PaddingPerHeader <$> replicateM n genPadding
+    where
+      -- Most of the time, no padding
+      genPadding :: Gen (Padding, Padding)
+      genPadding = frequency [
+          (7, (,) <$> pure (Padding "") <*> pure (Padding ""))
+        , (1, (,) <$> arbitrary         <*> pure (Padding ""))
+        , (1, (,) <$> pure (Padding "") <*> arbitrary)
+        , (1, (,) <$> arbitrary         <*> arbitrary)
+        ]
+
+
+  shrink =
+        map PaddingPerHeader
+      . shrinkList shrink
+      . getPaddingPerHeader
+
+introducePadding :: PaddingPerHeader -> [HTTP.Header] -> [HTTP.Header]
+introducePadding = \(PaddingPerHeader padding) ->
+    flip evalState padding . mapM go
+  where
+    go :: HTTP.Header -> State [(Padding, Padding)] HTTP.Header
+    go (name, value) = state $ \case
+      [] ->
+        ((name, value), [])
+      (l, r) : padding' ->
+        ((name, getPadding l <> value <> getPadding r), padding')
+
+labelPadding :: (a, [HTTP.Header]) -> Property -> Property
+labelPadding (_a, headers) =
+    tabulate "has padding" [
+        show $ any (hasPadding . snd) headers
+      ]
+  where
+    hasPadding :: Strict.ByteString -> Bool
+    hasPadding bs = or [
+          not . BS.Strict.null $ BS.Strict.Char8.takeWhile    isSpace bs
+        , not . BS.Strict.null $ BS.Strict.Char8.takeWhileEnd isSpace bs
+        ]
 
 {-------------------------------------------------------------------------------
   Arbitrary instances
@@ -539,7 +644,7 @@ instance Arbitrary (Awkward OrcaLoadReport) where
           & #applicationUtilization .~ applicationUtilization
 
 {-------------------------------------------------------------------------------
-  Auxiliary
+  Generating valid values
 -------------------------------------------------------------------------------}
 
 validCompressionId :: String -> Maybe String
@@ -570,3 +675,18 @@ validFormat format =
 validMessageType :: Strict.ByteString -> Bool
 validMessageType "Void" = False -- Would be parsed as @MessageTypeDefault@
 validMessageType _      = True
+
+{-------------------------------------------------------------------------------
+  Auxiliary
+-------------------------------------------------------------------------------}
+
+renderDoc :: Doc AnsiStyle -> String
+renderDoc =
+      Text.Lazy.unpack
+    . PP.Ansi.renderLazy
+    . resetTerminal
+    . PP.layoutPretty PP.defaultLayoutOptions
+  where
+    -- Reset the vivid red from tasty
+    resetTerminal :: PP.SimpleDocStream AnsiStyle -> PP.SimpleDocStream AnsiStyle
+    resetTerminal = PP.SAnnPush $ PP.Ansi.color PP.Ansi.Black

--- a/test-grapesy/Test/Util/Orphans.hs
+++ b/test-grapesy/Test/Util/Orphans.hs
@@ -1,0 +1,42 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Util.Orphans () where
+
+import Data.CaseInsensitive
+import Data.TreeDiff
+
+import Network.GRPC.Spec
+
+import Test.Util.Protobuf
+
+{-------------------------------------------------------------------------------
+  ToExpr (tree-diff)
+-------------------------------------------------------------------------------}
+
+instance ToExpr a => ToExpr (CI a) where
+  toExpr = toExpr . foldedCase
+
+instance ToExpr OrcaLoadReport where
+  toExpr = messageToExpr
+
+deriving anyclass instance ToExpr CompressionId
+deriving anyclass instance ToExpr ContentType
+deriving anyclass instance ToExpr CustomMetadata
+deriving anyclass instance ToExpr CustomMetadataMap
+deriving anyclass instance ToExpr GrpcError
+deriving anyclass instance ToExpr GrpcStatus
+deriving anyclass instance ToExpr HeaderName
+deriving anyclass instance ToExpr MessageType
+deriving anyclass instance ToExpr ProperTrailers
+deriving anyclass instance ToExpr Pushback
+deriving anyclass instance ToExpr RequestHeaders
+deriving anyclass instance ToExpr ResponseHeaders
+deriving anyclass instance ToExpr SpanId
+deriving anyclass instance ToExpr Timeout
+deriving anyclass instance ToExpr TimeoutUnit
+deriving anyclass instance ToExpr TimeoutValue
+deriving anyclass instance ToExpr TraceContext
+deriving anyclass instance ToExpr TraceId
+deriving anyclass instance ToExpr TraceOptions
+deriving anyclass instance ToExpr TrailersOnly
+

--- a/test-grapesy/Test/Util/Protobuf.hs
+++ b/test-grapesy/Test/Util/Protobuf.hs
@@ -1,0 +1,84 @@
+-- | Utilities for working with Protobuf messages
+module Test.Util.Protobuf (
+    messageToExpr
+  ) where
+
+import Data.ProtoLens.Message
+import Data.Proxy
+import Data.Text qualified as Text
+import Data.TreeDiff
+import Data.TreeDiff.OMap qualified as OMap
+import Control.Lens ((^.), Lens', (.~))
+import Data.Map qualified as Map
+import Data.Function ((&))
+import Data.ProtoLens.Encoding.Wire
+
+{-------------------------------------------------------------------------------
+  TreeDiff
+-------------------------------------------------------------------------------}
+
+messageToExpr :: forall msg. Message msg => msg -> Expr
+messageToExpr =
+      Rec (Text.unpack $ messageName (Proxy @msg))
+    . OMap.fromList
+    . fields
+
+fields :: Message msg => msg -> [(FieldName, Expr)]
+fields msg = concat [
+      map (knownField msg) allFields
+    , map unknownField (msg ^. unknownFields)
+    ]
+
+knownField :: msg -> FieldDescriptor msg -> (FieldName, Expr)
+knownField msg (FieldDescriptor name typ acc) = (
+      name
+    , case acc of
+        PlainField _    f ->          plainField typ  $  msg ^. f
+        OptionalField   f -> toExpr $ plainField typ <$> msg ^. f
+        RepeatedField _ f -> toExpr $ plainField typ <$> msg ^. f
+        MapField    k v f -> toExpr $
+          (messageToExpr . pairToMsg k v) <$> Map.toList (msg ^. f)
+    )
+
+plainField :: FieldTypeDescriptor value -> value -> Expr
+plainField (MessageField _)  = messageToExpr
+plainField (ScalarField typ) = scalarField typ
+
+scalarField :: ScalarField value -> value -> Expr
+scalarField EnumField     = enumField
+scalarField Int32Field    = toExpr
+scalarField Int64Field    = toExpr
+scalarField UInt32Field   = toExpr
+scalarField UInt64Field   = toExpr
+scalarField SInt32Field   = toExpr
+scalarField SInt64Field   = toExpr
+scalarField Fixed32Field  = toExpr
+scalarField Fixed64Field  = toExpr
+scalarField SFixed32Field = toExpr
+scalarField SFixed64Field = toExpr
+scalarField FloatField    = toExpr
+scalarField DoubleField   = toExpr
+scalarField BoolField     = toExpr
+scalarField StringField   = toExpr
+scalarField BytesField    = toExpr
+
+enumField :: MessageEnum value => value -> Expr
+enumField = toExpr . fromEnum
+
+unknownField :: TaggedValue -> (FieldName, Expr)
+unknownField (TaggedValue (Tag tag) value) = (show tag, wireValue value)
+
+wireValue :: WireValue -> Expr
+wireValue (Fixed32 x) = toExpr x
+wireValue (Fixed64 x) = toExpr x
+wireValue (Lengthy x) = toExpr x
+wireValue (VarInt x)  = toExpr x
+wireValue StartGroup  = toExpr ()
+wireValue EndGroup    = toExpr ()
+
+{-------------------------------------------------------------------------------
+  Auxiliary: working with maps
+-------------------------------------------------------------------------------}
+
+pairToMsg :: Message msg => Lens' msg k -> Lens' msg v -> (k, v) -> msg
+pairToMsg k v (x, y) = defMessage & k .~ x & v .~ y


### PR DESCRIPTION
The [gRPC spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) explicitly says about the values of headers:

> Implementations MUST accept padded and un-padded values and should emit un-padded values

We now do this (and test that we do).