### PR TITLE
Override ping rate limit on server

### DIFF
--- a/kvstore/KVStore/Client.hs
+++ b/kvstore/KVStore/Client.hs
@@ -93,6 +93,7 @@ client Cmdline{
            cmdJSON
          , cmdSecure
          , cmdDisableTcpNoDelay
+         , cmdPingRateLimit
          } statsVar = do
     knownKeys <- RandomAccessSet.new
     random    <- RandomGen.new
@@ -126,7 +127,8 @@ client Cmdline{
     params :: ConnParams
     params = def {
           connHTTP2Settings = def {
-              http2TcpNoDelay = not cmdDisableTcpNoDelay
+              http2TcpNoDelay            = not cmdDisableTcpNoDelay
+            , http2OverridePingRateLimit = cmdPingRateLimit
             }
         }
 

--- a/kvstore/KVStore/Cmdline.hs
+++ b/kvstore/KVStore/Cmdline.hs
@@ -19,6 +19,7 @@ data Cmdline = Cmdline {
     , cmdJSON              :: Bool
     , cmdSecure            :: Bool
     , cmdDisableTcpNoDelay :: Bool
+    , cmdPingRateLimit     :: Maybe Int
     }
 
 data Mode =
@@ -69,6 +70,13 @@ parseCmdline =
               Opt.long "disable-tcp-nodelay"
             , Opt.help "Disable the TCP_NODELAY option"
             ])
+      <*> (Opt.optional $
+            Opt.option Opt.auto $ mconcat [
+              Opt.long "ping-rate-limit"
+            , Opt.metavar "PINGs/sec"
+            , Opt.help "Allow at most this many pings per second from the peer"
+            ]
+          )
 
 parseMode :: Parser Mode
 parseMode = asum [

--- a/kvstore/KVStore/Server.hs
+++ b/kvstore/KVStore/Server.hs
@@ -26,6 +26,7 @@ withKeyValueServer cmdline@Cmdline{
                        cmdJSON
                      , cmdSecure
                      , cmdDisableTcpNoDelay
+                     , cmdPingRateLimit
                      } k = do
     store <- Store.new
 
@@ -61,7 +62,8 @@ withKeyValueServer cmdline@Cmdline{
     params :: ServerParams
     params = def {
           serverHTTP2Settings = def {
-              http2TcpNoDelay = not cmdDisableTcpNoDelay
+              http2TcpNoDelay            = not cmdDisableTcpNoDelay
+            , http2OverridePingRateLimit = cmdPingRateLimit
             }
 
           -- The Java benchmark does not use compression (unclear if the Java

--- a/util/Network/GRPC/Util/HTTP2.hs
+++ b/util/Network/GRPC/Util/HTTP2.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 
-#include "MachDeps.h"
+
 
 module Network.GRPC.Util.HTTP2 (
     -- * General auxiliary
@@ -138,9 +138,10 @@ mkServerConfig ::
 mkServerConfig http2Settings numberOfWorkers =
     Server.defaultServerConfig {
         Server.numberOfWorkers =
-          fromMaybe
+          maybe
             (Server.numberOfWorkers Server.defaultServerConfig)
-            (fromIntegral <$> numberOfWorkers)
+            fromIntegral
+            numberOfWorkers
       , Server.connectionWindowSize = fromIntegral $
           http2ConnectionWindowSize http2Settings
       , Server.settings = Server.defaultSettings {
@@ -148,6 +149,10 @@ mkServerConfig http2Settings numberOfWorkers =
               http2StreamWindowSize http2Settings
           , Server.maxConcurrentStreams = Just . fromIntegral $
               http2MaxConcurrentStreams http2Settings
+          , Server.pingRateLimit =
+              fromMaybe
+                (Server.pingRateLimit Server.defaultSettings)
+                (http2OverridePingRateLimit http2Settings)
           }
       }
 


### PR DESCRIPTION
This PR ensures we use `http2OverridePingRateLimit` on the server as well, and adds some options to the kvstore benchmark for setting the rate limit. A rate limit of 10 results in semi-frequent `too many ping` errors when the grapesy server is ran against the Java client (in JSON mode). A rate limit of 20 seems to be enough for those two to communicate without problems.