### PR TITLE
Explicitly use `127.0.0.1` in test suite where appropriate

### DIFF
--- a/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -72,10 +72,6 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
                     test_increment def {
                         useTLS = Just $ TlsFail TlsFailValidation
                       }
-                , testCase "hostname" $
-                    test_increment def {
-                        useTLS = Just $ TlsFail TlsFailHostname
-                      }
                 , testCase "unsupported" $
                     test_increment def {
                         useTLS = Just $ TlsFail TlsFailUnsupported


### PR DESCRIPTION
We use `insecureHost = Nothing` in the test suite, which causes `runTCPServerWithSocket` to bind to `localhost` by default. This wasn't an issue until `network-run` version 0.3.0 [started enabling `IPV6_V6ONLY` for server sockets on all non-FreeBSD platforms](https://github.com/kazu-yamamoto/network-run/pull/4), meaning you can't connect to a socket bound at 'localhost' using address '127.0.0.1'. I don't understand why this doesn't appear to have caused any issues on the linux machines we test on, but it broke the test suite on my macOS machine. This patch causes all tests to pass.