### PR TITLE
Depend on http-semantics

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -158,6 +158,7 @@ library
     , deepseq                   >= 1.4     && < 1.6
     , exceptions                >= 0.10    && < 0.11
     , grpc-spec                 >= 1.0     && < 1.1
+    , http-semantics            >= 0.3.0   && < 0.3.1
     , http-types                >= 0.12    && < 0.13
     , http2-tls                 >= 0.4.9   && < 0.5
     , lens                      >= 5.0     && < 5.4

--- a/grapesy/src/Network/GRPC/Util/Session/API.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/API.hs
@@ -16,9 +16,7 @@ import Network.GRPC.Util.Imports
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Lazy qualified as Lazy (ByteString)
 import Network.HTTP.Types qualified as HTTP
-
--- Doesn't really matter if we import this from .Client or .Server
-import Network.HTTP2.Client qualified as HTTP2 (Path)
+import Network.HTTP.Semantics qualified as HTTP.Semantics (Path)
 
 import Network.GRPC.Spec.Util.Parser (Parser)
 
@@ -28,7 +26,7 @@ import Network.GRPC.Spec.Util.Parser (Parser)
 
 data RequestInfo = RequestInfo {
       requestMethod  :: HTTP.Method
-    , requestPath    :: HTTP2.Path
+    , requestPath    :: HTTP.Semantics.Path
     , requestHeaders :: [HTTP.Header]
     }
   deriving (Show)

--- a/grapesy/src/Network/GRPC/Util/Session/Channel.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Channel.hs
@@ -42,8 +42,7 @@ import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, readTMVar, putTMVar
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Lazy qualified as BS.Lazy
 
--- Doesn't really matter if we import from .Client or .Server
-import Network.HTTP2.Client qualified as HTTP2 (
+import Network.HTTP.Semantics qualified as HTTP.Semantics (
     TrailersMaker
   , NextTrailersMaker(..)
   )
@@ -620,17 +619,17 @@ outboundTrailersMaker :: forall sess.
   => sess
   -> Channel sess
   -> RegularFlowState (Outbound sess)
-  -> HTTP2.TrailersMaker
+  -> HTTP.Semantics.TrailersMaker
 outboundTrailersMaker sess Channel{channelOutbound} regular = go
   where
-    go :: HTTP2.TrailersMaker
-    go (Just _) = return $ HTTP2.NextTrailersMaker go
+    go :: HTTP.Semantics.TrailersMaker
+    go (Just _) = return $ HTTP.Semantics.NextTrailersMaker go
     go Nothing  = do
         mFlowState <- atomically $
           unlessAbnormallyTerminated channelOutbound $
             readTMVar (flowTerminated regular)
         case mFlowState of
             Right trailers ->
-              return $ HTTP2.Trailers $ buildOutboundTrailers sess trailers
+              return $ HTTP.Semantics.Trailers $ buildOutboundTrailers sess trailers
             Left _exception ->
-              return $ HTTP2.Trailers []
+              return $ HTTP.Semantics.Trailers []


### PR DESCRIPTION
This way we can drop direct dependencies on http2
in places which are not HTTP2 specific, but barely HTTP specific.