### PR TITLE
chore: add Nix development environment by `flake.nix`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "Development environment for Grapesy";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          # This is a minimal development shell configuration that provides the necessary
+          # native dependencies for building Grapesy. I'm intentionally avoiding the use
+          # of haskell.nix or other more sophisticated Haskell packaging approaches for now
+          # because:
+          #
+          # 1. The snappy-c Haskell package is currently broken in nixpkgs master
+          # 2. I want a simple environment that focuses on providing just the native
+          #    dependencies needed for successful builds
+          # 3. This approach is more accessible to developers who don't use Nix
+          #
+          # In an ideal world, I would use haskell.nix for a more robust build and
+          # packaging solution, but this minimal configuration serves our immediate needs
+          # for development and testing.
+
+          buildInputs = with pkgs; [
+            # Haskell Development Tools
+            cabal-install
+            ghc
+            haskell-language-server
+            (writeScriptBin "haskell-language-server-wrapper" ''
+              #!${stdenv.shell}
+              exec haskell-language-server "$@"
+            '')
+
+            # Native Dependencies
+            pkg-config
+            protobuf
+            snappy
+            zlib
+          ];
+        };
+      });
+}


### PR DESCRIPTION
This PR adds a minimal Nix flake to provide a development environment for building Grapesy.
The flake sets up the necessary native dependencies (snappy, protobuf, zlib) along with Haskell development tools.

Why this approach?
===

I've chosen to use a simple mkShell rather than more sophisticated Haskell packaging approaches like haskell.nix for several reasons:

The snappy-c Haskell package currently has build issues in nixpkgs master
This configuration focuses solely on providing native dependencies needed for successful builds
The approach keeps compatibility with non-Nix development workflows

The flake provides all necessary tools for development without introducing complex Nix dependencies that might be unfamiliar to many Haskell developers.

What it provides
===

GHC and cabal-install
Haskell Language Server
Native libraries: snappy, protobuf, zlib
pkg-config for library detection

This should make it easy for Nix users to get started with Grapesy development with a simple nix develop.
I use with direnv.
