### PR TITLE
Enable `TCP_NODELAY`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -175,6 +175,16 @@ jobs:
           allow-newer: proto-lens:base
           allow-newer: proto-lens-runtime:base
 
+          source-repository-package
+            type:     git
+            location: https://github.com/edsko/network-run
+            tag:      70211ef61ebbf178d6681ec37d3293d720ec9030
+
+          source-repository-package
+            type:     git
+            location: https://github.com/edsko/http2-tls
+            tag:      53d8b7a0d2a044606de0906e5b66a1f2bce549bd
+
           package grapesy
             tests:       True
             benchmarks:  True

--- a/cabal.project
+++ b/cabal.project
@@ -5,6 +5,16 @@ package grapesy
   benchmarks: True
   flags: +build-demo +build-stress-test +snappy
 
+source-repository-package
+  type: git
+  location: https://github.com/edsko/network-run
+  tag: 70211ef61ebbf178d6681ec37d3293d720ec9030
+
+source-repository-package
+  type: git
+  location: https://github.com/edsko/http2-tls
+  tag: 53d8b7a0d2a044606de0906e5b66a1f2bce549bd
+
 --
 -- ghc 9.10
 --

--- a/cabal.project.ci
+++ b/cabal.project.ci
@@ -6,6 +6,16 @@ package grapesy
   flags: +build-demo +build-stress-test +snappy +strace
   ghc-options: -Werror
 
+source-repository-package
+  type: git
+  location: https://github.com/edsko/network-run
+  tag: 70211ef61ebbf178d6681ec37d3293d720ec9030
+
+source-repository-package
+  type: git
+  location: https://github.com/edsko/http2-tls
+  tag: 53d8b7a0d2a044606de0906e5b66a1f2bce549bd
+
 --
 -- ghc 9.10
 --

--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -206,12 +206,12 @@ library
     , hashable             >= 1.3     && < 1.5
     , http-types           >= 0.12    && < 0.13
     , http2                >= 5.2.4   && < 5.3
-    , http2-tls            >= 0.2.11  && < 0.4
+    , http2-tls            >= 0.3.1   && < 0.4
     , lens                 >= 5.0     && < 5.4
     , mtl                  >= 2.2     && < 2.4
     , network              >= 3.1     && < 3.3
     , network-byte-order   >= 0.1     && < 0.2
-    , network-run          >= 0.2.7   && < 0.4
+    , network-run          >= 0.3.2   && < 0.4
     , proto-lens           >= 0.7     && < 0.8
     , proto-lens-runtime   >= 0.7     && < 0.8
     , random               >= 1.2     && < 1.3

--- a/src/Network/GRPC/Server/Run.hs
+++ b/src/Network/GRPC/Server/Run.hs
@@ -410,9 +410,12 @@ disableTimeout =
 
 openServerSocket :: TMVar Socket -> AddrInfo -> IO Socket
 openServerSocket socketTMVar addr = do
-    sock <- Run.openServerSocket addr
+    sock <- Run.openServerSocketWithOptions socketOptions addr
     atomically $ putTMVar socketTMVar sock
     return sock
+  where
+    socketOptions :: [(SocketOption, Int)]
+    socketOptions = [(NoDelay, 1)]
 
 writeBufferSize :: BufferSize
 writeBufferSize = 4096


### PR DESCRIPTION
This is WIP, because setting `TCP_NODELAY` should be optional; for now we're just testing if this works at all.

Without `TCP_NODELAY`:

```
$ cabal run grapesy-kvstore -- --no-work-simulation
Did 11.433 RPCs/s
```

with:

```
$ cabal run grapesy-kvstore -- --no-work-simulation
Did 1778.667 RPCs/s
```

This is still nowhere near as good as the Java version

```
$ ./build/install/kvstore/bin/kvstore
Jul 04, 2024 11:44:24 AM io.grpc.examples.KvRunner runClient
INFO: Starting
Did 5183.583 RPCs/s
```

but at least no longer in "something must be badly wrong" territory.

Depends on

* https://github.com/kazu-yamamoto/network-run/pull/8 (additional discussion in https://github.com/kazu-yamamoto/network-run/pull/7)
* https://github.com/kazu-yamamoto/http2-tls/pull/16
