### PR TITLE
Move ProtocolException to own module

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -117,6 +117,7 @@ library
   other-modules:
       Network.GRPC.Util.Imports
       Network.GRPC.Util.Stream
+      Network.GRPC.Common.ProtocolException
       Network.GRPC.Client.Call
       Network.GRPC.Client.Connection
       Network.GRPC.Client.Meta

--- a/grapesy/src/Network/GRPC/Client/Binary.hs
+++ b/grapesy/src/Network/GRPC/Client/Binary.hs
@@ -13,13 +13,14 @@ module Network.GRPC.Client.Binary (
   , recvFinalOutput
   ) where
 
-import Control.Monad.IO.Class
-import Data.Binary
+import Network.GRPC.Util.Imports
+
+import Data.Binary (Binary, encode)
 import Data.ByteString.Lazy qualified as Lazy (ByteString)
 
 import Network.GRPC.Client (Call)
 import Network.GRPC.Client qualified as Client
-import Network.GRPC.Common
+import Network.GRPC.Common.StreamElem (StreamElem(..))
 import Network.GRPC.Common.Binary (decodeOrThrow)
 
 {-------------------------------------------------------------------------------

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -29,19 +29,15 @@ module Network.GRPC.Client.Call (
   , recvInitialResponse
   ) where
 
+import Network.GRPC.Util.Imports
+
 import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Concurrent.Thread.Delay qualified as UnboundedDelays
-import Control.Monad
 import Control.Monad.Catch
-import Control.Monad.IO.Class
-import Data.Bifunctor
-import Data.Bitraversable
 import Data.ByteString.Char8 qualified as BS.Strict.C8
 import Data.Foldable (asum)
 import Data.List (intersperse)
-import Data.Maybe (fromMaybe)
-import Data.Proxy
 import Data.Text qualified as Text
 import Data.Version
 import GHC.Stack
@@ -49,10 +45,11 @@ import GHC.Stack
 import Network.GRPC.Client.Connection (Connection, ConnParams(..))
 import Network.GRPC.Client.Connection qualified as Connection
 import Network.GRPC.Client.Session
-import Network.GRPC.Common
+import Network.GRPC.Common.StreamElem (StreamElem(..))
+import Network.GRPC.Common.ProtocolException
+import Network.GRPC.Util.Session.Channel (ChannelDiscarded (..))
 import Network.GRPC.Common.Compression qualified as Compression
 import Network.GRPC.Common.StreamElem qualified as StreamElem
-import Network.GRPC.Spec
 import Network.GRPC.Spec.Util.HKD qualified as HKD
 import Network.GRPC.Util.GHC
 import Network.GRPC.Util.Stream (ServerDisconnected(..))

--- a/grapesy/src/Network/GRPC/Client/Session.hs
+++ b/grapesy/src/Network/GRPC/Client/Session.hs
@@ -10,18 +10,14 @@ module Network.GRPC.Client.Session (
   , InvalidTrailers(..)
   ) where
 
-import Control.Exception
-import Data.Proxy
-import Data.Void
+import Network.GRPC.Util.Imports
+
 import Network.HTTP.Types qualified as HTTP
 
 import Network.GRPC.Client.Connection (Connection, ConnParams(..))
 import Network.GRPC.Client.Connection qualified as Connection
-import Network.GRPC.Common
 import Network.GRPC.Common.Compression qualified as Compr
 import Network.GRPC.Common.Headers
-import Network.GRPC.Spec
-import Network.GRPC.Spec.Serialization
 import Network.GRPC.Util.Session.API
 import Network.GRPC.Util.Session.Client
 

--- a/grapesy/src/Network/GRPC/Client/StreamType.hs
+++ b/grapesy/src/Network/GRPC/Client/StreamType.hs
@@ -18,17 +18,15 @@ module Network.GRPC.Client.StreamType (
   , rpcWith
   ) where
 
-import Control.Monad.Catch
-import Control.Monad.IO.Class
-import Control.Monad.Reader
-import Data.Proxy
+import Network.GRPC.Util.Imports
+
+import Control.Monad.Catch (MonadMask)
+import Control.Monad.Reader (ReaderT, ask)
 
 import Network.GRPC.Client.Call
 import Network.GRPC.Client.Connection
-import Network.GRPC.Common
+import Network.GRPC.Common.StreamElem (StreamElem(..))
 import Network.GRPC.Common.NextElem qualified as NextElem
-import Network.GRPC.Common.StreamType
-import Network.GRPC.Spec
 
 {------------------------------------------------------------------------------
   Constructing client handlers (used internally only)

--- a/grapesy/src/Network/GRPC/Client/StreamType/Conduit.hs
+++ b/grapesy/src/Network/GRPC/Client/StreamType/Conduit.hs
@@ -7,14 +7,13 @@ module Network.GRPC.Client.StreamType.Conduit (
   , biDiStreaming
   ) where
 
-import Control.Monad.Reader
-import Data.Conduit
-import Data.ProtoLens.Service.Types
+import Network.GRPC.Util.Imports
+
+import Control.Monad.Reader (ReaderT, lift)
+import Data.Conduit (ConduitT, yield, await)
 
 import Network.GRPC.Client
 import Network.GRPC.Client.StreamType.IO qualified as IO
-import Network.GRPC.Common
-import Network.GRPC.Spec
 
 {-------------------------------------------------------------------------------
   Conduits for different kinds of streaming types (communication patterns)

--- a/grapesy/src/Network/GRPC/Client/StreamType/IO.hs
+++ b/grapesy/src/Network/GRPC/Client/StreamType/IO.hs
@@ -10,13 +10,11 @@ module Network.GRPC.Client.StreamType.IO (
   , biDiStreaming
   ) where
 
-import Control.Monad.Reader
+import Network.GRPC.Util.Imports
+import Control.Monad.Reader (ReaderT, runReaderT, lift)
 
 import Network.GRPC.Client
 import Network.GRPC.Client.StreamType.CanCallRPC qualified as CanCallRPC
-import Network.GRPC.Common
-import Network.GRPC.Common.StreamType
-import Network.GRPC.Spec
 
 {-------------------------------------------------------------------------------
   Run client handlers

--- a/grapesy/src/Network/GRPC/Client/StreamType/IO/Binary.hs
+++ b/grapesy/src/Network/GRPC/Client/StreamType/IO/Binary.hs
@@ -14,16 +14,15 @@ module Network.GRPC.Client.StreamType.IO.Binary (
   , biDiStreaming
   ) where
 
-import Control.Monad.Reader
-import Data.Binary
+import Network.GRPC.Util.Imports
+
+import Control.Monad.Reader (ReaderT)
+import Data.Binary (Binary, encode)
 import Data.ByteString.Lazy qualified as Lazy (ByteString)
 
 import Network.GRPC.Client (Connection)
 import Network.GRPC.Client.StreamType.IO qualified as IO
-import Network.GRPC.Common
 import Network.GRPC.Common.Binary (decodeOrThrow)
-import Network.GRPC.Common.StreamType
-import Network.GRPC.Spec
 
 {-------------------------------------------------------------------------------
   Run client handlers

--- a/grapesy/src/Network/GRPC/Common/ProtocolException.hs
+++ b/grapesy/src/Network/GRPC/Common/ProtocolException.hs
@@ -1,0 +1,47 @@
+module Network.GRPC.Common.ProtocolException (
+    ProtocolException(..),
+    SomeProtocolException(..),
+) where
+
+import Network.GRPC.Util.Imports
+
+{-------------------------------------------------------------------------------
+  Exceptions
+-------------------------------------------------------------------------------}
+
+-- | Protocol exception
+--
+-- A protocol exception arises when the client and the server disagree on the
+-- sequence of inputs and outputs exchanged. This agreement might be part of a
+-- formal specification such as Protobuf, or it might be implicit in the
+-- implementation of a specific RPC.
+data ProtocolException rpc =
+    -- | We expected an input but got none
+    TooFewInputs
+
+    -- | We received an input when we expected no more inputs
+  | TooManyInputs (Input rpc)
+
+    -- | We expected an output, but got trailers instead
+  | TooFewOutputs (ResponseTrailingMetadata rpc)
+
+    -- | We expected trailers, but got an output instead
+  | TooManyOutputs (Output rpc)
+
+    -- | The server unexpectedly used the Trailers-Only case
+  | UnexpectedTrailersOnly (ResponseTrailingMetadata rpc)
+
+deriving stock instance IsRPC rpc => Show (ProtocolException rpc)
+
+-- | Existential wrapper around 'ProtocolException'
+--
+-- This makes it easier to catch these exceptions (without this, you'd have to
+-- catch the exception for a /specific/ instance of @rpc@).
+data SomeProtocolException where
+    ProtocolException :: forall rpc.
+         IsRPC rpc
+      => ProtocolException rpc
+      -> SomeProtocolException
+
+deriving stock    instance Show SomeProtocolException
+deriving anyclass instance Exception SomeProtocolException

--- a/grapesy/src/Network/GRPC/Server/Binary.hs
+++ b/grapesy/src/Network/GRPC/Server/Binary.hs
@@ -13,11 +13,12 @@ module Network.GRPC.Server.Binary (
   , recvFinalInput
   ) where
 
-import Data.Binary
-import Data.ByteString.Lazy qualified as Lazy (ByteString)
-import GHC.Stack
+import Network.GRPC.Util.Imports
 
-import Network.GRPC.Common
+import Data.Binary (Binary, encode)
+import Data.ByteString.Lazy qualified as Lazy (ByteString)
+
+import Network.GRPC.Common.StreamElem (StreamElem(..))
 import Network.GRPC.Common.Binary (decodeOrThrow)
 import Network.GRPC.Server (Call)
 import Network.GRPC.Server qualified as Server

--- a/grapesy/src/Network/GRPC/Server/Call.hs
+++ b/grapesy/src/Network/GRPC/Server/Call.hs
@@ -49,7 +49,8 @@ import Control.Concurrent.STM.TMVar (TMVar, putTMVar, tryPutTMVar, tryReadTMVar,
 import Network.HTTP.Types qualified as HTTP
 import Network.HTTP2.Server qualified as HTTP2
 
-import Network.GRPC.Common
+import Network.GRPC.Common.ProtocolException
+import Network.GRPC.Common.StreamElem (StreamElem(..))
 import Network.GRPC.Common.Compression qualified as Compr
 import Network.GRPC.Common.Headers
 import Network.GRPC.Common.StreamElem qualified as StreamElem

--- a/grapesy/src/Network/GRPC/Server/StreamType.hs
+++ b/grapesy/src/Network/GRPC/Server/StreamType.hs
@@ -25,7 +25,7 @@ module Network.GRPC.Server.StreamType (
 
 import Network.GRPC.Util.Imports
 
-import Network.GRPC.Common
+import Network.GRPC.Common.StreamElem (StreamElem(..))
 import Network.GRPC.Common.NextElem qualified as NextElem
 import Network.GRPC.Server
 

--- a/grapesy/src/Network/GRPC/Server/StreamType/Binary.hs
+++ b/grapesy/src/Network/GRPC/Server/StreamType/Binary.hs
@@ -6,15 +6,13 @@ module Network.GRPC.Server.StreamType.Binary (
   , mkBiDiStreaming
   ) where
 
-import Control.Monad.IO.Class
-import Data.Binary
+import Network.GRPC.Util.Imports
+
+import Data.Binary (Binary, encode)
 import Data.ByteString.Lazy qualified as Lazy (ByteString)
 
-import Network.GRPC.Common
 import Network.GRPC.Common.Binary (decodeOrThrow)
-import Network.GRPC.Common.StreamType
 import Network.GRPC.Server.StreamType qualified as StreamType
-import Network.GRPC.Spec
 
 {-------------------------------------------------------------------------------
   Handlers for specific streaming types


### PR DESCRIPTION
Avoid importing Network.GRPC.Common from inside the library