### PR TITLE
Allow setting number of worker threads and other HTTP/2 setting params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ dist-newstyle
 .envrc
 *.swp
 *.pcapng
-cabal.project.local
+*.local
 *.eventlog
 *.eventlog.html
 *.hp

--- a/demo-server/Main.hs
+++ b/demo-server/Main.hs
@@ -6,7 +6,6 @@ import Data.Aeson
 
 import Network.GRPC.Common
 import Network.GRPC.Common.Compression qualified as Compression
-import Network.GRPC.Common.HTTP2Settings (defaultHTTP2Settings)
 import Network.GRPC.Common.Protobuf
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
@@ -54,15 +53,13 @@ main = do
 
     let serverConfig :: ServerConfig
         serverConfig = ServerConfig {
-            serverInsecure                = cmdInsecure cmdline
-          , serverSecure                  = cmdSecure cmdline
-          , serverOverrideNumberOfWorkers = Nothing
-          , serverHTTP2Settings           = defaultHTTP2Settings
+            serverInsecure = cmdInsecure cmdline
+          , serverSecure   = cmdSecure cmdline
           }
 
     runServerWithHandlers
-      serverConfig
       (serverParams cmdline)
+      serverConfig
       (fromServices $ services cmdline db)
 
 getRouteGuideDb :: IO [Proto Feature]

--- a/demo-server/Main.hs
+++ b/demo-server/Main.hs
@@ -6,6 +6,7 @@ import Data.Aeson
 
 import Network.GRPC.Common
 import Network.GRPC.Common.Compression qualified as Compression
+import Network.GRPC.Common.HTTP2Settings (defaultHTTP2Settings)
 import Network.GRPC.Common.Protobuf
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
@@ -53,8 +54,10 @@ main = do
 
     let serverConfig :: ServerConfig
         serverConfig = ServerConfig {
-            serverInsecure = cmdInsecure cmdline
-          , serverSecure   = cmdSecure cmdline
+            serverInsecure                = cmdInsecure cmdline
+          , serverSecure                  = cmdSecure cmdline
+          , serverOverrideNumberOfWorkers = Nothing
+          , serverHTTP2Settings           = defaultHTTP2Settings
           }
 
     runServerWithHandlers

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -111,6 +111,7 @@ library
       Network.GRPC.Common.Protobuf
       Network.GRPC.Common.StreamElem
       Network.GRPC.Common.StreamType
+      Network.GRPC.Common.HTTP2Settings
       Network.GRPC.Internal.XIO
       Network.GRPC.Server
       Network.GRPC.Server.Binary

--- a/interop/Interop/Server.hs
+++ b/interop/Interop/Server.hs
@@ -7,6 +7,7 @@ import Control.Exception (SomeException)
 import Control.Monad.Catch (generalBracket, ExitCase(..))
 
 import Network.GRPC.Common
+import Network.GRPC.Common.HTTP2Settings (defaultHTTP2Settings)
 import Network.GRPC.Internal.XIO qualified as XIO
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
@@ -72,8 +73,7 @@ withInteropServer cmdline k = do
     serverConfig
       | cmdUseTLS cmdline
       = ServerConfig {
-            serverInsecure = Nothing
-          , serverSecure   = Just SecureConfig {
+            serverSecure = Just SecureConfig {
                 secureHost       = "0.0.0.0"
               , securePort       = cmdPort cmdline
               , securePubCert    = cmdPubCert cmdline
@@ -81,15 +81,20 @@ withInteropServer cmdline k = do
               , securePrivKey    = cmdPrivKey cmdline
               , secureSslKeyLog  = cmdSslKeyLog cmdline
               }
+          , serverInsecure                = Nothing
+          , serverOverrideNumberOfWorkers = Nothing
+          , serverHTTP2Settings           = defaultHTTP2Settings
           }
 
      | otherwise
      = ServerConfig {
-            serverSecure   = Nothing
-          , serverInsecure = Just InsecureConfig {
+            serverInsecure = Just InsecureConfig {
                 insecureHost = Nothing
               , insecurePort = cmdPort cmdline
               }
+          , serverSecure                  = Nothing
+          , serverOverrideNumberOfWorkers = Nothing
+          , serverHTTP2Settings           = defaultHTTP2Settings
           }
 
     serverParams :: ServerParams

--- a/kvstore/KVStore/Server.hs
+++ b/kvstore/KVStore/Server.hs
@@ -5,7 +5,6 @@ import Control.Monad
 
 import Network.GRPC.Common
 import Network.GRPC.Common.Compression qualified as Compr
-import Network.GRPC.Common.HTTP2Settings (defaultHTTP2Settings)
 import Network.GRPC.Server
 import Network.GRPC.Server.Run
 
@@ -30,14 +29,12 @@ withKeyValueServer cmdline@Cmdline{cmdJSON} k = do
           | otherwise = Protobuf.server $ handlers cmdline store
 
     server <- mkGrpcServer params rpcHandlers
-    forkServer config server k
+    forkServer params config server k
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure                = Just $ InsecureConfig Nothing defaultInsecurePort
-        , serverSecure                  = Nothing
-        , serverOverrideNumberOfWorkers = Nothing
-        , serverHTTP2Settings           = defaultHTTP2Settings
+          serverInsecure = Just $ InsecureConfig Nothing defaultInsecurePort
+        , serverSecure   = Nothing
         }
 
     params :: ServerParams

--- a/kvstore/KVStore/Server.hs
+++ b/kvstore/KVStore/Server.hs
@@ -5,6 +5,7 @@ import Control.Monad
 
 import Network.GRPC.Common
 import Network.GRPC.Common.Compression qualified as Compr
+import Network.GRPC.Common.HTTP2Settings (defaultHTTP2Settings)
 import Network.GRPC.Server
 import Network.GRPC.Server.Run
 
@@ -33,8 +34,10 @@ withKeyValueServer cmdline@Cmdline{cmdJSON} k = do
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure = Just $ InsecureConfig Nothing defaultInsecurePort
-        , serverSecure   = Nothing
+          serverInsecure                = Just $ InsecureConfig Nothing defaultInsecurePort
+        , serverSecure                  = Nothing
+        , serverOverrideNumberOfWorkers = Nothing
+        , serverHTTP2Settings           = defaultHTTP2Settings
         }
 
     params :: ServerParams

--- a/src/Network/GRPC/Common.hs
+++ b/src/Network/GRPC/Common.hs
@@ -41,9 +41,13 @@ module Network.GRPC.Common (
     -- * Configuration
   , SslKeyLog(..)
 
+  -- * HTTP\/2 Settings
+  , HTTP2Settings(..)
+
     -- * Defaults
   , defaultInsecurePort
   , defaultSecurePort
+  , defaultHTTP2Settings
 
     -- * Exceptions
 
@@ -74,6 +78,7 @@ import Network.Socket (PortNumber)
 
 import Control.Exception
 
+import Network.GRPC.Common.HTTP2Settings
 import Network.GRPC.Common.NextElem (NextElem(..))
 import Network.GRPC.Common.StreamElem (StreamElem(..))
 import Network.GRPC.Spec

--- a/src/Network/GRPC/Common/HTTP2Settings.hs
+++ b/src/Network/GRPC/Common/HTTP2Settings.hs
@@ -29,12 +29,13 @@ data HTTP2Settings = HTTP2Settings {
       --
       -- If the consumed window space of all streams exceeds this value, the
       -- sender will stop sending data. Therefore, if this value is less than
-      -- @'http2MaxConcurrentStreams' * 'http2StreamWindowSize'@, there
-      -- is risk of a control flow deadlock, since the connection window space
-      -- may be used up by streams that we are not yet processing before we have
+      -- @'http2MaxConcurrentStreams' * 'http2StreamWindowSize'@, there is risk
+      -- of a control flow deadlock, since the connection window space may be
+      -- used up by streams that we are not yet processing before we have
       -- received all data on the streams that we /are/ processing. To reduce
-      -- this risk, increase 'Network.GRPC.Server.Run.serverOverrideNumberOfWorkers'. See
-      -- <https://github.com/kazu-yamamoto/network-control/pull/4> for more
+      -- this risk, increase
+      -- 'Network.GRPC.Server.Run.serverOverrideNumberOfWorkers' for the server.
+      -- See <https://github.com/kazu-yamamoto/network-control/pull/4> for more
       -- information.
     , http2ConnectionWindowSize :: Word32
 

--- a/src/Network/GRPC/Common/HTTP2Settings.hs
+++ b/src/Network/GRPC/Common/HTTP2Settings.hs
@@ -1,0 +1,90 @@
+-- | Settings and parameters pertaining to HTTP\/2
+--
+-- Intended for unqualified import.
+
+module Network.GRPC.Common.HTTP2Settings
+  ( HTTP2Settings(..)
+  , defaultHTTP2Settings
+  ) where
+
+import Data.Default
+import Data.Word
+
+-- | HTTP\/2 settings
+data HTTP2Settings = HTTP2Settings {
+      -- | Maximum number of concurrent active streams
+      --
+      -- <https://datatracker.ietf.org/doc/html/rfc7540#section-5.1.2>
+      http2MaxConcurrentStreams :: Word32
+
+      -- | Window size for streams
+      --
+      -- <https://datatracker.ietf.org/doc/html/rfc7540#section-6.9.2>
+    , http2StreamWindowSize :: Word32
+
+      -- | Connection window size
+      --
+      -- This value is broadcast via a @WINDOW_UDPATE@ frame at the beginning of
+      -- a new connection.
+      --
+      -- If the consumed window space of all streams exceeds this value, the
+      -- sender will stop sending data. Therefore, if this value is less than
+      -- @'http2MaxConcurrentStreams' * 'http2StreamWindowSize'@, there
+      -- is risk of a control flow deadlock, since the connection window space
+      -- may be used up by streams that we are not yet processing before we have
+      -- received all data on the streams that we /are/ processing. To reduce
+      -- this risk, increase 'Network.GRPC.Server.Run.serverOverrideNumberOfWorkers'. See
+      -- <https://github.com/kazu-yamamoto/network-control/pull/4> for more
+      -- information.
+    , http2ConnectionWindowSize :: Word32
+
+      -- | Ping rate limit
+      --
+      -- This setting is specific to the [@http2@
+      -- package's](https://hackage.haskell.org/package/http2) implementation of
+      -- the HTTP\/2 specification. In particular, the library imposes a ping
+      -- rate limit as a security measure against
+      -- [CVE-2019-9512](https://www.cve.org/CVERecord?id=CVE-2019-9512). By
+      -- default (as of version 5.1.2) it sets this limit at 10 pings/second. If
+      -- you find yourself being disconnected from a gRPC peer because that peer
+      -- is sending too many pings (you will see an
+      -- [EnhanceYourCalm](https://hackage.haskell.org/package/http2-5.1.2/docs/Network-HTTP2-Client.html#t:ErrorCode)
+      -- exception, corresponding to the
+      -- [ENHANCE_YOUR_CALM](https://www.rfc-editor.org/rfc/rfc9113#ErrorCodes)
+      -- HTTP\/2 error code), you may wish to increase this limit. If you are
+      -- connecting to a peer that you trust, you can set this limit to
+      -- 'maxBound' (effectively turning off protecting against ping flooding).
+    , http2OverridePingRateLimit :: Maybe Int
+    }
+  deriving (Show)
+
+-- | Default HTTP\/2 settings
+--
+-- [Section 6.5.2 of the HTTP\/2
+-- specification](https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2)
+-- recommends that the @SETTINGS_MAX_CONCURRENT_STREAMS@ parameter be no smaller
+-- than 100 "so as not to unnecessarily limit parallelism", so we default to
+-- 128.
+--
+-- The default initial stream window size (corresponding to the
+-- @SETTINGS_INITIAL_WINDOW_SIZE@ HTTP\/2 parameter) is 64KB.
+--
+-- The default connection window size is 128 * 64KB to avoid the control flow
+-- deadlock discussed at 'http2ConnectionWindowSize'.
+--
+-- The ping rate limit imposed by the [@http2@
+-- package](https://hackage.haskell.org/package/http2) is not overridden by
+-- default.
+defaultHTTP2Settings :: HTTP2Settings
+defaultHTTP2Settings = HTTP2Settings {
+      http2MaxConcurrentStreams  = defMaxConcurrentStreams
+    , http2StreamWindowSize      = defInitialStreamWindowSize
+    , http2ConnectionWindowSize  = defMaxConcurrentStreams * defInitialStreamWindowSize
+    , http2OverridePingRateLimit = Nothing
+    }
+  where
+    defMaxConcurrentStreams    = 128
+    defInitialStreamWindowSize = 1024 * 64
+
+instance Default HTTP2Settings where
+  def = defaultHTTP2Settings

--- a/src/Network/GRPC/Server.hs
+++ b/src/Network/GRPC/Server.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Network.GRPC.Server (
     -- * Server proper
     mkGrpcServer

--- a/src/Network/GRPC/Server/Context.hs
+++ b/src/Network/GRPC/Server/Context.hs
@@ -91,7 +91,7 @@ data ServerParams = ServerParams {
       -- This setting is specific to the
       -- [http2](https://hackage.haskell.org/package/http2) package's
       -- implementation of the HTTP\/2 specification for servers. Set to
-      -- 'Nothing' to use the default of 8 worker threads.
+      -- 'Nothing' if you don't want to override the default.
       --
       -- __Note__: If a lower 'http2ConnectionWindowSize' is desired, the
       -- number of workers should be increased to avoid a potential HTTP\/2

--- a/src/Network/GRPC/Server/Run.hs
+++ b/src/Network/GRPC/Server/Run.hs
@@ -290,7 +290,9 @@ runInsecure ServerParams{serverOverrideNumberOfWorkers, serverHTTP2Settings} cfg
     serverConfig :: HTTP2.ServerConfig
     serverConfig = HTTP2.defaultServerConfig {
           HTTP2.numberOfWorkers =
-              fromIntegral $ fromMaybe 8 serverOverrideNumberOfWorkers
+              fromMaybe
+                (HTTP2.numberOfWorkers HTTP2.defaultServerConfig)
+                (fromIntegral <$> serverOverrideNumberOfWorkers)
         , HTTP2.connectionWindowSize =
               fromIntegral $ http2ConnectionWindowSize serverHTTP2Settings
         , HTTP2.settings =
@@ -329,7 +331,9 @@ runSecure ServerParams{serverOverrideNumberOfWorkers, serverHTTP2Settings} cfg s
             , HTTP2.TLS.settingsTimeout =
                 disableTimeout
             , HTTP2.TLS.settingsNumberOfWorkers =
-                fromIntegral $ fromMaybe 8 serverOverrideNumberOfWorkers
+                fromMaybe
+                  (HTTP2.TLS.settingsNumberOfWorkers HTTP2.TLS.defaultSettings)
+                  (fromIntegral <$> serverOverrideNumberOfWorkers)
             , HTTP2.TLS.settingsConnectionWindowSize =
                 fromIntegral $ http2ConnectionWindowSize serverHTTP2Settings
             , HTTP2.TLS.settingsStreamWindowSize =

--- a/src/Network/GRPC/Spec/Status.hs
+++ b/src/Network/GRPC/Spec/Status.hs
@@ -41,7 +41,7 @@ data GrpcError =
     -- | Invalid argument
     --
     -- The client specified an invalid argument. Note that this differs from
-    -- 'GrpcFailedPrecondition': 'GrpcInvalidArgumen'` indicates arguments that
+    -- 'GrpcFailedPrecondition': 'GrpcInvalidArgument'` indicates arguments that
     -- are problematic regardless of the state of the system (e.g., a malformed
     -- file name).
   | GrpcInvalidArgument
@@ -79,7 +79,7 @@ data GrpcError =
     -- * 'GrpcPermissionDenied' must not be used for rejections caused by
     --   exhausting some resource (use 'GrpcResourceExhausted' instead for those
     --   errors).
-    -- * 'GrpcPermissionDenoed' must not be used if the caller can not be
+    -- * 'GrpcPermissionDenied' must not be used if the caller can not be
     --   identified (use 'GrpcUnauthenticated' instead for those errors).
     --
     -- This error code does not imply the request is valid or the requested
@@ -99,7 +99,7 @@ data GrpcError =
     -- is non-empty, an rmdir operation is applied to a non-directory, etc.
     --
     -- Service implementors can use the following guidelines to decide between
-    -- 'GrpcFailedPrecondition', 'GrpcAborted', and 'GrpcUnvailable':
+    -- 'GrpcFailedPrecondition', 'GrpcAborted', and 'GrpcUnavailable':
     --
     -- (a) Use 'GrpcUnavailable' if the client can retry just the failing call.
     -- (b) Use 'GrpcAborted' if the client should retry at a higher level (e.g.,

--- a/test-grapesy/Test/Driver/ClientServer.hs
+++ b/test-grapesy/Test/Driver/ClientServer.hs
@@ -39,7 +39,6 @@ import Test.Tasty.QuickCheck qualified as QuickCheck
 import Network.GRPC.Client qualified as Client
 import Network.GRPC.Common
 import Network.GRPC.Common.Compression qualified as Compr
-import Network.GRPC.Common.HTTP2Settings
 import Network.GRPC.Internal.XIO (NeverThrows)
 import Network.GRPC.Internal.XIO qualified as XIO
 import Network.GRPC.Server qualified as Server
@@ -453,22 +452,18 @@ withTestServer cfg firstTestFailure handlerLock serverHandlers k = do
                       insecureHost = Nothing
                     , insecurePort = serverPort cfg
                     }
-                , serverSecure = Nothing
-                , serverOverrideNumberOfWorkers = Nothing
-                , serverHTTP2Settings = defaultHTTP2Settings
+                , serverSecure   = Nothing
                 }
               Just (TlsFail TlsFailUnsupported) -> Server.ServerConfig {
                   serverInsecure = Just Server.InsecureConfig {
                       insecureHost = Nothing
                     , insecurePort = serverPort cfg
                     }
-                , serverSecure = Nothing
-                , serverOverrideNumberOfWorkers = Nothing
-                , serverHTTP2Settings = defaultHTTP2Settings
+                , serverSecure   = Nothing
                 }
               Just _tlsSetup -> Server.ServerConfig {
                   serverInsecure = Nothing
-                , serverSecure = Just $ Server.SecureConfig {
+                , serverSecure   = Just $ Server.SecureConfig {
                       secureHost       = "127.0.0.1"
                     , securePort       = serverPort cfg
                     , securePubCert    = pubCert
@@ -476,8 +471,6 @@ withTestServer cfg firstTestFailure handlerLock serverHandlers k = do
                     , securePrivKey    = privKey
                     , secureSslKeyLog  = SslKeyLogNone
                     }
-                , serverOverrideNumberOfWorkers = Nothing
-                , serverHTTP2Settings = defaultHTTP2Settings
                 }
 
         serverParams :: Server.ServerParams
@@ -498,7 +491,7 @@ withTestServer cfg firstTestFailure handlerLock serverHandlers k = do
             }
 
     server <- Server.mkGrpcServer serverParams serverHandlers
-    Server.forkServer serverConfig server k
+    Server.forkServer serverParams serverConfig server k
 
 {-------------------------------------------------------------------------------
   Client

--- a/test-stress/Test/Stress/Server.hs
+++ b/test-stress/Test/Stress/Server.hs
@@ -1,6 +1,7 @@
 module Test.Stress.Server (server) where
 
 import Network.GRPC.Common
+import Network.GRPC.Common.HTTP2Settings
 import Network.GRPC.Server.Run
 import Network.GRPC.Server.StreamType
 import Network.GRPC.Server.StreamType.Binary qualified as Binary
@@ -22,6 +23,8 @@ server _cmdline =
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure = Just $ InsecureConfig Nothing defaultInsecurePort
-        , serverSecure   = Nothing
+          serverInsecure                = Just $ InsecureConfig Nothing defaultInsecurePort
+        , serverSecure                  = Nothing
+        , serverOverrideNumberOfWorkers = Nothing
+        , serverHTTP2Settings           = defaultHTTP2Settings
         }

--- a/test-stress/Test/Stress/Server.hs
+++ b/test-stress/Test/Stress/Server.hs
@@ -1,7 +1,6 @@
 module Test.Stress.Server (server) where
 
 import Network.GRPC.Common
-import Network.GRPC.Common.HTTP2Settings
 import Network.GRPC.Server.Run
 import Network.GRPC.Server.StreamType
 import Network.GRPC.Server.StreamType.Binary qualified as Binary
@@ -15,7 +14,7 @@ import Test.Stress.Server.API
 
 server :: Cmdline -> IO ()
 server _cmdline =
-    runServerWithHandlers config def [
+    runServerWithHandlers def config [
         fromMethod $
           Binary.mkNonStreaming @ManyShortLived @Word $
             return . succ
@@ -23,8 +22,6 @@ server _cmdline =
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure                = Just $ InsecureConfig Nothing defaultInsecurePort
-        , serverSecure                  = Nothing
-        , serverOverrideNumberOfWorkers = Nothing
-        , serverHTTP2Settings           = defaultHTTP2Settings
+          serverInsecure = Just $ InsecureConfig Nothing defaultInsecurePort
+        , serverSecure   = Nothing
         }


### PR DESCRIPTION
We now support setting the `SETTINGS_INITIAL_WINDOW_SIZE` and `SETTINGS_MAX_CONCURRENT_STREAMS` settings via `http2`. We also support setting the initial connection window size, and the number of server worker threads.

The default values we set for these help us avoid the window size exhaustion deadlock that resulted in
[#168](https://github.com/well-typed/grapesy/issues/168).

Resolves #145 