### PR TITLE
Remove Paths_grapesy dependency from the main library

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -87,7 +87,6 @@ common common-executable-flags
 
 library
   import:          lang
-  autogen-modules: Paths_grapesy
   hs-source-dirs:  src
 
   exposed-modules:
@@ -143,8 +142,8 @@ library
       Network.GRPC.Util.Thread
       Network.GRPC.Util.TLS
       Network.GRPC.Util.HeaderTable
+      Network.GRPC.Util.Version
 
-      Paths_grapesy
   build-depends:
     , aeson                     >= 1.5     && < 2.3
     , async                     >= 2.2     && < 2.3

--- a/grapesy/interop/Interop/Cmdline.hs
+++ b/grapesy/interop/Interop/Cmdline.hs
@@ -15,7 +15,7 @@ import Options.Applicative qualified as Opt
 
 import Network.GRPC.Common
 
-import Paths_grapesy
+import Paths_grapesy (getDataFileName)
 
 {-------------------------------------------------------------------------------
   Definition

--- a/grapesy/kvstore/KVStore/Server.hs
+++ b/grapesy/kvstore/KVStore/Server.hs
@@ -15,7 +15,7 @@ import KVStore.Cmdline
 import KVStore.Util.Store (Store)
 import KVStore.Util.Store qualified as Store
 
-import Paths_grapesy
+import Paths_grapesy (getDataFileName)
 
 {-------------------------------------------------------------------------------
   Server proper

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -37,9 +37,7 @@ import Control.Concurrent.Thread.Delay qualified as UnboundedDelays
 import Control.Monad.Catch
 import Data.ByteString.Char8 qualified as BS.Strict.C8
 import Data.Foldable (asum)
-import Data.List (intersperse)
 import Data.Text qualified as Text
-import Data.Version
 import GHC.Stack
 
 import Network.GRPC.Client.Connection (Connection, ConnParams(..))
@@ -58,7 +56,7 @@ import Network.GRPC.Util.Session.Channel qualified as Session
 import Network.GRPC.Util.Session.Client qualified as Session
 import Network.GRPC.Util.Thread qualified as Thread
 
-import Paths_grapesy qualified as Grapesy
+import Network.GRPC.Util.Version qualified as Grapesy
 
 {-------------------------------------------------------------------------------
   Open a call
@@ -272,9 +270,7 @@ startRPC conn _ callParams = do
         , requestUserAgent = Just $
             mconcat [
                 "grpc-haskell-grapesy/"
-              , mconcat . intersperse "." $
-                  map (BS.Strict.C8.pack . show) $
-                    versionBranch Grapesy.version
+              , BS.Strict.C8.pack Grapesy.version
               ]
         , requestIncludeTE =
             True

--- a/grapesy/src/Network/GRPC/Util/Version.hs
+++ b/grapesy/src/Network/GRPC/Util/Version.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE CPP #-} 
+module Network.GRPC.Util.Version (version) where
+
+-- | Version of this package
+version :: String
+version = CURRENT_PACKAGE_VERSION

--- a/grapesy/test-grapesy/Test/Driver/ClientServer.hs
+++ b/grapesy/test-grapesy/Test/Driver/ClientServer.hs
@@ -50,7 +50,7 @@ import Network.GRPC.Server qualified as Server
 import Network.GRPC.Server.Run qualified as Server
 import Test.Util.Exception
 
-import Paths_grapesy
+import Paths_grapesy (getDataFileName)
 
 {-------------------------------------------------------------------------------
   Top-level

--- a/grapesy/test-stress/Test/Stress/Cmdline.hs
+++ b/grapesy/test-stress/Test/Stress/Cmdline.hs
@@ -37,7 +37,7 @@ import Network.GRPC.Common.Compression (Compression)
 import Network.GRPC.Common.Compression qualified as Compr
 import Network.GRPC.Server.Run
 
-import Paths_grapesy
+import Paths_grapesy (getDataFileName)
 
 {-------------------------------------------------------------------------------
   Definitions


### PR DESCRIPTION
It's not that necessary in tests either:
arguably it's a bad thing to include in (global, i.e. installed) data-files things which are only needed for tests. I'll leave that for later refactoring.