### PR TITLE
    Check that messages are well-formed before enqueueing

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -351,6 +351,7 @@ test-suite test-grapesy
     , bytestring                  >= 0.10  && < 0.13
     , case-insensitive            >= 1.2   && < 1.3
     , containers                  >= 0.6   && < 0.8
+    , deepseq                     >= 1.4   && < 1.6
     , exceptions                  >= 0.10  && < 0.11
     , http-types                  >= 0.12  && < 0.13
     , http2                       >= 5.3.4 && < 5.4
@@ -636,6 +637,7 @@ benchmark grapesy-kvstore
     , base64-bytestring    >= 1.2  && < 1.3
     , bytestring           >= 0.10 && < 0.13
     , containers           >= 0.6  && < 0.8
+    , deepseq              >= 1.4  && < 1.6
     , hashable             >= 1.3  && < 1.5
     , optparse-applicative >= 0.16 && < 0.19
     , proto-lens-runtime   >= 0.7  && < 0.8

--- a/grapesy/kvstore/KVStore/API.hs
+++ b/grapesy/kvstore/KVStore/API.hs
@@ -8,6 +8,7 @@ module KVStore.API (
   , KVStore(..)
   ) where
 
+import Control.DeepSeq (NFData)
 import Control.Monad
 import Data.Aeson.Types qualified as Aeson
 import Data.ByteString (ByteString)
@@ -25,13 +26,14 @@ newtype Key = Key {
        getKey :: ByteString
      }
   deriving stock (Show, Eq, Ord)
-  deriving newtype (Hashable)
+  deriving newtype (Hashable, NFData)
   deriving (ToJSON, FromJSON) via Base64
 
 newtype Value = Value {
       getValue :: ByteString
     }
   deriving stock (Show, Eq, Ord)
+  deriving newtype (NFData)
   deriving (ToJSON, FromJSON) via Base64
 
 {-------------------------------------------------------------------------------

--- a/grapesy/src/Network/GRPC/Common/NextElem.hs
+++ b/grapesy/src/Network/GRPC/Common/NextElem.hs
@@ -26,7 +26,7 @@ import Network.GRPC.Common.StreamElem (StreamElem(..))
 -- | Is there a next element in a stream?
 --
 -- Does not record metadata, unlike 'Network.GRPC.Common.StreamElem.StreamElem'.
-data NextElem a = NoNextElem | NextElem a
+data NextElem a = NoNextElem | NextElem !a
   deriving stock (Show, Eq, Functor, Foldable, Traversable)
 
 {-------------------------------------------------------------------------------

--- a/grapesy/src/Network/GRPC/Common/StreamElem.hs
+++ b/grapesy/src/Network/GRPC/Common/StreamElem.hs
@@ -45,12 +45,12 @@ data StreamElem b a =
     --
     --   In this case, this element is /not/ final (and the final element, when
     --   we receive it, will be tagged as 'Final').
-    StreamElem a
+    StreamElem !a
 
     -- | We received the final element
     --
     -- The final element is annotated with some additional information.
-  | FinalElem a b
+  | FinalElem !a !b
 
     -- | There are no more elements
     --
@@ -59,7 +59,7 @@ data StreamElem b a =
     -- * The stream didn't contain any elements at all.
     -- * The final element was not marked as final.
     --   See 'StreamElem' for detailed additional discussion.
-  | NoMoreElems b
+  | NoMoreElems !b
   deriving stock (Show, Eq, Functor, Foldable, Traversable)
 
 instance Bifunctor StreamElem where

--- a/grapesy/src/Network/GRPC/Server/StreamType.hs
+++ b/grapesy/src/Network/GRPC/Server/StreamType.hs
@@ -288,6 +288,14 @@ data Services m (servs :: [[k]]) where
 --
 -- > Server.fromMethod @EmptyCall $ ServerHandler $ \(_ ::Empty) ->
 -- >   return (defMessage :: Empty)
+--
+-- If the streaming type cannot be deduced, you might need to specify that also:
+--
+-- > Server.fromMethod @Ping @NonStreaming $ ServerHandler $ ..
+--
+-- Alternatively, use one of the handler construction functions, such as
+--
+-- > Server.fromMethod @Ping $ Server.mkNonStreaming $ ..
 fromMethod :: forall rpc styp m.
      ( SupportsServerRpc rpc
      , ValidStreamingType styp

--- a/grapesy/src/Network/GRPC/Spec/MessageMeta.hs
+++ b/grapesy/src/Network/GRPC/Spec/MessageMeta.hs
@@ -4,8 +4,10 @@ module Network.GRPC.Spec.MessageMeta (
   , InboundMeta(..)
   ) where
 
+import Control.DeepSeq (NFData)
 import Data.Default
 import Data.Word
+import GHC.Generics (Generic)
 
 {-------------------------------------------------------------------------------
   Outbound messages
@@ -18,7 +20,8 @@ data OutboundMeta = OutboundMeta {
       -- smaller message.
       outboundEnableCompression :: Bool
     }
-  deriving stock (Show)
+  deriving stock (Show, Generic)
+  deriving anyclass (NFData)
 
 instance Default OutboundMeta where
   def = OutboundMeta {

--- a/grapesy/src/Network/GRPC/Spec/RPC/Protobuf.hs
+++ b/grapesy/src/Network/GRPC/Spec/RPC/Protobuf.hs
@@ -9,6 +9,7 @@ module Network.GRPC.Spec.RPC.Protobuf (
   , getProto
   ) where
 
+import Control.DeepSeq (NFData)
 import Control.Lens hiding (lens)
 import Data.ByteString qualified as Strict (ByteString)
 import Data.ByteString.Char8 qualified as BS.Char8
@@ -51,8 +52,14 @@ type instance Input  (Protobuf serv meth) = Proto (MethodInput  serv meth)
 type instance Output (Protobuf serv meth) = Proto (MethodOutput serv meth)
 
 instance ( HasMethodImpl      serv meth
+
+           -- Debugging
          , Show (MethodInput  serv meth)
          , Show (MethodOutput serv meth)
+
+           -- Serialization
+         , NFData (MethodInput  serv meth)
+         , NFData (MethodOutput serv meth)
 
            -- Metadata constraints
          , Show (RequestMetadata (Protobuf serv meth))
@@ -144,6 +151,7 @@ newtype Proto msg = Proto msg
     , Enum
     , FieldDefault
     , MessageEnum
+    , NFData
     )
 
 -- | Field accessor for 'Proto'

--- a/grapesy/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
+++ b/grapesy/test-grapesy/Test/Sanity/StreamingType/CustomFormat.hs
@@ -4,6 +4,7 @@ module Test.Sanity.StreamingType.CustomFormat (tests) where
 
 import Codec.Serialise qualified as Cbor
 import Control.Concurrent.Async (concurrently)
+import Control.DeepSeq (NFData)
 import Data.Bifunctor
 import Data.ByteString qualified as Strict (ByteString)
 import Data.Kind
@@ -59,6 +60,8 @@ data Function =
 class ( Typeable fun
       , Show (CalcInput  fun)
       , Show (CalcOutput fun)
+      , NFData (CalcInput  fun)
+      , NFData (CalcOutput fun)
       , Cbor.Serialise (CalcInput  fun)
       , Cbor.Serialise (CalcOutput fun)
       ) => CalculatorFunction (fun :: Function) where

--- a/grapesy/test-stress/Test/Stress/Driver.hs
+++ b/grapesy/test-stress/Test/Stress/Driver.hs
@@ -236,7 +236,7 @@ servers = [
         , componentPort   = 50000
         , componentSecure = False
         , componentStable = False
-        , componentLimit  = Just 60
+        , componentLimit  = Just 400
         , componentName   = "server-unstable-insecure"
         }
     , Component {
@@ -244,7 +244,7 @@ servers = [
         , componentPort   = 50001
         , componentSecure = True
         , componentStable = False
-        , componentLimit  = Just 100
+        , componentLimit  = Just 400
         , componentName   = "server-unstable-secure"
         }
     , Component {
@@ -252,7 +252,7 @@ servers = [
         , componentPort   = 50002
         , componentSecure = False
         , componentStable = True
-        , componentLimit  = Just 60
+        , componentLimit  = Just 400
         , componentName   = "server-stable-insecure"
         }
     , Component {
@@ -260,7 +260,7 @@ servers = [
         , componentPort   = 50003
         , componentSecure = True
         , componentStable = True
-        , componentLimit  = Just 100
+        , componentLimit  = Just 400
         , componentName   = "server-stable-secure"
         }
     ]


### PR DESCRIPTION
We force messages to NF before enqueueing them. This ensures that if those messages contain any pure exceptions (due to a bug in a client or a server), we detect the problem when the message is enqueued, and can throw an appropriate exception.
