### PR TITLE
More lenient RequestHeaders parsing

### DIFF
--- a/interop/Interop/Server.hs
+++ b/interop/Interop/Server.hs
@@ -94,7 +94,8 @@ withInteropServer cmdline k = do
 
     serverParams :: ServerParams
     serverParams = def {
-          serverTopLevel = swallowExceptions
+          serverTopLevel      = swallowExceptions
+        , serverVerifyHeaders = True
         }
 
     -- Don't show handler exceptions on stderr

--- a/src/Network/GRPC/Client/Connection.hs
+++ b/src/Network/GRPC/Client/Connection.hs
@@ -412,6 +412,8 @@ startRPC Connection{connMetaVar, connParams, connStateVar} _ callParams = do
             Nothing
         , requestPreviousRpcAttempts =
             Nothing
+        , requestUnrecognized =
+            ()
         }
 
     callSession :: ClientSession rpc

--- a/src/Network/GRPC/Server/Context.hs
+++ b/src/Network/GRPC/Server/Context.hs
@@ -76,6 +76,13 @@ data ServerParams = ServerParams {
       -- Set to 'Nothing' to omit the content-type header completely
       -- (this is not conform the gRPC spec).
     , serverContentType :: Maybe ContentType
+
+      -- | Verify that all request headers can be parsed
+      --
+      -- When enabled, we verify at the start of each request that all request
+      -- headers are valid. By default we do /not/ do this, throwing an error
+      -- only in scenarios where we really cannot continue.
+    , serverVerifyHeaders :: Bool
     }
 
 instance Default ServerParams where
@@ -84,6 +91,7 @@ instance Default ServerParams where
       , serverTopLevel          = defaultServerTopLevel
       , serverExceptionToClient = defaultServerExceptionToClient
       , serverContentType       = Just ContentTypeDefault
+      , serverVerifyHeaders     = False
       }
 
 defaultServerTopLevel ::

--- a/src/Network/GRPC/Spec.hs
+++ b/src/Network/GRPC/Spec.hs
@@ -60,6 +60,8 @@ module Network.GRPC.Spec (
     -- * Compression
   , CompressionId(..)
   , Compression(..)
+  , serializeCompressionId
+  , deserializeCompressionId
     -- ** Compression algorithms
   , noCompression
   , gzip
@@ -71,6 +73,9 @@ module Network.GRPC.Spec (
     -- * Requests
   , RequestHeaders_(..)
   , RequestHeaders
+  , RequestHeaders'
+  , InvalidRequestHeaders(..)
+  , prettyInvalidRequestHeaders
     -- ** Parameters
   , CallParams(..)
     -- ** Pseudo-headers
@@ -90,6 +95,7 @@ module Network.GRPC.Spec (
     -- ** Headers
   , buildRequestHeaders
   , parseRequestHeaders
+  , parseRequestHeaders'
     -- ** Timeouts
   , Timeout(..)
   , TimeoutValue(..)

--- a/test-grapesy/Test/Driver/ClientServer.hs
+++ b/test-grapesy/Test/Driver/ClientServer.hs
@@ -484,6 +484,10 @@ withTestServer cfg firstTestFailure handlerLock serverHandlers k = do
                   NoOverride            -> Nothing
                   ValidOverride   ctype -> Just ctype
                   InvalidOverride ctype -> Just ctype
+            , Server.serverVerifyHeaders =
+                -- We want to check that we can spot invalid headers
+                -- (and that we don't generate any in the client)
+                True
             }
 
     server <- Server.mkGrpcServer serverParams serverHandlers

--- a/test-grapesy/Test/Prop/Serialization.hs
+++ b/test-grapesy/Test/Prop/Serialization.hs
@@ -398,7 +398,6 @@ instance Arbitrary (Awkward CustomMetadataMap) where
 instance Arbitrary (Awkward RequestHeaders) where
   arbitrary = Awkward <$> do
       requestTimeout             <- awkward
-      requestMetadata            <- awkward
       requestCompression         <- awkward
       requestAcceptCompression   <- awkward
       requestContentType         <- awkward
@@ -407,9 +406,9 @@ instance Arbitrary (Awkward RequestHeaders) where
       requestIncludeTE           <- arbitrary
       requestTraceContext        <- awkward
       requestPreviousRpcAttempts <- awkward
+      requestMetadata            <- awkward
       return $ RequestHeaders{
           requestTimeout
-        , requestMetadata
         , requestCompression
         , requestAcceptCompression
         , requestContentType
@@ -418,10 +417,11 @@ instance Arbitrary (Awkward RequestHeaders) where
         , requestIncludeTE
         , requestTraceContext
         , requestPreviousRpcAttempts
+        , requestMetadata
+        , requestUnrecognized = ()
         }
   shrink h@(Awkward h') = concat [
         shrinkAwkward (\x -> h'{requestTimeout             = x}) requestTimeout             h
-      , shrinkAwkward (\x -> h'{requestMetadata            = x}) requestMetadata            h
       , shrinkAwkward (\x -> h'{requestCompression         = x}) requestCompression         h
       , shrinkAwkward (\x -> h'{requestAcceptCompression   = x}) requestAcceptCompression   h
       , shrinkAwkward (\x -> h'{requestContentType         = x}) requestContentType         h
@@ -430,6 +430,7 @@ instance Arbitrary (Awkward RequestHeaders) where
       , shrinkRegular (\x -> h'{requestIncludeTE           = x}) requestIncludeTE           h
       , shrinkAwkward (\x -> h'{requestTraceContext        = x}) requestTraceContext        h
       , shrinkAwkward (\x -> h'{requestPreviousRpcAttempts = x}) requestPreviousRpcAttempts h
+      , shrinkAwkward (\x -> h'{requestMetadata            = x}) requestMetadata            h
       ]
 
 instance Arbitrary (Awkward ResponseHeaders) where


### PR DESCRIPTION
We still need to do the same for the response headers (and trailers).