### PR TITLE
Use a larger stream window

### DIFF
--- a/src/Network/GRPC/Common/HTTP2Settings.hs
+++ b/src/Network/GRPC/Common/HTTP2Settings.hs
@@ -168,7 +168,7 @@ defaultHTTP2Settings :: HTTP2Settings
 defaultHTTP2Settings = HTTP2Settings {
       http2MaxConcurrentStreams        = defMaxConcurrentStreams
     , http2StreamWindowSize            = defInitialStreamWindowSize
-    , http2ConnectionWindowSize        = defMaxConcurrentStreams * defInitialStreamWindowSize
+    , http2ConnectionWindowSize        = defInitialConnectionWindowSize
     , http2TcpNoDelay                  = True
     , http2OverridePingRateLimit       = Just 100
     , http2OverrideEmptyFrameRateLimit = Nothing
@@ -176,8 +176,9 @@ defaultHTTP2Settings = HTTP2Settings {
     , http2OverrideRstRateLimit        = Nothing
     }
   where
-    defMaxConcurrentStreams    = 128
-    defInitialStreamWindowSize = 1024 * 64
+    defMaxConcurrentStreams        = 128
+    defInitialStreamWindowSize     = 256 * 1024        -- 256KiB
+    defInitialConnectionWindowSize = 2   * 1024 * 1024 -- 2MiB
 
 instance Default HTTP2Settings where
   def = defaultHTTP2Settings


### PR DESCRIPTION
With the new `http2` architecture, we don't have a fixed number of pooled workers, so we don't need to guard against window size deadlock by limiting the stream/connection windows. [Using a larger stream window size results in fewer window updates being sent](https://github.com/well-typed/grapesy/issues/192#issuecomment-2415085482), so this PR increases the default to the numbers I used in the benchmark for that linked comment.

I also opened some PRs to remove the `{settings}numberOfWorkers` fields in `http2{-tls}`: [`http2` PR](https://github.com/kazu-yamamoto/http2/pull/147), [`http2-tls` PR](https://github.com/kazu-yamamoto/http2-tls/pull/21)

Closes #192 