### PR TITLE
Do not import Data.ProtoLens.Labels

### DIFF
--- a/grapesy/src/Network/GRPC/Common/Protobuf.hs
+++ b/grapesy/src/Network/GRPC/Common/Protobuf.hs
@@ -36,7 +36,6 @@ import Data.Function ((&))
 import Data.Int
 import Data.Maybe (fromMaybe)
 import Data.ProtoLens.Field (HasField(..))
-import Data.ProtoLens.Labels () -- provides instances for OverloadedLabels
 import Data.ProtoLens.Message (FieldDefault(..), Message(defMessage))
 import Data.Text (Text)
 


### PR DESCRIPTION
Otherwise grapesy infects downstream users with IsLabels instance and steals #field syntax, preventing using generic-lens or similar libraries.  IsLabels instance is not used in any tutorials or tests without explicit import.
Fixes #282 