### PR TITLE
Enable `TCP_NODELAY`, alternative approach

### DIFF
--- a/grapesy.cabal
+++ b/grapesy.cabal
@@ -206,16 +206,16 @@ library
     , hashable             >= 1.3     && < 1.5
     , http-types           >= 0.12    && < 0.13
     , http2                >= 5.2.4   && < 5.3
-    , http2-tls            >= 0.2.11  && < 0.4
+    , http2-tls            >= 0.4     && < 0.5
     , lens                 >= 5.0     && < 5.4
     , mtl                  >= 2.2     && < 2.4
     , network              >= 3.1     && < 3.3
-    , network-byte-order   >= 0.1     && < 0.2
-    , network-run          >= 0.2.7   && < 0.4
+    , network-run          >= 0.4     && < 0.5
     , proto-lens           >= 0.7     && < 0.8
     , proto-lens-runtime   >= 0.7     && < 0.8
     , random               >= 1.2     && < 1.3
     , record-hasfield      >= 1.0     && < 1.1
+    , recv                 >= 0.1     && < 0.2
     , stm                  >= 2.5     && < 2.6
     , text                 >= 1.2     && < 2.2
     , time-manager         >= 0.1     && < 0.2
@@ -576,6 +576,10 @@ benchmark grapesy-kvstore
       KVStore.Util.Store
 
       Proto.Kvstore
+
+      Paths_grapesy
+  autogen-modules:
+      Paths_grapesy
   build-depends:
       grapesy
   build-depends:

--- a/kvstore/KVStore/Client.hs
+++ b/kvstore/KVStore/Client.hs
@@ -89,7 +89,12 @@ showStats Cmdline{cmdDuration} stats = unlines [
 -- separate thread, and kill the thread after some amount of time. The number
 -- of RPC calls made can then be read off from the 'IORef'.
 client :: Cmdline -> IORef Stats -> IO ()
-client Cmdline{cmdJSON} statsVar = do
+client Cmdline{
+           cmdJSON
+         , cmdSecure
+         , cmdDisableTcpNoDelay
+         , cmdPingRateLimit
+         } statsVar = do
     knownKeys <- RandomAccessSet.new
     random    <- RandomGen.new
 
@@ -120,14 +125,31 @@ client Cmdline{cmdJSON} statsVar = do
               _ -> error "impossible"
   where
     params :: ConnParams
-    params = def
+    params = def {
+          connHTTP2Settings = def {
+              http2TcpNoDelay            = not cmdDisableTcpNoDelay
+            , http2OverridePingRateLimit = cmdPingRateLimit
+            }
+        }
 
     server :: Server
-    server = ServerInsecure $ Address {
-         addressHost      = "127.0.0.1"
-       , addressPort      = defaultInsecurePort
-       , addressAuthority = Nothing
-       }
+    server
+      | cmdSecure
+      = ServerSecure
+          NoServerValidation
+          SslKeyLogNone -- Let the server write the log
+          Address {
+              addressHost      = "127.0.0.1"
+            , addressPort      = defaultSecurePort
+            , addressAuthority = Nothing
+            }
+
+      | otherwise
+      = ServerInsecure $ Address {
+             addressHost      = "127.0.0.1"
+           , addressPort      = defaultInsecurePort
+           , addressAuthority = Nothing
+           }
 
 {-------------------------------------------------------------------------------
   Access the various server features

--- a/kvstore/KVStore/Cmdline.hs
+++ b/kvstore/KVStore/Cmdline.hs
@@ -13,10 +13,13 @@ import Options.Applicative qualified as Opt
 -------------------------------------------------------------------------------}
 
 data Cmdline = Cmdline {
-      cmdMode         :: Mode
-    , cmdDuration     :: Int
-    , cmdSimulateWork :: Bool
-    , cmdJSON         :: Bool
+      cmdMode              :: Mode
+    , cmdDuration          :: Int
+    , cmdSimulateWork      :: Bool
+    , cmdJSON              :: Bool
+    , cmdSecure            :: Bool
+    , cmdDisableTcpNoDelay :: Bool
+    , cmdPingRateLimit     :: Maybe Int
     }
 
 data Mode =
@@ -59,6 +62,21 @@ parseCmdline =
               Opt.long "json"
             , Opt.help "Use JSON instead of Protobuf"
             ])
+      <*> (Opt.switch $ mconcat [
+              Opt.long "secure"
+            , Opt.help "Enable TLS"
+            ])
+      <*> (Opt.switch $ mconcat [
+              Opt.long "disable-tcp-nodelay"
+            , Opt.help "Disable the TCP_NODELAY option"
+            ])
+      <*> (Opt.optional $
+            Opt.option Opt.auto $ mconcat [
+              Opt.long "ping-rate-limit"
+            , Opt.metavar "PINGs/sec"
+            , Opt.help "Allow at most this many pings per second from the peer"
+            ]
+          )
 
 parseMode :: Parser Mode
 parseMode = asum [

--- a/src/Network/GRPC/Common/HTTP2Settings.hs
+++ b/src/Network/GRPC/Common/HTTP2Settings.hs
@@ -56,6 +56,37 @@ data HTTP2Settings = HTTP2Settings {
       -- connecting to a peer that you trust, you can set this limit to
       -- 'maxBound' (effectively turning off protecting against ping flooding).
     , http2OverridePingRateLimit :: Maybe Int
+
+      -- | Enable @TCP_NODELAY@
+      --
+      -- Send out TCP segments as soon as possible, even if there is only a
+      -- small amount of data.
+      --
+      -- When @TCP_NODELAY@ is /NOT/ set, the TCP implementation will wait to
+      -- send a TCP segment to the receiving peer until either (1) there is
+      -- enough data to fill a certain minimum segment size or (2) we receive an
+      -- ACK from the receiving peer for data we sent previously. This adds a
+      -- network roundtrip delay to every RPC message we want to send (to
+      -- receive the ACK). If the peer uses TCP delayed acknowledgement, which
+      -- will typically be the case, then this delay will increase further
+      -- still; default for delayed acknowledgement is 40ms, thus resulting in a
+      -- theoretical maximum of 25 RPCs/sec.
+      --
+      -- We therefore enable TCP_NODELAY by default, so that data is sent to the
+      -- peer as soon as we have an entire gRPC message serialized and ready to
+      -- send (we send the data to the TCP layer only once an entire message is
+      -- written, or the @http2@ write buffer is full).
+      --
+      -- Turning this off /could/ improve throughput, as fewer TCP segments will
+      -- be needed, but you probably only want to do this if you send very few
+      -- very large RPC messages. In gRPC this is anyway discouraged, because
+      -- gRPC messages do not support incremental (de)serialization; if you need
+      -- to send large amounts of data, it is preferable to split these into
+      -- many, smaller, gRPC messages; this also gives the application the
+      -- possibility of reporting on data transmission progress.
+      --
+      -- TL;DR: leave this at the default unless you know what you are doing.
+    , http2TcpNoDelay :: Bool
     }
   deriving (Show)
 
@@ -82,6 +113,7 @@ defaultHTTP2Settings = HTTP2Settings {
     , http2StreamWindowSize      = defInitialStreamWindowSize
     , http2ConnectionWindowSize  = defMaxConcurrentStreams * defInitialStreamWindowSize
     , http2OverridePingRateLimit = Nothing
+    , http2TcpNoDelay            = True
     }
   where
     defMaxConcurrentStreams    = 128

--- a/util/Network/GRPC/Util/HTTP2.hs
+++ b/util/Network/GRPC/Util/HTTP2.hs
@@ -1,18 +1,38 @@
+{-# LANGUAGE CPP #-}
+
+#include "MachDeps.h"
+
 module Network.GRPC.Util.HTTP2 (
     -- * General auxiliary
     fromHeaderTable
     -- * Configuration
-  , allocConfigWithTimeout
+  , withConfigForInsecure
+  , withConfigForSecure
+    -- * Settings
+  , mkServerConfig
+  , mkTlsSettings
   ) where
 
+import Control.Exception
 import Data.Bifunctor
+import Data.ByteString qualified as Strict (ByteString)
+import Data.Maybe (fromMaybe)
+import Foreign (mallocBytes, free)
 import Network.HPACK (BufferSize)
 import Network.HPACK qualified as HPACK
 import Network.HPACK.Token qualified as HPACK
 import Network.HTTP.Types qualified as HTTP
 import Network.HTTP2.Server qualified as Server
-import Network.Socket
-import System.TimeManager qualified as TimeoutManager
+import Network.HTTP2.TLS.Server qualified as Server.TLS
+import Network.Socket (Socket, SockAddr)
+import Network.Socket qualified as Socket
+import Network.Socket.BufferPool (Recv)
+import Network.Socket.BufferPool qualified as Recv
+import Network.Socket.ByteString qualified as Socket
+import System.TimeManager qualified as Time (Manager)
+import System.TimeManager qualified as TimeManager
+
+import Network.GRPC.Common.HTTP2Settings
 
 {-------------------------------------------------------------------------------
   General auxiliary
@@ -25,13 +45,169 @@ fromHeaderTable = map (first HPACK.tokenKey) . fst
   Configuration
 -------------------------------------------------------------------------------}
 
--- | Adaptation of 'allocSimpleConfig' that allows to specify a timeout
-allocConfigWithTimeout :: Socket -> BufferSize -> Int -> IO Server.Config
-allocConfigWithTimeout sock confBufferSize timeout = do
-    -- Since 'allocSimpleConfig' calls some functions that are not exported,
-    -- we use it as-is, and then throw away the 'TimeManager' it created and
-    -- override it with our own. We can only do this because none of the other
-    -- values in this record depend on the time manager.
-    config <- Server.allocSimpleConfig sock confBufferSize
-    timeoutManager <- TimeoutManager.initialize $ timeout * 1_000_000
-    return config{Server.confTimeoutManager = timeoutManager}
+-- | Create config to be used with @http2@ (without TLS)
+--
+-- We do not use @allocSimpleConfig@ from @http2:Network.HTTP2.Server@, but
+-- instead create a config that is very similar to the config created by
+-- 'allocConfigForSecure'.
+withConfigForInsecure ::
+     Socket
+  -> (Server.Config -> IO a)
+  -> IO a
+withConfigForInsecure sock k =
+    TimeManager.withManager (disableTimeout * 1_000_000) $ \mgr -> do
+      -- @recv@ does not provide a way to deallocate a buffer pool, and
+      -- @http2-tls@ (in @freeServerConfig@) does not attempt to deallocate it.
+      -- We follow suit here.
+      pool   <- Recv.newBufferPool readBufferLowerLimit readBufferSize
+      mysa   <- Socket.getSocketName sock
+      peersa <- Socket.getPeerName sock
+      withConfig
+        mgr
+        (Socket.sendAll sock)
+        (Recv.receive sock pool)
+        mysa
+        peersa
+        k
+  where
+    def :: Server.TLS.Settings
+    def = Server.TLS.defaultSettings
+
+    -- Use the defaults from @http2-tls@
+    readBufferLowerLimit, readBufferSize :: Int
+    readBufferLowerLimit = Server.TLS.settingsReadBufferLowerLimit def
+    readBufferSize       = Server.TLS.settingsReadBufferSize       def
+
+-- | Create config to be used with @http2-tls@ (with TLS)
+--
+-- This is adapted from @allocConfigForServer@ in
+-- @http2-tls:Network.HTTP2.TLS.Config@.
+withConfigForSecure ::
+     Time.Manager
+  -> Server.TLS.IOBackend
+  -> (Server.Config -> IO a)
+  -> IO a
+withConfigForSecure mgr backend =
+    withConfig
+      mgr
+      (Server.TLS.send         backend)
+      (Server.TLS.recv         backend)
+      (Server.TLS.mySockAddr   backend)
+      (Server.TLS.peerSockAddr backend)
+
+-- | Internal generalization
+withConfig ::
+     Time.Manager
+  -> (Strict.ByteString -> IO ())
+  -> Recv
+  -> SockAddr
+  -> SockAddr
+  -> (Server.Config -> IO a)
+  -> IO a
+withConfig mgr send recv mysa peersa k =
+    bracket (mallocBytes writeBufferSize) free $ \buf -> do
+      recvN <- Recv.makeRecvN mempty recv
+      k Server.Config {
+          confWriteBuffer       = buf
+        , confBufferSize        = writeBufferSize
+        , confSendAll           = send
+        , confReadN             = recvN
+        , confPositionReadMaker = Server.defaultPositionReadMaker
+        , confTimeoutManager    = mgr
+        , confMySockAddr        = mysa
+        , confPeerSockAddr      = peersa
+        }
+  where
+    -- This is the default value for @settingsSendBufferSize@ in @http2-tls@
+    -- and the default value given in the documentation in @http2@.
+    writeBufferSize :: BufferSize
+    writeBufferSize = 4096
+
+{-------------------------------------------------------------------------------
+  Settings
+
+  NOTE: If we want to override 'HTTP2.TLS.settingsReadBufferLowerLimit' or
+  'HTTP2.TLS.settingsReadBufferSize', we should also modify
+  'allocConfigForInsecure'.
+-------------------------------------------------------------------------------}
+
+mkServerConfig ::
+     HTTP2Settings
+  -> Maybe Word  -- ^ Override number of workers
+  -> Server.ServerConfig
+mkServerConfig http2Settings numberOfWorkers =
+    Server.defaultServerConfig {
+        Server.numberOfWorkers =
+          fromMaybe
+            (Server.numberOfWorkers Server.defaultServerConfig)
+            (fromIntegral <$> numberOfWorkers)
+      , Server.connectionWindowSize = fromIntegral $
+          http2ConnectionWindowSize http2Settings
+      , Server.settings = Server.defaultSettings {
+            Server.initialWindowSize = fromIntegral $
+              http2StreamWindowSize http2Settings
+          , Server.maxConcurrentStreams = Just . fromIntegral $
+              http2MaxConcurrentStreams http2Settings
+--          , Server.pingRateLimit =
+--              fromMaybe
+--                (Server.pingRateLimit Server.defaultSettings)
+--                (http2OverridePingRateLimit http2Settings)
+          }
+      }
+
+-- | Settings for secure server (with TLS)
+--
+-- NOTE: This overlaps with the values in 'mkServerConfig', and I /think/ we
+-- don't actually need this, because we don't use @runWithSocket@ from
+-- @http2-tls@ (but rather @runTLSWithSocket@. However, we set them here anyway
+-- for completeness and in case @http2-tls@ decides to use them elsewhere.
+mkTlsSettings ::
+     HTTP2Settings
+  -> Maybe Word         -- ^ Override number of workers
+  -> (String -> IO ())  -- ^ Key logger
+  -> Server.TLS.Settings
+mkTlsSettings http2Settings numberOfWorkers keyLogger =
+    Server.TLS.defaultSettings {
+        Server.TLS.settingsKeyLogger =
+          keyLogger
+      , Server.TLS.settingsTimeout =
+          disableTimeout
+      , Server.TLS.settingsNumberOfWorkers =
+          fromMaybe
+            (Server.TLS.settingsNumberOfWorkers Server.TLS.defaultSettings)
+            (fromIntegral <$> numberOfWorkers)
+      , Server.TLS.settingsConnectionWindowSize = fromIntegral $
+          http2ConnectionWindowSize http2Settings
+      , Server.TLS.settingsStreamWindowSize = fromIntegral $
+          http2StreamWindowSize http2Settings
+      , Server.TLS.settingsConcurrentStreams = fromIntegral $
+          http2MaxConcurrentStreams http2Settings
+      }
+
+{-------------------------------------------------------------------------------
+  Timeouts
+-------------------------------------------------------------------------------}
+
+-- | Work around the fact that we cannot disable timeouts in http2/http2-tls
+--
+-- TODO: <https://github.com/well-typed/grapesy/issues/123>
+-- We need a proper solution for this.
+disableTimeout :: Int
+disableTimeout =
+#if (WORD_SIZE_IN_BITS == 64)
+    -- Set a really high timeout to effectively disable timeouts (100 years)
+    --
+    -- NOTE: We cannot use 'maxBound' here, because this value is multiplied
+    -- by @1_000_000@ in 'Network.Run.TCP.Timeout.runTCPServerWithSocket'
+    -- (in @network-run@).
+    100 * 365 * 24 * 60 * 60
+#else
+#warning "Timeout for RPC messages is set to 30 minutes on 32-bit systems."
+#warning "See https://github.com/kazu-yamamoto/http2/issues/112"
+    -- Unfortunately, the same trick does not work on 32-bit systems, where we
+    -- simply don't have enough range. The maximum timeout we can support here
+    -- is roughly 35 mins. We set it to 30 minutes exactly, to at least provide
+    -- a clue if the timeout does hit (1_800_000_000 < 2_147_483_647).
+    30 * 60
+#endif
+


### PR DESCRIPTION
This replaces #181, and depends on

* https://github.com/kazu-yamamoto/network-run/pull/9 (into https://github.com/kazu-yamamoto/network-run/tree/main2) (an alternative to https://github.com/kazu-yamamoto/network-run/pull/8)
* https://github.com/kazu-yamamoto/http2-tls/pull/17 (into https://github.com/kazu-yamamoto/http2-tls/tree/main2) (an alternative to https://github.com/kazu-yamamoto/http2-tls/pull/16)

Just to verify that we can set `TCP_NODELAY` both server-side and client-side, as well as with and without TLS, I did some measurements:

secure | server TCP_NODELAY | client TCP_NODELAY | performance
--  | --  | --  | --
no  | no  | no  | 11.717 RPCs/s
no  | no  | yes | 22.517 RPCs/s
no  | yes | no  | 21.683 RPCs/s
no  | yes | yes | 1735.617 RPCs/s :heavy_check_mark: 
--  | --  | --  | --
yes | no  | no  | 11.417 RPCs/s
yes | no  | yes | 22.983 RPCs/s
yes | yes | no  | 21.383 RPCs/s
yes | yes | yes | 973.000 RPCs/s :heavy_check_mark: 

(all with `--no-work-simulation`)