### PR TITLE
Deal with missing trailers

### DIFF
--- a/docs/demo-client.md
+++ b/docs/demo-client.md
@@ -169,7 +169,7 @@ $ cabal run demo-client --  --core sayHelloBidiStream  \
 {message: "John Ack"}
 Disconnected. Reconnecting after 1701081μs
 Reconnecting now.
-demo-client: CallClosedWithoutTrailers
+demo-client: GrpcException {grpcError = GrpcUnknown, grpcErrorMessage = Just "Call closed without trailers", grpcErrorMetadata = []}
 ```
 
 ### Dealing with unterminated streams


### PR DESCRIPTION
There was not much to do here; we added some tests that we deal with things correctly, and modified the code slightly to throw a `GrpcException` rather than a custom exception in the case of no trailers at all.