### PR TITLE
Remove `HTTP2Settings` from `ServerParams`

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -155,7 +155,6 @@ library
     , exceptions           >= 0.10    && < 0.11
     , grpc-spec            >= 0.1     && < 0.2
     , http-types           >= 0.12    && < 0.13
-    , http2                >= 5.3.4   && < 5.4
     , http2-tls            >= 0.4.1   && < 0.5
     , lens                 >= 5.0     && < 5.4
     , mtl                  >= 2.2     && < 2.4
@@ -171,6 +170,12 @@ library
     , unbounded-delays     >= 0.1.1   && < 0.2
     , unordered-containers >= 0.2     && < 0.3
     , utf8-string          >= 1.0     && < 1.1
+
+      -- We pin a very specific vrsion of http2.
+      --
+      -- Other versions should be tested against the full grapesy test suite
+      -- (regular tests and stress tests).
+    , http2 == 5.3.5
 
 test-suite test-record-dot
   import:         lang, common-executable-flags

--- a/grapesy/interop/Interop/Server.hs
+++ b/grapesy/interop/Interop/Server.hs
@@ -67,7 +67,7 @@ services =
 withInteropServer :: Cmdline -> (RunningServer -> IO a) -> IO a
 withInteropServer cmdline k = do
     server <- mkGrpcServer serverParams $ fromServices services
-    forkServer serverParams serverConfig server k
+    forkServer def serverConfig server k
   where
     serverConfig :: ServerConfig
     serverConfig

--- a/grapesy/kvstore/KVStore/Server.hs
+++ b/grapesy/kvstore/KVStore/Server.hs
@@ -57,20 +57,21 @@ withKeyValueServer cmdline@Cmdline{
           | otherwise = Protobuf.server $ handlers cmdline store
 
     server <- mkGrpcServer params rpcHandlers
-    forkServer params config server k
+    forkServer http2 config server k
   where
+    http2 :: HTTP2Settings
+    http2 = def {
+          http2TcpNoDelay            = not cmdDisableTcpNoDelay
+        , http2OverridePingRateLimit = cmdPingRateLimit
+        }
+
     params :: ServerParams
     params = def {
-          serverHTTP2Settings = def {
-              http2TcpNoDelay            = not cmdDisableTcpNoDelay
-            , http2OverridePingRateLimit = cmdPingRateLimit
-            }
-
           -- The Java benchmark does not use compression (unclear if the Java
           -- implementation supports compression at all; the compression Interop
           -- tests are also disabled for Java). For a fair comparison, we
           -- therefore disable compression here also.
-        , serverCompression = Compr.none
+          serverCompression = Compr.none
         }
 
 {-------------------------------------------------------------------------------

--- a/grapesy/src/Network/GRPC/Server/Context.hs
+++ b/grapesy/src/Network/GRPC/Server/Context.hs
@@ -83,9 +83,6 @@ data ServerParams = ServerParams {
       -- (merely that the metadata is syntactically correct). See
       -- 'Network.GRPC.Server.getRequestMetadata' for detailed discussion.
     , serverVerifyHeaders :: Bool
-
-      -- | HTTP\/2 settings
-    , serverHTTP2Settings :: HTTP2Settings
     }
 
 instance Default ServerParams where
@@ -95,7 +92,6 @@ instance Default ServerParams where
       , serverExceptionToClient = defaultServerExceptionToClient
       , serverContentType       = Just ContentTypeDefault
       , serverVerifyHeaders     = False
-      , serverHTTP2Settings     = def
       }
 
 defaultServerTopLevel :: RequestHandler () -> RequestHandler ()

--- a/grapesy/test-grapesy/Test/Driver/ClientServer.hs
+++ b/grapesy/test-grapesy/Test/Driver/ClientServer.hs
@@ -482,7 +482,7 @@ withTestServer cfg firstTestFailure handlerLock serverHandlers k = do
             }
 
     server <- Server.mkGrpcServer serverParams serverHandlers
-    Server.forkServer serverParams serverConfig server k
+    Server.forkServer def serverConfig server k
 
 {-------------------------------------------------------------------------------
   Client


### PR DESCRIPTION
This was a relatively common pattern:

```haskell
server <- mkGrpcServer serverParams $ ..
forkServer serverParams serverConfig server $ \runningServer -> ..
```

but it is misleading: notice that the `serverParams` need to be passed _twice_, even though on call to `forkServer` we need _only_ the `HTTP2Settings`, and on the call to `mkGrpcServer` we need everything in `ServerParams` _except_ the `HTTP2Settings`: they are completely separate. This gets even more confusing in a pattern such as this:

```haskell
server <- mkGrpcServer def $ ..
forkServer def serverConfig server $ \runningServer -> ..
```

where we are using `def` in both places; becomes quite easy to make a change in the wrong place, and then be confused that it didn't take effect. We are now separating these two values out completely.