### PR TITLE
Fix `outboundTrailersMaker`

### DIFF
--- a/util/Network/GRPC/Util/Session/Server.hs
+++ b/util/Network/GRPC/Util/Session/Server.hs
@@ -77,7 +77,7 @@ setupResponseChannel sess
             regular <- initFlowStateRegular headers
             markReady $ FlowStateRegular regular
             let resp :: Server.Response
-                resp = setResponseTrailers sess channel
+                resp = setResponseTrailers sess channel regular
                      $ Server.responseStreaming
                              (responseStatus  responseInfo)
                              (responseHeaders responseInfo)
@@ -103,7 +103,8 @@ setResponseTrailers ::
      IsSession sess
   => sess
   -> Channel sess
+  -> RegularFlowState (Outbound sess)
   -> Server.Response -> Server.Response
-setResponseTrailers sess channel resp =
+setResponseTrailers sess channel regular resp =
     Server.setResponseTrailersMaker resp $
-      outboundTrailersMaker sess channel
+      outboundTrailersMaker sess channel regular

--- a/util/Network/GRPC/Util/Thread.hs
+++ b/util/Network/GRPC/Util/Thread.hs
@@ -16,6 +16,7 @@ module Network.GRPC.Util.Thread (
   , cancelThread
   , withThreadInterface
   , waitForNormalThreadTermination
+  , waitForAbnormalThreadTermination
   , waitForNormalOrAbnormalThreadTermination
   , hasThreadTerminated
   ) where
@@ -315,6 +316,15 @@ waitForNormalOrAbnormalThreadTermination ::
   -> STM (Either SomeException a)
 waitForNormalOrAbnormalThreadTermination state =
     hasThreadTerminated state >>= maybe retry return
+
+-- | Wait for the thread to terminate abnormally
+waitForAbnormalThreadTermination ::
+     TVar (ThreadState a)
+  -> STM SomeException
+waitForAbnormalThreadTermination state =
+    hasThreadTerminated state >>= \case
+      Just (Left e) -> return e
+      _otherwise    -> retry
 
 -- | Has the thread terminated?
 hasThreadTerminated ::


### PR DESCRIPTION
In current `http2`, `respond` returns when the body is sent and before the trailers are constructed. In the new `http2` architecture, `respond` does not return until *after* trailers are constructed, which deadlocks `grapesy`.