### PR TITLE
Fix `Invalid.requestMetadata` test

### DIFF
--- a/grapesy/test-grapesy/Test/Sanity/BrokenDeployments.hs
+++ b/grapesy/test-grapesy/Test/Sanity/BrokenDeployments.hs
@@ -272,6 +272,7 @@ test_invalidRequestMetadata = respondWith response $ \addr -> do
                (Client.ResponseHeaders' HandledSynthesized) <-
       Client.withConnection connParams' (Client.ServerInsecure addr) $ \conn ->
         Client.withRPC conn def (Proxy @Ping) $ \call -> do
+          Client.sendEndOfInput call
           Client.recvInitialResponse call
     case mResp of
       Right headers


### PR DESCRIPTION
Not sure why we didn't see this bug before, but a recent change to `http2` make it visible.