### PR TITLE
Generalize test infrastructure a bit

### DIFF
--- a/grapesy/test-grapesy/Test/Regression/Issue102.hs
+++ b/grapesy/test-grapesy/Test/Regression/Issue102.hs
@@ -48,7 +48,10 @@ tests = testGroup "Issue102" [
 -- | Client makes many concurrent calls, throws an exception during one of them.
 test_clientException :: IO ()
 test_clientException = testClientServer $ ClientServerTest {
-      config = def { expectEarlyClientTermination = True }
+      config = def {
+           isExpectedClientException = isDeliberateException
+         , isExpectedServerException = isClientDisconnected
+         }
     , client = simpleTestClient $ \conn -> do
         -- Make 100 concurrent calls. 99 of them counting to 50, and one
         -- more that throws an exception once it reaches 10.
@@ -90,7 +93,7 @@ test_serverException :: IO ()
 test_serverException = do
     handlerCounter <- newIORef @Int 0
     testClientServer $ ClientServerTest {
-        config = def { expectEarlyServerTermination = True }
+        config = def { isExpectedServerException = isDeliberateException }
       , client = simpleTestClient $ \conn -> do
           -- Make 100 concurrent calls counting to 50.
           let predicate = (> 50)
@@ -131,7 +134,10 @@ test_serverException = do
 -- does not wait for client termination.
 test_earlyTerminationNoWait :: IO ()
 test_earlyTerminationNoWait = testClientServer $ ClientServerTest {
-      config = def { expectEarlyClientTermination = True }
+      config = def {
+          isExpectedClientException = isDeliberateException
+        , isExpectedServerException = isClientDisconnected
+        }
     , client = simpleTestClient $ \conn -> do
         _mResult <-
           try @DeliberateException $

--- a/grapesy/test-grapesy/Test/Sanity/BrokenDeployments.hs
+++ b/grapesy/test-grapesy/Test/Sanity/BrokenDeployments.hs
@@ -348,7 +348,9 @@ test_undefinedOutput :: Assertion
 test_undefinedOutput = do
     st <- newIORef 0
     testClientServer $ ClientServerTest {
-        config = def
+        config = def {
+            isExpectedServerException = isDeliberateException
+          }
       , server = [Server.fromMethod @Ping $ Server.mkNonStreaming (handler st)]
       , client = simpleTestClient $ \conn -> do
 
@@ -384,6 +386,7 @@ test_undefinedOutput = do
         if isFirst
           then return $ throw $ DeliberateException (userError "uhoh")
           else return $ defMessage & #id .~ req ^. #id
+
 {-------------------------------------------------------------------------------
   Timeouts
 -------------------------------------------------------------------------------}

--- a/grapesy/test-grapesy/Test/Sanity/Interop.hs
+++ b/grapesy/test-grapesy/Test/Sanity/Interop.hs
@@ -216,7 +216,7 @@ test_cancellation_client :: IO ()
 test_cancellation_client =
     testClientServer ClientServerTest {
         config = def {
-            expectEarlyClientTermination = True
+            isExpectedServerException = isClientDisconnected
           }
       , client = simpleTestClient $ \conn -> do
           -- We wait for the first input, but then cancel the request
@@ -245,7 +245,7 @@ test_cancellation_server :: IO ()
 test_cancellation_server =
     testClientServer ClientServerTest {
         config = def {
-            expectEarlyServerTermination = True
+            isExpectedServerException = isHandlerTerminated
           }
       , client = simpleTestClient $ \conn -> do
           result :: Either GrpcException [Int] <- try $

--- a/grapesy/test-grapesy/Test/Sanity/Reclamation.hs
+++ b/grapesy/test-grapesy/Test/Sanity/Reclamation.hs
@@ -32,7 +32,7 @@ brokenHandler _call = throwIO $ DeliberateException $ userError "Broken handler"
 
 serverException1 :: Assertion
 serverException1 = testClientServer $ ClientServerTest {
-      config = def
+      config = def { isExpectedServerException = isDeliberateException }
     , server = [Server.someRpcHandler $ Server.mkRpcHandler brokenHandler]
     , client = \params testServer delimitTestScope -> delimitTestScope $
         replicateM_ 1000 $ do
@@ -46,7 +46,7 @@ serverException1 = testClientServer $ ClientServerTest {
 
 serverException2 :: Assertion
 serverException2 = testClientServer $ ClientServerTest {
-      config = def
+      config = def { isExpectedServerException = isDeliberateException }
     , server = [Server.someRpcHandler $ Server.mkRpcHandler brokenHandler]
     , client = \params testServer delimitTestScope -> delimitTestScope $
         replicateM_ 1000 $


### PR DESCRIPTION
Previously we had logic in place that for every tests tried to guess which exceptions were expected, given the test configuration. This was a bit limiting however; it's easier to just put this logic in the tests themselves. We make that change in this PR, which will make the _next_ PR a bit easier.