### PR TITLE
    `recvResponseInitialMetadata` vs `recvResponseMetadata`

### DIFF
--- a/grapesy/interop/Interop/Client/TestCase/CustomMetadata.hs
+++ b/grapesy/interop/Interop/Client/TestCase/CustomMetadata.hs
@@ -57,13 +57,12 @@ runTest cmdline = do
         mkStreamingOutputCallRequest [(False, 314159)] (Just 271828)
 
 verifyRespMetadata ::
-     ResponseMetadata (Protobuf TestService meth)
-     -- ^ This /could/ be trailing (if the server responded with Trailers-Only)
+     ResponseInitialMetadata (Protobuf TestService meth)
   -> ResponseTrailingMetadata (Protobuf TestService meth)
   -> IO ()
 verifyRespMetadata initMeta trailMeta = do
     assertEqual initMeta $
-      ResponseInitialMetadata $ InteropRespInitMeta (Just expectInitVal)
+      InteropRespInitMeta (Just expectInitVal)
     assertEqual trailMeta $
       InteropRespTrailMeta (Just expectTrailVal)
 

--- a/grapesy/src/Network/GRPC/Client.hs
+++ b/grapesy/src/Network/GRPC/Client.hs
@@ -43,12 +43,13 @@ module Network.GRPC.Client (
     -- $openRequest
   , sendInput
   , recvOutput
-  , recvResponseInitialMetadata
+  , recvResponseMetadata
 
     -- ** Protocol specific wrappers
   , sendNextInput
   , sendFinalInput
   , sendEndOfInput
+  , recvResponseInitialMetadata
   , recvNextOutput
   , recvFinalOutput
   , recvTrailers

--- a/grapesy/src/Network/GRPC/Common.hs
+++ b/grapesy/src/Network/GRPC/Common.hs
@@ -134,6 +134,9 @@ data ProtocolException rpc =
     -- | We expected trailers, but got an output instead
   | TooManyOutputs (Output rpc)
 
+    -- | The server unexpectedly used the Trailers-Only case
+  | UnexpectedTrailersOnly (ResponseTrailingMetadata rpc)
+
 deriving stock instance IsRPC rpc => Show (ProtocolException rpc)
 
 -- | Existential wrapper around 'ProtocolException'

--- a/grapesy/test-grapesy/Test/Driver/Dialogue/Execution.hs
+++ b/grapesy/test-grapesy/Test/Driver/Dialogue/Execution.hs
@@ -205,8 +205,7 @@ clientLocal clock call = \(LocalSteps steps) ->
           Initiate expectedMetadata -> liftIO $ do
             receivedMetadata <- within timeoutReceive action $
                                   Client.recvResponseInitialMetadata call
-            expect (tick, action) (== ResponseInitialMetadata expectedMetadata) $
-              receivedMetadata
+            expect (tick, action) (== expectedMetadata) receivedMetadata
           Send (FinalElem a b) -> do
             -- On the client side, when the server sends the final message, we
             -- will receive that final message in one HTTP data frame, and then

--- a/tutorials/lowlevel/lowlevel.cabal
+++ b/tutorials/lowlevel/lowlevel.cabal
@@ -60,10 +60,10 @@ library
       Proto.API.RouteGuide
   other-modules:
       Proto.RouteGuide
-      Paths_basics
+      Paths_lowlevel
   autogen-modules:
       Proto.RouteGuide
-      Paths_basics
+      Paths_lowlevel
 
 executable route_guide_server
   import:          lang
@@ -73,7 +73,7 @@ executable route_guide_server
 
   build-depends:
       -- internal
-    , basics
+    , lowlevel
   build-depends:
       -- inherited
     , grapesy
@@ -87,7 +87,7 @@ executable route_guide_client
 
   build-depends:
       -- internal
-    , basics
+    , lowlevel
   build-depends:
       -- inherited
     , grapesy

--- a/tutorials/lowlevel/src/RouteGuide.hs
+++ b/tutorials/lowlevel/src/RouteGuide.hs
@@ -25,7 +25,7 @@ import Network.GRPC.Common.Protobuf
 
 import Proto.RouteGuide
 
-import Paths_basics
+import Paths_lowlevel
 
 {-------------------------------------------------------------------------------
   Querying the database


### PR DESCRIPTION
Renamed `recvResponseInitialMetadata` to `recvResponseMetadata`, and (re)introduced `recvResponseInitialMetaata` in the protocol specific API. This provides a better API.
