### PR TITLE
Support concurrent clients in kvstore

### DIFF
--- a/kvstore/KVStore/Cmdline.hs
+++ b/kvstore/KVStore/Cmdline.hs
@@ -20,6 +20,7 @@ data Cmdline = Cmdline {
     , cmdSecure            :: Bool
     , cmdDisableTcpNoDelay :: Bool
     , cmdPingRateLimit     :: Maybe Int
+    , cmdSemaphoreLimit    :: Maybe Int
     }
 
 data Mode =
@@ -75,6 +76,13 @@ parseCmdline =
               Opt.long "ping-rate-limit"
             , Opt.metavar "PINGs/sec"
             , Opt.help "Allow at most this many pings per second from the peer"
+            ]
+          )
+      <*> (Opt.optional $
+            Opt.option Opt.auto $ mconcat [
+              Opt.long "semaphore-limit"
+            , Opt.metavar "NUM_TOKENS"
+            , Opt.help "Allow at most this many clients to run concurrently"
             ]
           )
 

--- a/kvstore/KVStore/Util/RandomAccessSet.hs
+++ b/kvstore/KVStore/Util/RandomAccessSet.hs
@@ -41,9 +41,9 @@ isEmpty ras = withRAS ras $ Set.null
 getRandomKey :: RandomAccessSet a -> IO a
 getRandomKey ras = do
     gen  <- Random.new
-    size <- withRAS ras $ Set.size
-    n    <- Random.nextInt gen size
-    withRAS ras $ Set.elemAt n
+    withRASIO ras $ \s -> do
+      n <- Random.nextInt gen (Set.size s)
+      return $ Set.elemAt n s
 
 add :: Ord a => RandomAccessSet a -> a -> IO Bool
 add ras value =
@@ -67,3 +67,10 @@ modifyRAS ras f = modifyMVar (unwrap ras) $ return . f
 
 modifyRAS_ :: RandomAccessSet a -> (Set a -> Set a) -> IO ()
 modifyRAS_ ras f = modifyMVar_ (unwrap ras) $ return . f
+
+{-------------------------------------------------------------------------------
+  Internal: wrap IO operations
+-------------------------------------------------------------------------------}
+
+withRASIO :: RandomAccessSet a -> (Set a -> IO b) -> IO b
+withRASIO ras = withMVar (unwrap ras)


### PR DESCRIPTION
This allows us to have better parity with the Java kvstore benchmark, specifically the gson one, which has a semaphore limiting concurrency of clients. When using 100 tokens for the semaphore (like the Java benchmark), we get similar `Key not found` errors as the Java benchmark. It appears to work similarly.