### PR TITLE
Fix tests on MacOS

### DIFF
--- a/grapesy/test-grapesy/Test/Regression/Issue238.hs
+++ b/grapesy/test-grapesy/Test/Regression/Issue238.hs
@@ -189,7 +189,7 @@ testWith handlers client = do
   where
     serverConfig :: Server.ServerConfig
     serverConfig = Server.ServerConfig {
-          serverInsecure = Just $ Server.InsecureConfig Nothing 0
+          serverInsecure = Just $ Server.InsecureConfig (Just "127.0.0.1") 0
         , serverSecure   = Nothing
         }
 

--- a/tutorials/basics/app/Server.hs
+++ b/tutorials/basics/app/Server.hs
@@ -76,6 +76,6 @@ main = do
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure = Just (InsecureConfig Nothing defaultInsecurePort)
+          serverInsecure = Just (InsecureConfig (Just "0.0.0.0") defaultInsecurePort)
         , serverSecure   = Nothing
         }

--- a/tutorials/lowlevel/app/Server.hs
+++ b/tutorials/lowlevel/app/Server.hs
@@ -85,6 +85,6 @@ main = do
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure = Just (InsecureConfig Nothing defaultInsecurePort)
+          serverInsecure = Just (InsecureConfig (Just "0.0.0.0") defaultInsecurePort)
         , serverSecure   = Nothing
         }

--- a/tutorials/metadata/app/Server.hs
+++ b/tutorials/metadata/app/Server.hs
@@ -68,6 +68,6 @@ main =
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure = Just (InsecureConfig Nothing defaultInsecurePort)
+          serverInsecure = Just (InsecureConfig (Just "0.0.0.0") defaultInsecurePort)
         , serverSecure   = Nothing
         }

--- a/tutorials/monadstack/app/Server.hs
+++ b/tutorials/monadstack/app/Server.hs
@@ -95,6 +95,6 @@ main = do
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure = Just (InsecureConfig Nothing defaultInsecurePort)
+          serverInsecure = Just (InsecureConfig (Just "0.0.0.0") defaultInsecurePort)
         , serverSecure   = Nothing
         }

--- a/tutorials/quickstart/app/Server.hs
+++ b/tutorials/quickstart/app/Server.hs
@@ -32,6 +32,6 @@ main =
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure = Just (InsecureConfig Nothing defaultInsecurePort)
+          serverInsecure = Just (InsecureConfig (Just "0.0.0.0") defaultInsecurePort)
         , serverSecure   = Nothing
         }

--- a/tutorials/trailers-only/app/Server.hs
+++ b/tutorials/trailers-only/app/Server.hs
@@ -77,6 +77,6 @@ main = do
   where
     config :: ServerConfig
     config = ServerConfig {
-          serverInsecure = Just (InsecureConfig Nothing defaultInsecurePort)
+          serverInsecure = Just (InsecureConfig (Just "0.0.0.0") defaultInsecurePort)
         , serverSecure   = Nothing
         }


### PR DESCRIPTION
Previously the Issue238 tests failed on MacOS with "connection refused" in the client, but suspiciously all other tests passed. It took me longer than I'd like to admit to figure out why this was the case, but it's because these tests don't use the shared `testClientServer` driver that all of the other ones do. Instead, their own `testWith` passes `Nothing` as the bind addr, and on MacOS that winds up making an IPv6 socket and binding it to `::`. On Linux, one of two things prevents this from being a problem depending on the setup:

- An IPv4 socket is created by default.
- The `IPV6_V6ONLY` option is `0` by default (the manpage says that this can vary at runtime by some unspecified mechanism and programs must check `/proc/sys/net/ipv6/bindv6only` if they want to know the default value)


Providing an IPv4 bind address fixes this issue on MacOS.