### PR TITLE
POC: Add Unix socket support

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -274,14 +274,15 @@ test-suite test-grapesy
 
   build-depends:
       -- Additional dependencies
-    , proto-lens-runtime >= 0.7   && < 0.8
-    , QuickCheck         >= 2.14  && < 2.16
-    , serialise          >= 0.2   && < 0.3
-    , tasty              >= 1.4   && < 1.6
-    , tasty-hunit        >= 0.10  && < 0.11
-    , tasty-quickcheck   >= 0.10  && < 0.12
-    , temporary          >= 1.3   && < 1.4
-    , unix               >= 2.7   && < 2.9
+    , filepath           >= 1.4.2.1 && < 1.6
+    , proto-lens-runtime >= 0.7     && < 0.8
+    , QuickCheck         >= 2.14    && < 2.16
+    , serialise          >= 0.2     && < 0.3
+    , tasty              >= 1.4     && < 1.6
+    , tasty-hunit        >= 0.10    && < 0.11
+    , tasty-quickcheck   >= 0.10    && < 0.12
+    , temporary          >= 1.3     && < 1.4
+    , unix               >= 2.7     && < 2.9
 
 test-suite test-stress
   import:             lang, common-executable-flags

--- a/grapesy/src/Network/GRPC/Server/Run.hs
+++ b/grapesy/src/Network/GRPC/Server/Run.hs
@@ -66,7 +66,9 @@ data ServerConfig = ServerConfig {
   deriving stock (Show, Generic)
 
 -- | Offer insecure connection (no TLS)
-data InsecureConfig = InsecureConfig {
+data InsecureConfig =
+    -- | Insecure TCP connection
+    InsecureConfig {
       -- | Hostname
       insecureHost :: Maybe HostName
 
@@ -76,6 +78,11 @@ data InsecureConfig = InsecureConfig {
       -- testing scenarios; see 'getServerPort' or the more general
       -- 'getInsecureSocket' for a way to figure out what this port actually is.
     , insecurePort :: PortNumber
+    }
+    -- | Insecure (but local) Unix domain socket connection
+  | InsecureUnix {
+      -- | Path to the socket
+      insecurePath :: FilePath
     }
   deriving stock (Show, Generic)
 
@@ -297,14 +304,10 @@ runInsecure ::
   -> HTTP2.Server
   -> IO ()
 runInsecure http2 cfg socketTMVar server = do
-    withServerSocket
-        http2
-        socketTMVar
-        (insecureHost cfg)
-        (insecurePort cfg) $ \listenSock ->
+    openSock cfg $ \listenSock ->
       withTimeManager $ \mgr ->
         Run.runTCPServerWithSocket listenSock $ \clientSock -> do
-          when (http2TcpNoDelay http2) $ do
+          when (http2TcpNoDelay http2 && not isUnixSocket) $ do
             -- See description of 'withServerSocket'
             setSocketOption clientSock NoDelay 1
           when (http2TcpAbortiveClose http2) $ do
@@ -315,6 +318,22 @@ runInsecure http2 cfg socketTMVar server = do
   where
     serverConfig :: HTTP2.ServerConfig
     serverConfig = mkServerConfig http2
+
+    openSock :: InsecureConfig -> (Socket -> IO a) -> IO a
+    openSock InsecureConfig{insecureHost, insecurePort} = do
+      withServerSocket
+        http2
+        socketTMVar
+        insecureHost
+        insecurePort
+    openSock InsecureUnix{insecurePath} = do
+      withUnixSocket
+        insecurePath
+        socketTMVar
+
+    isUnixSocket = case cfg of
+      InsecureConfig{} -> False
+      InsecureUnix{}   -> True
 
 {-------------------------------------------------------------------------------
   Secure (over TLS)
@@ -420,3 +439,21 @@ withServerSocket http2Settings socketTMVar host port k = do
           ]
         ]
 
+-- | Create a Unix domain socket
+--
+-- Note that @TCP_NODELAY@ should not be set on unix domain sockets,
+-- otherwise clients would get their connection closed immediately.
+withUnixSocket :: FilePath -> TMVar Socket -> (Socket -> IO a) -> IO a
+withUnixSocket path socketTMVar k = do
+    bracket openServerSocket close $ \sock -> do
+      atomically $ putTMVar socketTMVar sock
+      k sock
+  where
+    openServerSocket :: IO Socket
+    openServerSocket = do
+      sock <- socket AF_UNIX Stream 0
+      setSocketOption sock ReuseAddr 1
+      withFdSocket sock setCloseOnExecIfNeeded
+      bind sock $ SockAddrUnix path
+      listen sock 1024
+      return sock

--- a/grapesy/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/grapesy/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -7,6 +7,8 @@ module Test.Sanity.StreamingType.NonStreaming (tests) where
 import Data.Word
 import Test.Tasty
 import Test.Tasty.HUnit
+import System.IO.Temp (getCanonicalTemporaryDirectory)
+import System.FilePath ((</>))
 
 import Network.GRPC.Client qualified as Client
 import Network.GRPC.Client.Binary qualified as Binary
@@ -25,6 +27,9 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
       testGroup "increment" [
           testCase "default" $
             test_increment def
+        , testCase "unix socket" $ do
+            tmpDir <- getCanonicalTemporaryDirectory
+            test_increment def { serverPort = Left (tmpDir </> "grapesy.sock") }
         , testGroup "Content-Type" [
               testGroup "ok" [
                   -- Without the +format part


### PR DESCRIPTION
This has been tested with Buck2's persistent worker feature. I also tested communication over unix sockets where grapesy was used for both the client and server.

Note that I know nothing about unix sockets. Any magic numbers or settings in the code are from the `network-run` package.

To get it to work I had to avoid doing `setSocketOption clientSock NoDelay 1` for unix sockets, otherwise clients would get their connection closed immediately.

I temporarily removed the `HTTP2.Client.authority = authority addr` line. I don't think there's a sensible value for unix sockets.