### PR TITLE
Thread improvements and introducing monitoring

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -193,6 +193,10 @@ library
       -- (regular tests and stress tests).
     , http2 == 5.3.9
 
+
+  if(flag(patched-ghc-for-exception-debugging))
+    cpp-options: -DPATCHED_GHC_FOR_EXCEPTION_DEBUGGING
+
 test-suite test-record-dot
   import:         lang, common-executable-flags
   type:           exitcode-stdio-1.0
@@ -502,5 +506,10 @@ Flag build-stress-test
 
 Flag strace
   description: Write events to /dev/null in @grapesy-kvstore@ so that they show up in strace
+  default: False
+  manual: True
+
+Flag patched-ghc-for-exception-debugging
+  description: Use custom patched GHC with some exception improvements (probably useful for grapesy devs only)
   default: False
   manual: True

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -34,7 +34,8 @@ import Network.GRPC.Util.Imports
 import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Concurrent.Thread.Delay qualified as UnboundedDelays
-import Control.Monad.Catch
+import Control.Monad.Catch (MonadMask)
+import Control.Monad.Catch qualified as Exceptions
 import Data.ByteString.Char8 qualified as BS.Strict.C8
 import Data.Foldable (asum)
 import Data.Text qualified as Text
@@ -114,7 +115,7 @@ withRPC :: forall rpc m a.
      (MonadMask m, MonadIO m, SupportsClientRpc rpc, HasCallStack)
   => Connection -> CallParams rpc -> Proxy rpc -> (Call rpc -> m a) -> m a
 withRPC conn callParams proxy k = fmap fst $
-    generalBracket
+    Exceptions.generalBracket
       (liftIO $
          startRPC conn proxy callParams)
       (\(Call{callChannel}, cancelRequest) exitCase -> liftIO $

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -436,7 +436,8 @@ closeRPC callChannel cancelRequest exitCase = liftIO $ do
             , case mTerminated of
                 Thread.ThreadNotYetRunning_ () -> False
                 Thread.ThreadRunning_          -> False
-                Thread.ThreadDone_             -> True
+                Thread.ThreadDone_ _           -> True
+                Thread.ThreadTrivial_ _        -> True
                 Thread.ThreadException_ _      -> True
             ]
 

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -32,7 +32,8 @@ module Network.GRPC.Client.Call (
 import Network.GRPC.Util.Imports
 
 import Control.Concurrent
-import Control.Concurrent.STM
+import Control.Concurrent.STM (STM)
+import Control.Concurrent.STM qualified as STM
 import Control.Concurrent.Thread.Delay qualified as UnboundedDelays
 import Control.Monad.Catch (MonadMask)
 import Control.Monad.Catch qualified as Exceptions
@@ -232,8 +233,8 @@ startRPC conn _ callParams = do
       status <- atomically $ do
           (Left <$> Thread.waitForNormalOrAbnormalThreadTermination
                       (Session.channelInbound channel))
-        `orElse`
-          (Right <$> readTMVar connClosed)
+        `STM.orElse`
+          (Right <$> STM.readTMVar connClosed)
       forM_ mClientSideTimeout killThread
       case status of
         Left _ -> return () -- Channel closed before the connection
@@ -413,7 +414,7 @@ closeRPC callChannel cancelRequest exitCase = liftIO $ do
     checkCanDiscard :: IO Bool
     checkCanDiscard = do
         mRecvFinal  <- atomically $
-          readTVar $ Session.channelRecvFinal callChannel
+          STM.readTVar $ Session.channelRecvFinal callChannel
         let onNotRunning :: STM ()
             onNotRunning = return ()
         mTerminated <- atomically $

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -623,7 +623,7 @@ recvResponseInitialMetadata call@Call{} = liftIO $ do
       ResponseTrailingMetadata md' ->
         err $ UnexpectedTrailersOnly md'
   where
-    err :: ProtocolException rpc -> IO a
+    err :: HasCallStack => ProtocolException rpc -> IO a
     err = throwM . ProtocolException
 
 -- | Receive the next output
@@ -641,7 +641,7 @@ recvNextOutput call@Call{} = liftIO $ do
       Right (_env, out) ->
         return out
   where
-    err :: ProtocolException rpc -> IO a
+    err :: HasCallStack => ProtocolException rpc -> IO a
     err = throwM . ProtocolException
 
 -- | Receive output, which we expect to be the /final/ output
@@ -666,7 +666,7 @@ recvFinalOutput call@Call{} = liftIO $ do
           FinalElem  out' _ -> err $ TooManyOutputs @rpc out'
           StreamElem out'   -> err $ TooManyOutputs @rpc out'
   where
-    err :: ProtocolException rpc -> IO a
+    err :: HasCallStack => ProtocolException rpc -> IO a
     err = throwM . ProtocolException
 
 -- | Receive trailers
@@ -682,7 +682,7 @@ recvTrailers call@Call{} = liftIO $ do
       FinalElem  out _ts -> err $ TooManyOutputs @rpc out
       StreamElem out     -> err $ TooManyOutputs @rpc out
   where
-    err :: ProtocolException rpc -> IO a
+    err :: HasCallStack => ProtocolException rpc -> IO a
     err = throwM . ProtocolException
 
 {-------------------------------------------------------------------------------

--- a/grapesy/src/Network/GRPC/Client/Connection.hs
+++ b/grapesy/src/Network/GRPC/Client/Connection.hs
@@ -31,9 +31,8 @@ module Network.GRPC.Client.Connection (
 import Network.GRPC.Util.Imports
 
 import Control.Concurrent.MVar (MVar, readMVar, modifyMVar_)
-import Control.Concurrent.STM (atomically, retry, throwSTM)
-import Control.Concurrent.STM.TVar (TVar, readTVar)
-import Control.Concurrent.STM.TMVar (TMVar)
+import Control.Concurrent.STM (TVar, TMVar)
+import Control.Concurrent.STM qualified as STM
 import System.Random (randomRIO)
 
 import Network.GRPC.Client.Meta (Meta)
@@ -303,11 +302,11 @@ getConnectionToServer :: forall.
   => Connection
   -> IO (TMVar (Maybe ExactException), Session.ConnectionToServer)
 getConnectionToServer Connection{connStateVar} = atomically $ do
-    connState <- readTVar connStateVar
+    connState <- STM.readTVar connStateVar
     case connState of
-      ConnectionNotReady              -> retry
+      ConnectionNotReady              -> STM.retry
       ConnectionReady connClosed conn -> return (connClosed, conn)
-      ConnectionAbandoned err         -> throwSTM err
+      ConnectionAbandoned err         -> STM.throwSTM err
       ConnectionOutOfScope            -> error "impossible"
 
 -- | Get outbound compression algorithm

--- a/grapesy/src/Network/GRPC/Client/Run.hs
+++ b/grapesy/src/Network/GRPC/Client/Run.hs
@@ -32,9 +32,8 @@ import Network.GRPC.Client.Connection
 import Network.GRPC.Util.Imports
 
 import Control.Concurrent.MVar (MVar, newMVar, newEmptyMVar, putMVar, takeMVar)
-import Control.Concurrent.STM (atomically)
-import Control.Concurrent.STM.TVar (TVar, newTVarIO, writeTVar, readTVar)
-import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, putTMVar)
+import Control.Concurrent.STM (TVar, TMVar)
+import Control.Concurrent.STM qualified as STM
 import Network.HPACK qualified as HPACK
 import Network.HTTP2.Client qualified as HTTP2.Client
 import Network.HTTP2.TLS.Client qualified as HTTP2.TLS.Client
@@ -107,7 +106,7 @@ withConnection connParams server k = do
 openConnection :: ConnParams -> Server -> IO Connection
 openConnection connParams server = do
     connMetaVar  <- newMVar $ Meta.init (connInitCompression connParams)
-    connStateVar <- newTVarIO ConnectionNotReady
+    connStateVar <- STM.newTVarIO ConnectionNotReady
 
     connOutOfScope <- newEmptyMVar
     let stayConnectedThread :: IO ()
@@ -161,7 +160,7 @@ newConnectionAttempt attemptParams
                      attemptOnConnection
                      attemptState
                      attemptOutOfScope = do
-    attemptClosed <- newEmptyTMVarIO
+    attemptClosed <- STM.newEmptyTMVarIO
     return ConnectionAttempt{
         attemptParams
       , attemptOnConnection
@@ -209,8 +208,8 @@ stayConnected connParams initialServer connStateVar connOutOfScope = do
               connectUnix connParams attempt path
 
         thisReconnectPolicy <- atomically $ do
-          putTMVar (attemptClosed attempt) $ either Just (\() -> Nothing) mRes
-          connState <- readTVar connStateVar
+          STM.putTMVar (attemptClosed attempt) $ either Just (\() -> Nothing) mRes
+          connState <- STM.readTVar connStateVar
           return $ case connState of
             ConnectionReady{}->
               -- Suppose we have a maximum of 5x to try and connect to a server.
@@ -222,18 +221,18 @@ stayConnected connParams initialServer connStateVar connOutOfScope = do
 
         case mRes of
           Right () -> do
-            atomically $ writeTVar connStateVar $ ConnectionOutOfScope
+            atomically $ STM.writeTVar connStateVar $ ConnectionOutOfScope
           Left err
             | isFatalException err ->
-                atomically $ writeTVar connStateVar $ ConnectionAbandoned err
+                atomically $ STM.writeTVar connStateVar $ ConnectionAbandoned err
             | otherwise -> do
                 -- Mark the connection as not ready /before/ running the reconnt
                 -- policy. This prevents any attempts to use the connection
                 -- while the policy is running.
-                atomically $ writeTVar connStateVar $ ConnectionNotReady
+                atomically $ STM.writeTVar connStateVar $ ConnectionNotReady
                 runReconnectPolicy thisReconnectPolicy >>= \case
                   DontReconnect -> do
-                    atomically $ writeTVar connStateVar $ ConnectionAbandoned err
+                    atomically $ STM.writeTVar connStateVar $ ConnectionAbandoned err
                   DoReconnect reconnect -> do
                     let
                       nextServer =
@@ -280,7 +279,7 @@ connectSocket connParams attempt connAuthority sock = do
       HTTP2.Client.run clientConfig conf $ \sendRequest _aux -> do
         let conn = Session.ConnectionToServer sendRequest
         atomically $
-          writeTVar (attemptState attempt) $
+          STM.writeTVar (attemptState attempt) $
             ConnectionReady (attemptClosed attempt) conn
         runOnConnection $ attemptOnConnection attempt
         takeMVar $ attemptOutOfScope attempt
@@ -353,7 +352,7 @@ connectSecure connParams attempt validation sslKeyLog addr = do
         $ \sendRequest _aux -> do
       let conn = Session.ConnectionToServer sendRequest
       atomically $
-        writeTVar (attemptState attempt) $
+        STM.writeTVar (attemptState attempt) $
           ConnectionReady (attemptClosed attempt) conn
       runOnConnection $ attemptOnConnection attempt
       takeMVar $ attemptOutOfScope attempt

--- a/grapesy/src/Network/GRPC/Client/Session.hs
+++ b/grapesy/src/Network/GRPC/Client/Session.hs
@@ -17,6 +17,7 @@ import Network.HTTP.Types qualified as HTTP
 import Network.GRPC.Client.Connection (Connection, ConnParams(..))
 import Network.GRPC.Client.Connection qualified as Connection
 import Network.GRPC.Common.Compression qualified as Compr
+import Network.GRPC.Common.Exception
 import Network.GRPC.Common.Headers
 import Network.GRPC.Util.Session.API
 import Network.GRPC.Util.Session.Client

--- a/grapesy/src/Network/GRPC/Common/Exception.hs
+++ b/grapesy/src/Network/GRPC/Common/Exception.hs
@@ -9,7 +9,8 @@
 -- depends on, such as @http2@.
 module Network.GRPC.Common.Exception (
     -- * Exception rendering
-    ToExceptionDoc -- opaque
+    ToExceptionDoc(..)
+  , renderDoc
   , renderException
   , LinesToExceptionDoc(..)
 
@@ -28,23 +29,31 @@ module Network.GRPC.Common.Exception (
   , tryExact
   , waitCatchExact
 
-    -- * Shim: backtraces
+    -- * Shims
+
+    -- ** Throwing
+  , throwIO
+  , throwM
+
+    -- ** Backtraces
   , Backtraces
   , collectBacktraces
   , displayBacktraces
 
-    -- * Shim: WithAnnotations (ExceptionWithContext)
+    -- ** Annotations
   , WithAnnotations
   , pattern WithAnnotations
-
-    -- * Shim: annotateIO
   , annotateIO
+  , addExceptionContext
   ) where
 
 import Control.Concurrent.Async
 import Control.Concurrent.STM
-import Control.Exception
+import Control.Exception (Exception(..), SomeException(..))
+import Control.Exception qualified as Base
+import Control.Monad.Catch qualified as Exceptions
 import Data.Bifunctor
+import Data.Foldable (asum)
 import Data.Foldable qualified as Foldable
 import Data.Semigroup
 import Data.String
@@ -52,6 +61,8 @@ import Data.Typeable
 import GHC.Generics
 import GHC.Stack
 import GHC.TypeLits
+import Network.HTTP2.Client qualified as HTTP2
+import System.ThreadManager qualified as TimeManager
 
 #if MIN_VERSION_base(4,20,0)
 import Control.Exception.Annotation
@@ -93,6 +104,12 @@ renderDoc = \d ->
           VCat    ds'   -> go $ map (i,) ds' ++ ds
           Indent     i' d' -> go $ (i + i', d') : ds
 
+withHeader :: String -> Doc -> Doc
+withHeader header body = mconcat [
+      fromString header
+    , Indent 2 body
+    ]
+
 {-------------------------------------------------------------------------------
   Construct readable exception rendering
 -------------------------------------------------------------------------------}
@@ -117,6 +134,7 @@ class ToExceptionDoc a where
 renderException :: ToExceptionDoc e => e -> String
 renderException = renderDoc . toExceptionDoc
 
+-- | Deriving-via support for 'ToExceptionDoc'
 newtype LinesToExceptionDoc a = LinesToExceptionDoc a
 
 instance Show a => ToExceptionDoc (LinesToExceptionDoc a) where
@@ -133,30 +151,23 @@ instance ( GToDoc p
          , KnownSymbol typ
          , KnownSymbol modl
          ) => GToDoc (D1 ('MetaData typ modl pkg isNewtype) p) where
-  gToDoc (M1 x) = mconcat [
-        fromString $ concat [
-            symbolVal (Proxy @modl)
-          , "."
-          , symbolVal (Proxy @typ)
-          ]
-      , Indent 2 $ gToDoc x
-      ]
+  gToDoc (M1 x) =
+      withHeader (symbolVal (Proxy @modl) ++ "." ++ symbolVal (Proxy @typ)) $
+        gToDoc x
 
 instance ( GToDoc p
          , KnownSymbol constr
          ) => GToDoc (C1 ('MetaCons constr fixity hasFields) p) where
-  gToDoc (M1 x) = mconcat [
-        fromString $ symbolVal (Proxy @constr)
-      , Indent 2 $ gToDoc x
-      ]
+  gToDoc (M1 x) =
+      withHeader (symbolVal (Proxy @constr)) $
+        gToDoc x
 
 instance ( GToDoc p
          , KnownSymbol fieldSel
          ) => GToDoc (S1 ('MetaSel (Just fieldSel) unpack strict lazy) p) where
-  gToDoc (M1 x) = mconcat [
-        fromString $ symbolVal (Proxy @fieldSel)
-      , Indent 2 $ gToDoc x
-      ]
+  gToDoc (M1 x) =
+      withHeader (symbolVal (Proxy @fieldSel)) $
+        gToDoc x
 
 instance GToDoc p => GToDoc (S1 ('MetaSel Nothing unpack strict lazy) p) where
   gToDoc (M1 x) = gToDoc x
@@ -184,37 +195,23 @@ instance ToExceptionDoc a => ToExceptionDoc (Maybe a) where
 instance ToExceptionDoc a => ToExceptionDoc [a] where
   toExceptionDoc = foldMap toExceptionDoc
 
-instance ToExceptionDoc SomeException where
-  toExceptionDoc se@(SomeException e) = mconcat [
-          fromString $ show (typeOf e)
-        , Indent 2 $ mconcat [
-              fromLines $ displayException e
-            , toExceptionDoc classified
-            ]
-        ]
-    where
-      classified :: Classified
-      classified = classifyAnnotations se
-
 instance ToExceptionDoc CallStack where
   toExceptionDoc cs =
       fromLines $ prettyCallStack cs
 
-#if MIN_VERSION_base(4,20,0)
-instance ToExceptionDoc SomeExceptionAnnotation where
-  toExceptionDoc (SomeExceptionAnnotation a) =
-      fromLines $ displayExceptionAnnotation a
+instance ToExceptionDoc Backtraces where
+  toExceptionDoc bt =
+      fromLines $ displayBacktraces bt
 
+#if MIN_VERSION_base(4,20,0)
 instance ToExceptionDoc ExceptionContext where
   toExceptionDoc (ExceptionContext anns) = toExceptionDoc anns
 #endif
 
 #if MIN_VERSION_base(4,21,0)
-instance ToExceptionDoc WhileHandling where
-  toExceptionDoc (WhileHandling e) = mconcat [
-        "WhileHandling"
-      , Indent 2 $ toExceptionDoc e
-      ]
+instance ToExceptionDoc Base.WhileHandling where
+  toExceptionDoc (Base.WhileHandling e) =
+      withHeader "WhileHandling" $ toExceptionDoc e
 #endif
 
 {-------------------------------------------------------------------------------
@@ -292,21 +289,39 @@ withoutAnnotations (WrapExactException (SomeException e)) k = k e
 -- since 'throwIO' /itself/ can be used safely with 'ExactException'.
 catchExact :: IO a -> (ExactException -> IO a) -> IO a
 #if !MIN_VERSION_base(4,21,0)
-catchExact = catch
+catchExact = Base.catch
 #else
 catchExact action handler =
-    catchNoPropagate action (handler . aux)
+    Base.catchNoPropagate action (handler . aux)
   where
     -- NOTE: only used in GHC 9.12 and up
-    aux :: ExceptionWithContext SomeException -> ExactException
-    aux (ExceptionWithContext _ctxt se) = WrapExactException se
+    aux :: Base.ExceptionWithContext SomeException -> ExactException
+    aux (Base.ExceptionWithContext _ctxt se) = WrapExactException se
 #endif
 
 tryExact :: IO a -> IO (Either ExactException a)
-tryExact = try
+tryExact = Base.try
 
 waitCatchExact :: Async a -> STM (Either ExactException a)
 waitCatchExact = fmap (first WrapExactException) . waitCatchSTM
+
+{-------------------------------------------------------------------------------
+  Shim: throwing
+-------------------------------------------------------------------------------}
+
+throwIO :: (Exception e, HasCallStack) => e -> IO a
+throwIO = Base.throwIO
+#if !MIN_VERSION_base(4,20,0)
+  where
+    _suppressRedundantConstraintWarning = callStack
+#endif
+
+throwM :: (Exception e, Exceptions.MonadThrow m, HasCallStack) => e -> m a
+throwM = Exceptions.throwM
+#if !MIN_VERSION_exceptions(0,10,6)
+  where
+    _suppressRedundantConstraintWarning = callStack
+#endif
 
 {-------------------------------------------------------------------------------
   Shim: bug-free version of 'ExceptionWithContext'
@@ -354,16 +369,16 @@ instance Exception a => Exception (WithAnnotations a) where
             in SomeException c
     fromException se = do
         e <- fromException se
-        return (WithAnnotations (someExceptionContext se) e)
+        return (WithAnnotations (Base.someExceptionContext se) e)
     backtraceDesired (WithAnnotations _ e) = backtraceDesired e
     displayException = displayException . toException
 
 #else
 
-type WithAnnotations = ExceptionWithContext
+type WithAnnotations = Base.ExceptionWithContext
 
 pattern WithAnnotations :: ExceptionContext -> a -> WithAnnotations a
-pattern WithAnnotations ctxt e = ExceptionWithContext ctxt e
+pattern WithAnnotations ctxt e = Base.ExceptionWithContext ctxt e
 
 #endif
 
@@ -401,23 +416,6 @@ displayBacktraces = Backtrace.displayBacktraces . unwrapBacktraces
 
 #endif
 
-instance ToExceptionDoc Backtraces where
-  toExceptionDoc bt =
-      fromLines $ displayBacktraces bt
-
-{-------------------------------------------------------------------------------
-  Shim: Make 'WhileHandling' an empty type for GHC < 9.12
--------------------------------------------------------------------------------}
-
-#if !MIN_VERSION_base(4,21,0)
-
-data WhileHandling
-
-instance ToExceptionDoc WhileHandling where
-  toExceptionDoc x = case x of {}
-
-#endif
-
 {-------------------------------------------------------------------------------
   Shim: Make `annotateIO` a no-op for GHC < 9.10
 -------------------------------------------------------------------------------}
@@ -427,59 +425,116 @@ instance ToExceptionDoc WhileHandling where
 annotateIO :: ann -> IO a -> IO a
 annotateIO _ = id
 
-#endif
-
-{-------------------------------------------------------------------------------
-  Classify exception annotations
--------------------------------------------------------------------------------}
-
-#if !MIN_VERSION_base(4,20,0)
-
--- No annotations prior to GHC 9.10
-data Classified = NoAnnotations
-
-classifyAnnotations :: SomeException -> Classified
-classifyAnnotations _ = NoAnnotations
-
-instance ToExceptionDoc Classified where
-  toExceptionDoc NoAnnotations = mempty
+addExceptionContext :: ann -> SomeException -> SomeException
+addExceptionContext _ = id
 
 #else
 
-data Classified = Classified{
-      other         :: [SomeExceptionAnnotation]
-    , backtraces    :: Maybe Backtraces
-    , whileHandling :: Maybe WhileHandling
-    }
+annotateIO ::
+     ExceptionAnnotation ann
+  => ann -> IO a -> IO a
+annotateIO = Base.annotateIO
 
-instance ToExceptionDoc Classified where
-  toExceptionDoc Classified{other, backtraces, whileHandling} = mconcat [
-        foldMap toExceptionDoc other
-      , foldMap toExceptionDoc backtraces
-      , foldMap toExceptionDoc whileHandling
-      ]
-
-classifyAnnotations :: SomeException -> Classified
-classifyAnnotations se =
-    let ExceptionContext annotations = someExceptionContext se
-    in go Classified{
-              other         = []
-            , backtraces    = Nothing
-            , whileHandling = Nothing
-            }
-          annotations
-  where
-    go :: Classified -> [SomeExceptionAnnotation] -> Classified
-    go acc [] = acc{other = reverse (other acc)}
-    go acc (sa@(SomeExceptionAnnotation a):as)
-      | Just a' <- cast a, Nothing <- backtraces acc
-      = go acc{backtraces = Just a'} as
-
-      | Just a' <- cast a, Nothing <- whileHandling acc
-      = go acc{whileHandling = Just a'} as
-
-      | otherwise
-      = go acc{other = sa:other acc} as
+addExceptionContext ::
+     ExceptionAnnotation ann
+  => ann -> SomeException -> SomeException
+addExceptionContext = Base.addExceptionContext
 
 #endif
 
+{-------------------------------------------------------------------------------
+  Special-casing: exception annotations
+-------------------------------------------------------------------------------}
+
+data SpecialCaseException =
+    CaseSomeAsyncException Base.SomeAsyncException
+  | CaseKilledByThreadManager TimeManager.KilledByThreadManager
+  | CaseHTTP2Error HTTP2.HTTP2Error
+
+specialCaseException :: Typeable e => e -> Maybe SpecialCaseException
+specialCaseException e = asum [
+      CaseSomeAsyncException    <$> cast e
+    , CaseKilledByThreadManager <$> cast e
+    , CaseHTTP2Error            <$> cast e
+    ]
+
+instance ToExceptionDoc SomeException where
+  toExceptionDoc (SomeException e) =
+      withHeader (show (typeOf e)) $ mconcat [
+          renderWithoutContext e
+#if MIN_VERSION_base(4,20,0)
+        , toExceptionDoc ?exceptionContext
+#endif
+        ]
+
+renderWithoutContext :: Exception e => e -> Doc
+renderWithoutContext e =
+    maybe (renderGenericException e) toExceptionDoc $
+      specialCaseException e
+
+-- | Display generic exception (no special-casing)
+--
+-- The exception context is handled in the 'ToExceptionDoc' instance for
+-- 'SomeException'.
+renderGenericException :: Exception e => e -> Doc
+renderGenericException = fromLines . displayException
+
+instance ToExceptionDoc SpecialCaseException where
+  toExceptionDoc = \case
+      CaseSomeAsyncException    x -> toExceptionDoc x
+      CaseKilledByThreadManager x -> toExceptionDoc x
+      CaseHTTP2Error            x -> toExceptionDoc x
+
+instance ToExceptionDoc Base.SomeAsyncException where
+  toExceptionDoc (Base.SomeAsyncException e) =
+      withHeader "SomeAsyncException" $ renderWithoutContext e
+
+instance ToExceptionDoc TimeManager.KilledByThreadManager where
+  toExceptionDoc = \case
+      TimeManager.KilledByThreadManager mse ->
+        withHeader "KilledByThreadManager" $ toExceptionDoc mse
+
+instance ToExceptionDoc HTTP2.HTTP2Error where
+  toExceptionDoc = \case
+      HTTP2.BadThingHappen se ->
+        withHeader "BadThingHappen" $ toExceptionDoc se
+      other ->
+        renderGenericException other
+
+{-------------------------------------------------------------------------------
+  Special-casing: exceptions
+-------------------------------------------------------------------------------}
+
+#if MIN_VERSION_base(4,20,0)
+
+data SpecialCaseAnnotation =
+    CaseBacktraces Backtraces
+#if MIN_VERSION_base(4,21,0)
+  | CaseWhileHandling Base.WhileHandling
+#endif
+
+specialCaseAnnotation :: Typeable ann => ann -> Maybe SpecialCaseAnnotation
+specialCaseAnnotation ann = asum [
+      CaseBacktraces    <$> cast ann
+#if MIN_VERSION_base(4,21,0)
+    , CaseWhileHandling <$> cast ann
+#endif
+    ]
+
+instance ToExceptionDoc SomeExceptionAnnotation where
+  toExceptionDoc (SomeExceptionAnnotation ann) =
+      maybe (renderGenericAnnotation ann) toExceptionDoc $
+        specialCaseAnnotation ann
+
+-- | Render generic annotation (no special-casing)
+renderGenericAnnotation :: ExceptionAnnotation ann => ann -> Doc
+renderGenericAnnotation = fromLines . displayExceptionAnnotation
+
+instance ToExceptionDoc SpecialCaseAnnotation where
+  toExceptionDoc = \case
+      CaseBacktraces    x -> toExceptionDoc x
+#if MIN_VERSION_base(4,21,0)
+      CaseWhileHandling x -> toExceptionDoc x
+#endif
+
+#endif

--- a/grapesy/src/Network/GRPC/Common/Exception.hs
+++ b/grapesy/src/Network/GRPC/Common/Exception.hs
@@ -45,10 +45,14 @@ module Network.GRPC.Common.Exception (
   , pattern WithAnnotations
   , annotateIO
   , addExceptionContext
+
+    -- ** STM
+  , atomically
   ) where
 
 import Control.Concurrent.Async
-import Control.Concurrent.STM
+import Control.Concurrent.STM (STM)
+import Control.Concurrent.STM qualified as STM
 import Control.Exception (Exception(..), SomeException(..))
 import Control.Exception qualified as Base
 import Control.Monad.Catch qualified as Exceptions
@@ -538,3 +542,27 @@ instance ToExceptionDoc SpecialCaseAnnotation where
 #endif
 
 #endif
+
+{-------------------------------------------------------------------------------
+  STM support
+-------------------------------------------------------------------------------}
+
+-- | Backtrace to a call to 'atomically'
+--
+-- When an STM transaction throws an exception, this will tell us where that
+-- tranaction was invoked (though not where /within/ the transaction it
+-- threw an exception).
+newtype AtomicallyBacktrace = AtomicallyBacktrace Backtraces
+  deriving stock (Generic)
+  deriving anyclass (ToExceptionDoc)
+
+#if MIN_VERSION_base(4,20,0)
+instance ExceptionAnnotation AtomicallyBacktrace where
+  displayExceptionAnnotation = renderDoc . toExceptionDoc
+#endif
+
+atomically :: HasCallStack => STM a -> IO a
+atomically stm = do
+    backtraces <- collectBacktraces
+    annotateIO (AtomicallyBacktrace backtraces) $
+      STM.atomically stm

--- a/grapesy/src/Network/GRPC/Common/Exception.hs
+++ b/grapesy/src/Network/GRPC/Common/Exception.hs
@@ -47,7 +47,12 @@ module Network.GRPC.Common.Exception (
   , addExceptionContext
 
     -- ** STM
+#ifdef PATCHED_GHC_FOR_EXCEPTION_DEBUGGING
+  , STM.atomically
+#else
+  , AtomicallyBacktrace(..)
   , atomically
+#endif
   ) where
 
 import Control.Concurrent.Async
@@ -212,7 +217,14 @@ instance ToExceptionDoc ExceptionContext where
   toExceptionDoc (ExceptionContext anns) = toExceptionDoc anns
 #endif
 
-#if MIN_VERSION_base(4,21,0)
+#ifdef PATCHED_GHC_FOR_EXCEPTION_DEBUGGING
+instance ToExceptionDoc Base.WhileHandling where
+  toExceptionDoc (Base.WhileHandling cs e) =
+      withHeader "WhileHandling" $ mconcat [
+          fromLines $ prettyCallStack cs
+        , toExceptionDoc e
+        ]
+#elif MIN_VERSION_base(4,21,0)
 instance ToExceptionDoc Base.WhileHandling where
   toExceptionDoc (Base.WhileHandling e) =
       withHeader "WhileHandling" $ toExceptionDoc e
@@ -547,6 +559,9 @@ instance ToExceptionDoc SpecialCaseAnnotation where
   STM support
 -------------------------------------------------------------------------------}
 
+#ifdef PATCHED_GHC_FOR_EXCEPTION_DEBUGGING
+-- Nothing to do, part of the patch
+#else
 -- | Backtrace to a call to 'atomically'
 --
 -- When an STM transaction throws an exception, this will tell us where that
@@ -566,3 +581,4 @@ atomically stm = do
     backtraces <- collectBacktraces
     annotateIO (AtomicallyBacktrace backtraces) $
       STM.atomically stm
+#endif

--- a/grapesy/src/Network/GRPC/Common/Protobuf.hs
+++ b/grapesy/src/Network/GRPC/Common/Protobuf.hs
@@ -37,6 +37,7 @@ import Data.Int (Int32)
 import Data.ProtoLens.Field (HasField(..), field)
 import Data.ProtoLens.Message (FieldDefault(..), Message(defMessage))
 
+import Network.GRPC.Common.Exception
 import Network.GRPC.Common.Protobuf.Any (Any)
 import Network.GRPC.Common.Protobuf.Any qualified as Any
 

--- a/grapesy/src/Network/GRPC/Server/Call.hs
+++ b/grapesy/src/Network/GRPC/Server/Call.hs
@@ -43,9 +43,8 @@ module Network.GRPC.Server.Call (
 
 import Network.GRPC.Util.Imports
 
-import Control.Concurrent.STM (atomically, throwSTM)
-import Control.Concurrent.STM.TVar (TVar, writeTVar, readTVar, newTVarIO)
-import Control.Concurrent.STM.TMVar (TMVar, putTMVar, tryPutTMVar, tryReadTMVar, newEmptyTMVarIO, readTMVar)
+import Control.Concurrent.STM (TVar, TMVar)
+import Control.Concurrent.STM qualified as STM
 import Network.HTTP.Types qualified as HTTP
 import Network.HTTP.Semantics.Server qualified as Server
 
@@ -148,8 +147,8 @@ setupCall :: forall rpc.
   -> ServerContext
   -> IO (Call rpc, Maybe Timeout)
 setupCall conn callContext@ServerContext{serverParams} = do
-    callResponseMetadata <- newTVarIO CallInitialMetadataNotSet
-    callResponseKickoff  <- newEmptyTMVarIO
+    callResponseMetadata <- STM.newTVarIO CallInitialMetadataNotSet
+    callResponseKickoff  <- STM.newEmptyTMVarIO
 
     (inboundHeaders, timeout) <- determineInbound callSession req
     let callRequestHeaders = inbHeaders inboundHeaders
@@ -234,7 +233,7 @@ startOutbound :: forall rpc.
   -> IO (Session.FlowStart (ServerOutbound rpc), Session.ResponseInfo)
 startOutbound serverParams metadataVar kickoffVar cOut = do
     -- Wait for kickoff (see 'Kickoff' for discussion)
-    kickoff <- atomically $ readTMVar kickoffVar
+    kickoff <- atomically $ STM.readTMVar kickoffVar
 
     -- Session start
     flowStart :: Session.FlowStart (ServerOutbound rpc) <-
@@ -250,7 +249,7 @@ startOutbound serverParams metadataVar kickoffVar cOut = do
           -- handler might not yet have had the opportunity to set the initial
           -- metdata prior to the error.
           responseMetadata <- do
-            mMetadata <- atomically $ readTVar metadataVar
+            mMetadata <- atomically $ STM.readTVar metadataVar
             case mMetadata of
               CallInitialMetadataSet md _backtrace ->
                 buildMetadataIO md
@@ -523,13 +522,13 @@ setResponseInitialMetadata Call{ callResponseMetadata
                            md = do
     newBacktrace <- collectBacktraces
     atomically $ do
-      mKickoff  <- fmap kickoffBacktrace <$> tryReadTMVar callResponseKickoff
+      mKickoff  <- fmap kickoffBacktrace <$> STM.tryReadTMVar callResponseKickoff
       case mKickoff of
         Nothing ->
-          writeTVar callResponseMetadata $
+          STM.writeTVar callResponseMetadata $
             CallInitialMetadataSet md newBacktrace
         Just oldBacktrace ->
-          throwSTM $ ResponseAlreadyInitiated {
+          STM.throwSTM $ ResponseAlreadyInitiated {
               responseInitiatedFirst = oldBacktrace
             , responseInitiatedAgain = newBacktrace
             }
@@ -549,7 +548,7 @@ setResponseInitialMetadata Call{ callResponseMetadata
 initiateResponse :: HasCallStack => Call rpc -> IO ()
 initiateResponse Call{callResponseKickoff} = void $ do
     backtrace <- collectBacktraces
-    atomically $ tryPutTMVar callResponseKickoff $ KickoffRegular backtrace
+    atomically $ STM.tryPutTMVar callResponseKickoff $ KickoffRegular backtrace
 
 -- | Use the gRPC @Trailers-Only@ case for non-error responses
 --
@@ -580,12 +579,12 @@ sendTrailersOnly Call{callContext, callResponseKickoff} metadata = do
     metadata'    <- buildMetadataIO metadata
     newBacktrace <- collectBacktraces
     atomically $ do
-      previously <- fmap kickoffBacktrace <$> tryReadTMVar callResponseKickoff
+      previously <- fmap kickoffBacktrace <$> STM.tryReadTMVar callResponseKickoff
       case previously of
         Nothing ->
-          putTMVar callResponseKickoff $
+          STM.putTMVar callResponseKickoff $
             KickoffTrailersOnly newBacktrace (trailers metadata')
-        Just oldBacktrace -> throwSTM $ ResponseAlreadyInitiated {
+        Just oldBacktrace -> STM.throwSTM $ ResponseAlreadyInitiated {
             responseInitiatedFirst = oldBacktrace
           , responseInitiatedAgain = newBacktrace
           }
@@ -707,7 +706,7 @@ sendProperTrailers Call{callContext, callResponseKickoff, callChannel}
     backtrace <- collectBacktraces
     updated <-
       atomically $
-        tryPutTMVar callResponseKickoff $
+        STM.tryPutTMVar callResponseKickoff $
           KickoffTrailersOnly
             backtrace
             ( properTrailersToTrailersOnly (

--- a/grapesy/src/Network/GRPC/Server/Call.hs
+++ b/grapesy/src/Network/GRPC/Server/Call.hs
@@ -650,7 +650,7 @@ recvNextInput call@Call{} = do
       NoNextElem   -> err $ TooFewInputs @rpc
       NextElem inp -> return inp
   where
-    err :: ProtocolException rpc -> IO a
+    err :: HasCallStack => ProtocolException rpc -> IO a
     err = throwIO . ProtocolException
 
 -- | Receive input, which we expect to be the /final/ input
@@ -672,7 +672,7 @@ recvFinalInput call@Call{} = do
           FinalElem  inp' NoMetadata -> err $ TooManyInputs @rpc inp'
           StreamElem inp'            -> err $ TooManyInputs @rpc inp'
   where
-    err :: ProtocolException rpc -> IO a
+    err :: HasCallStack => ProtocolException rpc -> IO a
     err = throwIO . ProtocolException
 
 -- | Wait for the client to indicate that there are no more inputs
@@ -686,7 +686,7 @@ recvEndOfInput call@Call{} = do
       FinalElem  inp NoMetadata -> err $ TooManyInputs @rpc inp
       StreamElem inp            -> err $ TooManyInputs @rpc inp
   where
-    err :: ProtocolException rpc -> IO a
+    err :: HasCallStack => ProtocolException rpc -> IO a
     err = throwIO . ProtocolException
 
 {-------------------------------------------------------------------------------

--- a/grapesy/src/Network/GRPC/Server/Handler.hs
+++ b/grapesy/src/Network/GRPC/Server/Handler.hs
@@ -16,7 +16,7 @@ module Network.GRPC.Server.Handler (
   ) where
 
 import Control.Concurrent.STM
-import Control.Exception
+import Control.Exception qualified as E
 import System.ThreadManager (KilledByThreadManager(..))
 
 import Network.GRPC.Common.Exception
@@ -308,7 +308,7 @@ data AsyncStatus a =
 
 waitAsyncStatus :: (forall x. IO x -> IO x) -> Async a -> IO (AsyncStatus a)
 waitAsyncStatus unmask async =
-    handle (return . WaitInterrupted) $
+    E.handle (return . WaitInterrupted) $
       either AsyncFailed AsyncDone <$>
         unmask (tryAgain $ atomically $ waitCatchExact async)
   where
@@ -320,4 +320,4 @@ waitAsyncStatus unmask async =
     -- See also blog post “When "blocked indefinitely" is not indefinite”
     -- <https://well-typed.com/blog/2024/01/when-blocked-indefinitely-is-not-indefinite/>.
     tryAgain :: forall x. IO x -> IO x
-    tryAgain f = f `catch` \BlockedIndefinitelyOnSTM -> f
+    tryAgain f = f `catch` \E.BlockedIndefinitelyOnSTM -> f

--- a/grapesy/src/Network/GRPC/Server/Handler.hs
+++ b/grapesy/src/Network/GRPC/Server/Handler.hs
@@ -15,7 +15,6 @@ module Network.GRPC.Server.Handler (
   , runHandler
   ) where
 
-import Control.Concurrent.STM
 import Control.Exception qualified as E
 import System.ThreadManager (KilledByThreadManager(..))
 
@@ -306,7 +305,10 @@ data AsyncStatus a =
  | AsyncFailed ExactException
  | WaitInterrupted ExactException
 
-waitAsyncStatus :: (forall x. IO x -> IO x) -> Async a -> IO (AsyncStatus a)
+waitAsyncStatus ::
+     HasCallStack
+  => (forall x. IO x -> IO x)
+  -> Async a -> IO (AsyncStatus a)
 waitAsyncStatus unmask async =
     E.handle (return . WaitInterrupted) $
       either AsyncFailed AsyncDone <$>

--- a/grapesy/src/Network/GRPC/Server/Handler.hs
+++ b/grapesy/src/Network/GRPC/Server/Handler.hs
@@ -66,8 +66,11 @@ import Network.GRPC.Util.Stream (ClientDisconnected(..))
 -- the client as 'GrpcException' with 'GrpcUnknown' error code.
 data RpcHandler (m :: Type -> Type) (rpc :: k) = RpcHandler {
       -- | Handler proper
-      runRpcHandler :: Call rpc -> m ()
+      runRpcHandler_ :: HasCallStack => Call rpc -> m ()
     }
+
+runRpcHandler :: HasCallStack => RpcHandler m rpc -> Call rpc -> m ()
+runRpcHandler RpcHandler{runRpcHandler_} = runRpcHandler_
 
 -- | Hoist an 'RpcHandler' to a different monad
 --
@@ -102,7 +105,8 @@ mkRpcHandler ::
      ( Default (ResponseInitialMetadata rpc)
      , MonadIO m
      )
-  => (Call rpc -> m ()) -> RpcHandler m rpc
+  => (HasCallStack => Call rpc -> m ())
+  -> RpcHandler m rpc
 mkRpcHandler k = RpcHandler $ \call -> do
     liftIO $ setResponseInitialMetadata call def
     k call

--- a/grapesy/src/Network/GRPC/Server/Run.hs
+++ b/grapesy/src/Network/GRPC/Server/Run.hs
@@ -28,8 +28,8 @@ module Network.GRPC.Server.Run (
 
 import Network.GRPC.Util.Imports
 
-import Control.Concurrent.STM (STM, atomically, catchSTM, throwSTM, orElse)
-import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, putTMVar, readTMVar)
+import Control.Concurrent.STM (STM, TMVar)
+import Control.Concurrent.STM qualified as STM
 import Network.HTTP.Semantics.Server qualified as Server
 import Network.HTTP2.Server qualified as HTTP2 (ServerConfig, run)
 import Network.HTTP2.TLS.Server qualified as HTTP2.TLS
@@ -195,8 +195,8 @@ forkServer ::
   -> (RunningServer -> IO a)
   -> IO a
 forkServer http2 ServerConfig{serverInsecure, serverSecure} server k = do
-    runningSocketInsecure <- newEmptyTMVarIO
-    runningSocketSecure   <- newEmptyTMVarIO
+    runningSocketInsecure <- STM.newEmptyTMVarIO
+    runningSocketSecure   <- STM.newEmptyTMVarIO
 
     let secure, insecure :: IO ()
         insecure =
@@ -266,15 +266,15 @@ getSecureSocket server = do
 -- Precondition: only one server must be enabled (secure or insecure).
 getServerSocket :: RunningServer -> STM Socket
 getServerSocket server = do
-    insecure <- catchSTM (Right <$> getInsecureSocket server) (return . Left)
-    secure   <- catchSTM (Right <$> getSecureSocket   server) (return . Left)
+    insecure <- STM.catchSTM (Right <$> getInsecureSocket server) (return . Left)
+    secure   <- STM.catchSTM (Right <$> getSecureSocket   server) (return . Left)
     case (insecure, secure) of
       (Right sock, Left ServerTerminated) ->
         return sock
       (Left ServerTerminated, Right sock) ->
         return sock
       (Left ServerTerminated, Left ServerTerminated) ->
-        throwSTM ServerTerminated
+        STM.throwSTM ServerTerminated
       (Right _, Right _) ->
         error $ "getServerSocket: precondition violated"
 
@@ -293,11 +293,11 @@ getServerPort server = do
 -- | Internal generalization of 'getInsecureSocket'/'getSecureSocket'
 getSocket :: Async () -> TMVar Socket -> STM Socket
 getSocket serverAsync socketTMVar = do
-    status <-  (Left  <$> waitCatchExact serverAsync)
-      `orElse` (Right <$> readTMVar      socketTMVar)
+    status <-      (Left  <$> waitCatchExact serverAsync)
+      `STM.orElse` (Right <$> STM.readTMVar  socketTMVar)
     case status of
-      Left (Left err) -> throwSTM err
-      Left (Right ()) -> throwSTM $ ServerTerminated
+      Left (Left err) -> STM.throwSTM err
+      Left (Right ()) -> STM.throwSTM $ ServerTerminated
       Right sock      -> return sock
 
 {-------------------------------------------------------------------------------
@@ -440,7 +440,7 @@ withServerSocket http2Settings socketTMVar host port k = do
     addr <- Run.resolve Socket.Stream host (show port) [Socket.AI_PASSIVE]
 #endif
     bracket (openServerSocket addr) Socket.close $ \sock -> do
-      atomically $ putTMVar socketTMVar sock
+      atomically $ STM.putTMVar socketTMVar sock
       k sock
   where
     openServerSocket :: AddrInfo -> IO Socket
@@ -457,7 +457,7 @@ withServerSocket http2Settings socketTMVar host port k = do
 withUnixSocket :: FilePath -> TMVar Socket -> (Socket -> IO a) -> IO a
 withUnixSocket path socketTMVar k = do
     bracket openServerSocket Socket.close $ \sock -> do
-      atomically $ putTMVar socketTMVar sock
+      atomically $ STM.putTMVar socketTMVar sock
       k sock
   where
     openServerSocket :: IO Socket

--- a/grapesy/src/Network/GRPC/Util/Imports.hs
+++ b/grapesy/src/Network/GRPC/Util/Imports.hs
@@ -7,7 +7,7 @@ module Network.GRPC.Util.Imports (
 import Control.Concurrent.Async as X (Async, cancelWith, wait, withAsync)
 import Control.DeepSeq as X (NFData, force)
 import Control.Exception as X (evaluate)
-import Control.Exception as X (Exception (toException, fromException, displayException), bracket, catch, throwIO)
+import Control.Exception as X (Exception (toException, fromException, displayException), bracket, catch)
 import Control.Monad as X (void, when, unless, forM_)
 import Control.Monad.Catch as X (ExitCase(..))
 import Control.Monad.IO.Class as X (MonadIO(liftIO))

--- a/grapesy/src/Network/GRPC/Util/Session/Channel.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Channel.hs
@@ -36,9 +36,8 @@ module Network.GRPC.Util.Session.Channel (
 
 import Network.GRPC.Util.Imports
 
-import Control.Concurrent.STM (STM, atomically, throwSTM)
-import Control.Concurrent.STM.TVar (TVar, newTVarIO, readTVar, writeTVar)
-import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, readTMVar, putTMVar, takeTMVar)
+import Control.Concurrent.STM (STM, TVar, TMVar)
+import Control.Concurrent.STM qualified as STM
 import Data.ByteString.Builder (Builder)
 import Data.ByteString.Lazy qualified as BS.Lazy
 
@@ -190,8 +189,8 @@ initChannel :: HasCallStack => IO (Channel sess)
 initChannel = do
     channelInbound   <- newThreadState
     channelOutbound  <- newThreadState
-    channelSentFinal <- newTVarIO Nothing
-    channelRecvFinal <- newTVarIO RecvNotFinal
+    channelSentFinal <- STM.newTVarIO Nothing
+    channelRecvFinal <- STM.newTVarIO RecvNotFinal
     return Channel{
         channelInbound
       , channelOutbound
@@ -201,8 +200,8 @@ initChannel = do
 
 initFlowStateRegular :: Headers flow -> IO (RegularFlowState flow)
 initFlowStateRegular flowHeaders = do
-   flowMsg        <- newEmptyTMVarIO
-   flowTerminated <- newEmptyTMVarIO
+   flowMsg        <- STM.newEmptyTMVarIO
+   flowTerminated <- STM.newEmptyTMVarIO
    return RegularFlowState {
        flowHeaders
      , flowMsg
@@ -254,21 +253,21 @@ send Channel{channelOutbound, channelSentFinal} = \msg -> do
         -- sends messages to the peer will get to it eventually (unless it dies,
         -- in which case the thread status will change and the call to
         -- 'getThreadInterface' will be retried).
-        sentFinal <- readTVar channelSentFinal
+        sentFinal <- STM.readTVar channelSentFinal
         case sentFinal of
-          Just cs -> throwSTM $ SendAfterFinal cs
+          Just cs -> STM.throwSTM $ SendAfterFinal cs
           Nothing -> return ()
         case st of
           FlowStateRegular regular -> do
             StreamElem.whenDefinitelyFinal msg $ \_trailers ->
-              writeTVar channelSentFinal $ Just backtrace
+              STM.writeTVar channelSentFinal $ Just backtrace
 
-            putTMVar (flowMsg regular) msg
+            STM.putTMVar (flowMsg regular) msg
           FlowStateNoMessages _ ->
             -- For outgoing messages, the caller decides to use Trailers-Only,
             -- so if they then subsequently call 'send', we throw an exception.
             -- This is different for /inbound/ messages; see 'recv', below.
-            throwSTM $ SendButTrailersOnly
+            STM.throwSTM $ SendButTrailersOnly
 
 -- | Receive a message from the node's peer
 --
@@ -340,12 +339,12 @@ recv' messageWithoutTrailers
         -- that receives messages from the peer will get to it eventually
         -- (unless it dies, in which case the thread status will change and the
         -- call to 'getThreadInterface' will be retried).
-        readFinal <- readTVar channelRecvFinal
+        readFinal <- STM.readTVar channelRecvFinal
         case readFinal of
           RecvNotFinal ->
             case st of
               FlowStateRegular regular -> Right <$> do
-                streamElem <- takeTMVar (flowMsg regular)
+                streamElem <- STM.takeTMVar (flowMsg regular)
                 -- We update 'channelRecvFinal' in the same tx as the read, to
                 -- atomically change "there is a value" to "all values read".
                 case streamElem of
@@ -353,20 +352,20 @@ recv' messageWithoutTrailers
                     return $ messageWithoutTrailers msg
                   FinalElem msg trailers -> do
                     let (b, mTrailers) = messageWithTrailers (msg, trailers)
-                    writeTVar channelRecvFinal $
+                    STM.writeTVar channelRecvFinal $
                       maybe (RecvFinal backtrace) RecvWithoutTrailers mTrailers
                     return $ b
                   NoMoreElems trailers -> do
-                    writeTVar channelRecvFinal $ RecvFinal backtrace
+                    STM.writeTVar channelRecvFinal $ RecvFinal backtrace
                     return $ trailersWithoutMessage trailers
               FlowStateNoMessages trailers -> do
-                writeTVar channelRecvFinal $ RecvFinal backtrace
+                STM.writeTVar channelRecvFinal $ RecvFinal backtrace
                 return $ Left trailers
           RecvWithoutTrailers trailers -> do
-            writeTVar channelRecvFinal $ RecvFinal backtrace
+            STM.writeTVar channelRecvFinal $ RecvFinal backtrace
             return $ Right $ trailersWithoutMessage trailers
           RecvFinal cs ->
-            throwSTM $ RecvAfterFinal cs
+            STM.throwSTM $ RecvAfterFinal cs
 
 -- | Thrown by 'send'
 --
@@ -544,14 +543,14 @@ sendMessageLoop :: forall sess.
   -> IO ()
 sendMessageLoop sess st stream = do
     trailers <- loop
-    atomically $ putTMVar (flowTerminated st) trailers
+    atomically $ STM.putTMVar (flowTerminated st) trailers
   where
     build :: (Message (Outbound sess) -> Builder)
     build = buildMsg sess (flowHeaders st)
 
     loop :: IO (Trailers (Outbound sess))
     loop = do
-        msg <- atomically $ takeTMVar (flowMsg st)
+        msg <- atomically $ STM.takeTMVar (flowMsg st)
         case msg of
           StreamElem x -> do
             writeChunk stream $ build x
@@ -592,23 +591,23 @@ recvMessageLoop sess st stream =
             return trailers
           Nothing -> do
             trailers <- processTrailers
-            atomically $ putTMVar (flowMsg st) $ NoMoreElems trailers
+            atomically $ STM.putTMVar (flowMsg st) $ NoMoreElems trailers
             return trailers
 
     processOne :: Message (Inbound sess) -> IO ()
     processOne msg = do
-        atomically $ putTMVar (flowMsg st) $ StreamElem msg
+        atomically $ STM.putTMVar (flowMsg st) $ StreamElem msg
 
     processFinal :: Message (Inbound sess) -> IO (Trailers (Inbound sess))
     processFinal msg = do
         trailers <- processTrailers
-        atomically $ putTMVar (flowMsg st) $ FinalElem msg trailers
+        atomically $ STM.putTMVar (flowMsg st) $ FinalElem msg trailers
         return trailers
 
     processTrailers :: IO (Trailers (Inbound sess))
     processTrailers = do
         trailers <- parseInboundTrailers sess =<< getTrailers stream
-        atomically $ putTMVar (flowTerminated st) $ trailers
+        atomically $ STM.putTMVar (flowTerminated st) $ trailers
         return trailers
 
     throwParseErrors :: Parser.ProcessResult String b -> IO (Maybe b)
@@ -634,7 +633,7 @@ outboundTrailersMaker sess Channel{channelOutbound} regular = go
     go Nothing  = do
         mFlowState <- atomically $
           unlessAbnormallyTerminated channelOutbound $
-            readTMVar (flowTerminated regular)
+            STM.readTMVar (flowTerminated regular)
         case mFlowState of
             Right trailers ->
               return $ HTTP.Semantics.Trailers $ buildOutboundTrailers sess trailers

--- a/grapesy/src/Network/GRPC/Util/Session/Channel.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Channel.hs
@@ -7,7 +7,6 @@ module Network.GRPC.Util.Session.Channel (
     Channel(..)
   , initChannel
     -- ** Flow state
-  , FlowState(..)
   , RegularFlowState(..)
   , initFlowStateRegular
     -- * Working with an open channel
@@ -24,7 +23,6 @@ module Network.GRPC.Util.Session.Channel (
   , ChannelDiscarded(..)
   , ChannelAborted(..)
     -- * Support for half-closing
-  , InboundResult
   , AllowHalfClosed(..)
   , linkOutboundToInbound
     -- * Constructing channels
@@ -84,10 +82,10 @@ import Network.GRPC.Util.Thread
 -- Each channel is constructed for a /single/ session (request/response).
 data Channel sess = Channel {
       -- | Thread state of the thread receiving messages from the peer
-      channelInbound :: TVar (ThreadState (FlowState (Inbound sess)))
+      channelInbound :: TVar (FlowThreadState (Inbound sess))
 
       -- | Thread state of the thread sending messages to the peer
-    , channelOutbound :: TVar (ThreadState (FlowState (Outbound sess)))
+    , channelOutbound :: TVar (FlowThreadState (Outbound sess))
 
       -- | Have we sent the final message?
       --
@@ -104,6 +102,19 @@ data Channel sess = Channel {
     , channelRecvFinal :: TVar (RecvFinal (Inbound sess))
     }
 
+-- | Thread that deals with inbound or outbound flow
+type FlowThreadState flow =
+       ThreadState
+         (RegularFlowState flow)
+         (Trailers         flow)
+         (NoMessages       flow)
+
+-- | Interface to 'FlowThreadState'
+type FlowThreadIface flow =
+       ThreadIface
+         (RegularFlowState flow)
+         (NoMessages       flow)
+
 -- | Has the client code received the final message from the peer yet?
 --
 -- NOTE: \"delivered\" here means: put the final message that we received from
@@ -119,11 +130,6 @@ data RecvFinal flow =
   | RecvFinal Backtraces
 
 deriving instance DataFlow flow => Show (RecvFinal flow)
-
--- | Data flow state
-data FlowState flow =
-    FlowStateRegular (RegularFlowState flow)
-  | FlowStateNoMessages (NoMessages flow)
 
 -- | Regular (streaming) flow state
 data RegularFlowState flow = RegularFlowState {
@@ -177,6 +183,13 @@ data RegularFlowState flow = RegularFlowState {
       --   available by 'recvMessageLoop'.
       --
       -- /Their/ sole purpose is to catch user errors, not capture data flow.
+      --
+      -- == Relation to 'ThreadState'
+      --
+      -- Although the threads write their final result (that is, the trailers)
+      -- to the 'ThreadState', we cannot use that in the trailers maker, because
+      -- the trailers are constructed /within/ the thread: that is, before it
+      -- terminates.
     , flowTerminated :: TMVar (Trailers flow)
     }
 
@@ -227,11 +240,10 @@ getInboundHeaders ::
 getInboundHeaders Channel{channelInbound} =
     withThreadInterface channelInbound (return . aux)
   where
-    aux :: forall flow.
-         FlowState flow
-      -> Either (NoMessages flow) (Headers flow)
-    aux (FlowStateRegular    regular)  = Right $ flowHeaders regular
-    aux (FlowStateNoMessages trailers) = Left trailers
+    aux :: FlowThreadIface flow -> Either (NoMessages flow) (Headers flow)
+    aux = \case
+      IfaceAvailable regular  -> Right $ flowHeaders regular
+      IfaceTrivial   trailers -> Left trailers
 
 -- | Send a message to the node's peer
 --
@@ -251,9 +263,9 @@ send Channel{channelOutbound, channelSentFinal} = \msg -> do
     aux ::
          Backtraces
       -> StreamElem (Trailers (Outbound sess)) (Message (Outbound sess))
-      -> FlowState (Outbound sess)
+      -> FlowThreadIface (Outbound sess)
       -> STM ()
-    aux backtrace msg st = do
+    aux backtrace msg iface = do
         -- By checking that we haven't sent the final message yet, we know that
         -- this call to 'putMVar' will not block indefinitely: the thread that
         -- sends messages to the peer will get to it eventually (unless it dies,
@@ -263,13 +275,12 @@ send Channel{channelOutbound, channelSentFinal} = \msg -> do
         case sentFinal of
           Just cs -> STM.throwSTM $ SendAfterFinal cs
           Nothing -> return ()
-        case st of
-          FlowStateRegular regular -> do
+        case iface of
+          IfaceAvailable regular -> do
             StreamElem.whenDefinitelyFinal msg $ \_trailers ->
               STM.writeTVar channelSentFinal $ Just backtrace
-
             STM.putTMVar (flowMsg regular) msg
-          FlowStateNoMessages _ ->
+          IfaceTrivial _trailers ->
             -- For outgoing messages, the caller decides to use Trailers-Only,
             -- so if they then subsequently call 'send', we throw an exception.
             -- This is different for /inbound/ messages; see 'recv', below.
@@ -339,9 +350,9 @@ recv' messageWithoutTrailers
 
     aux ::
          Backtraces
-      -> FlowState (Inbound sess)
+      -> FlowThreadIface (Inbound sess)
       -> STM (Either (NoMessages (Inbound sess)) b)
-    aux backtrace st = do
+    aux backtrace iface = do
         -- By checking that we haven't received the final message yet, we know
         -- that this call to 'takeTMVar' will not block indefinitely: the thread
         -- that receives messages from the peer will get to it eventually
@@ -350,8 +361,8 @@ recv' messageWithoutTrailers
         readFinal <- STM.readTVar channelRecvFinal
         case readFinal of
           RecvNotFinal ->
-            case st of
-              FlowStateRegular regular -> Right <$> do
+            case iface of
+              IfaceAvailable regular -> Right <$> do
                 streamElem <- STM.takeTMVar (flowMsg regular)
                 -- We update 'channelRecvFinal' in the same tx as the read, to
                 -- atomically change "there is a value" to "all values read".
@@ -366,7 +377,7 @@ recv' messageWithoutTrailers
                   NoMoreElems trailers -> do
                     STM.writeTVar channelRecvFinal $ RecvFinal backtrace
                     return $ trailersWithoutMessage trailers
-              FlowStateNoMessages trailers -> do
+              IfaceTrivial trailers -> do
                 STM.writeTVar channelRecvFinal $ RecvFinal backtrace
                 return $ Left trailers
           RecvWithoutTrailers trailers -> do
@@ -410,7 +421,7 @@ data RecvAfterFinal =
 -- See 'close' for discussion.
 waitForOutbound :: HasCallStack => Channel sess -> IO ()
 waitForOutbound Channel{channelOutbound} =
-    waitForNormalThreadTermination channelOutbound
+    void $ waitForNormalThreadTermination channelOutbound
 
 -- | Close the channel
 --
@@ -482,10 +493,6 @@ data ChannelAborted = ChannelAborted Backtraces
   Support for half-closing
 -------------------------------------------------------------------------------}
 
-type InboundResult sess =
-       Either (NoMessages (Inbound sess))
-              (Trailers   (Inbound sess))
-
 -- | Should we allow for a half-closed connection state?
 --
 -- In HTTP2, streams are bidirectional and can be half-closed in either
@@ -494,9 +501,9 @@ type InboundResult sess =
 -- (indicating that the client will not send any more messages), but not from
 -- the server to the client: when the server half-closes their connection, it
 -- sends the gRPC trailers and this terminates the call.
-data AllowHalfClosed sess =
+data AllowHalfClosed r =
     ContinueWhenInboundClosed
-  | TerminateWhenInboundClosed (InboundResult sess -> ExactException)
+  | TerminateWhenInboundClosed (r -> ExactException)
 
 -- | Link outbound thread to the inbound thread
 --
@@ -506,12 +513,11 @@ data AllowHalfClosed sess =
 -- its time blocked on messages from the peer, and will therefore notice when
 -- the connection is lost. This is not true for the outbound thread, which
 -- spends most of its time blocked waiting for messages to send to the peer.
-linkOutboundToInbound :: forall sess.
+linkOutboundToInbound :: forall sess r.
      (IsSession sess, HasCallStack)
-  => AllowHalfClosed sess
+  => AllowHalfClosed r
   -> Channel sess
-  -> IO (InboundResult sess)
-  -> IO ()
+  -> IO r -> IO r
 linkOutboundToInbound allowHalfClosed channel inbound = do
     mResult <- tryExact inbound
 
@@ -520,10 +526,11 @@ linkOutboundToInbound allowHalfClosed channel inbound = do
     -- cleaning up.
 
     case (mResult, allowHalfClosed) of
-      (Right _result, ContinueWhenInboundClosed) ->
-        return ()
-      (Right result, TerminateWhenInboundClosed f) ->
+      (Right result, ContinueWhenInboundClosed) ->
+        return result
+      (Right result, TerminateWhenInboundClosed f) -> do
         void $ cancelThread (channelOutbound channel) (f result)
+        return result
       (Left (exception :: ExactException), _) -> do
         void $ cancelThread (channelOutbound channel) exception
         throwExact exception
@@ -548,10 +555,11 @@ sendMessageLoop :: forall sess.
   => sess
   -> RegularFlowState (Outbound sess)
   -> OutputStream
-  -> IO ()
+  -> IO (Trailers (Outbound sess))
 sendMessageLoop sess st stream = do
     trailers <- loop
     atomically $ STM.putTMVar (flowTerminated st) trailers
+    return trailers
   where
     build :: (Message (Outbound sess) -> Builder)
     build = buildMsg sess (flowHeaders st)

--- a/grapesy/src/Network/GRPC/Util/Session/Channel.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Channel.hs
@@ -22,9 +22,6 @@ module Network.GRPC.Util.Session.Channel (
   , close
   , ChannelDiscarded(..)
   , ChannelAborted(..)
-    -- * Support for half-closing
-  , AllowHalfClosed(..)
-  , linkOutboundToInbound
     -- * Constructing channels
   , sendMessageLoop
   , recvMessageLoop
@@ -490,54 +487,6 @@ data ChannelAborted = ChannelAborted Backtraces
   deriving anyclass (Exception)
 
 {-------------------------------------------------------------------------------
-  Support for half-closing
--------------------------------------------------------------------------------}
-
--- | Should we allow for a half-closed connection state?
---
--- In HTTP2, streams are bidirectional and can be half-closed in either
--- direction. This is however not true for all applications /of/ HTTP2. For
--- example, in gRPC the stream can be half-closed from the client to the server
--- (indicating that the client will not send any more messages), but not from
--- the server to the client: when the server half-closes their connection, it
--- sends the gRPC trailers and this terminates the call.
-data AllowHalfClosed r =
-    ContinueWhenInboundClosed
-  | TerminateWhenInboundClosed (r -> ExactException)
-
--- | Link outbound thread to the inbound thread
---
--- This should be wrapped around the body of the inbound thread. It ensures that
--- when the inbound thread throws an exception, the outbound thread dies also.
--- This improves predictability of exceptions: the inbound thread spends most of
--- its time blocked on messages from the peer, and will therefore notice when
--- the connection is lost. This is not true for the outbound thread, which
--- spends most of its time blocked waiting for messages to send to the peer.
-linkOutboundToInbound :: forall sess r.
-     (IsSession sess, HasCallStack)
-  => AllowHalfClosed r
-  -> Channel sess
-  -> IO r -> IO r
-linkOutboundToInbound allowHalfClosed channel inbound = do
-    mResult <- tryExact inbound
-
-    -- Implementation note: After cancelThread returns, 'channelOutbound' has
-    -- been updated, and considered dead, even if perhaps the thread is still
-    -- cleaning up.
-
-    case (mResult, allowHalfClosed) of
-      (Right result, ContinueWhenInboundClosed) ->
-        return result
-      (Right result, TerminateWhenInboundClosed f) -> do
-        void $ cancelThread (channelOutbound channel) (f result)
-        return result
-      (Left (exception :: ExactException), _) -> do
-        void $ cancelThread (channelOutbound channel) exception
-        throwExact exception
-  where
-    _ = addConstraint @(IsSession sess)
-
-{-------------------------------------------------------------------------------
   Constructing channels
 
   Both 'sendMessageLoop' and 'recvMessageLoop' will be run in newly forked
@@ -550,13 +499,26 @@ linkOutboundToInbound allowHalfClosed channel inbound = do
 -------------------------------------------------------------------------------}
 
 -- | Send all messages to the node's peer
+--
+-- The outbound thread is set up to be monitoring the input thread. This
+-- improves predictability of exceptions: the inbound thread spends most of its
+-- time blocked on messages from the peer, and will therefore notice when the
+-- connection is lost. This is not true for the outbound thread, which spends
+-- most of its time blocked waiting for messages to send to the peer.
+--
+-- TODO: There is currently a race condition: suppose the client is waiting for
+-- the trailers from the server, and then disconnects. As it stands, we might
+-- send those trailers from the 'sendMessageLoop', but then before the thread
+-- can terminate cleanly it is killed by the monitor. We should ensure that
+-- we /demonitor/ the inbound thread just prior to sending the trailers.
 sendMessageLoop :: forall sess.
      IsSession sess
   => sess
   -> RegularFlowState (Outbound sess)
   -> OutputStream
+  -> MonitorRef -- ^ Monitor for the inbound thread
   -> IO (Trailers (Outbound sess))
-sendMessageLoop sess st stream = do
+sendMessageLoop sess st stream _monitorInbound = do
     trailers <- loop
     atomically $ STM.putTMVar (flowTerminated st) trailers
     return trailers

--- a/grapesy/src/Network/GRPC/Util/Session/Channel.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Channel.hs
@@ -500,17 +500,26 @@ data ChannelAborted = ChannelAborted Backtraces
 
 -- | Send all messages to the node's peer
 --
--- The outbound thread is set up to be monitoring the input thread. This
--- improves predictability of exceptions: the inbound thread spends most of its
--- time blocked on messages from the peer, and will therefore notice when the
--- connection is lost. This is not true for the outbound thread, which spends
--- most of its time blocked waiting for messages to send to the peer.
+-- The outbound thread is set up to monitor the input thread:
 --
--- TODO: There is currently a race condition: suppose the client is waiting for
--- the trailers from the server, and then disconnects. As it stands, we might
--- send those trailers from the 'sendMessageLoop', but then before the thread
--- can terminate cleanly it is killed by the monitor. We should ensure that
--- we /demonitor/ the inbound thread just prior to sending the trailers.
+-- * The outbound thread spends most of its time blocked waiting for messages to
+--   send to the network peer, and may not notice when the connection is lost.
+--   The inbound thread however spends most of its time blocked on waiting for
+--   messages /from/ the peer and so will notice more or less immediately.
+--
+-- * We need an important \"atomicity\" property however: once the outbound
+--   thread has sent the trailers, we _expect_ the client to disconnect. We
+--   must therefore stop monitoring the inboud thread prior to sending the
+--   trailers, to avoid a race condition where
+--
+--   1. the outbound thread sends the final chunk
+--   2. the client receives the trailers and disconnects
+--   3. the outbound thread gets the monitor notification before it gets a chance
+--      to terminate, and dies, resulting in unexpected exceptions
+--
+--   Note that the client disconnecting /before/ receiving the final chunk
+--   constitutes a violation of the protocol, and so it would be correct for
+--   the outbound thread to report abnormal termination.
 sendMessageLoop :: forall sess.
      IsSession sess
   => sess
@@ -518,7 +527,7 @@ sendMessageLoop :: forall sess.
   -> OutputStream
   -> MonitorRef -- ^ Monitor for the inbound thread
   -> IO (Trailers (Outbound sess))
-sendMessageLoop sess st stream _monitorInbound = do
+sendMessageLoop sess st stream monitorInbound = do
     trailers <- loop
     atomically $ STM.putTMVar (flowTerminated st) trailers
     return trailers
@@ -535,15 +544,20 @@ sendMessageLoop sess st stream _monitorInbound = do
             flush stream
             loop
           FinalElem x trailers -> do
+            demonitor monitorInbound
             writeChunkFinal stream $ build x
             return trailers
           NoMoreElems trailers -> do
+            demonitor monitorInbound
             -- It is crucial to still 'writeChunkFinal' here to guarantee that
             -- cancellation is a no-op. Without it, cancellation may result in a
             -- @RST_STREAM@ frame may being sent to the peer.
             --
             -- This does not necessarily write a DATA frame, since http2 avoids
             -- writing empty data frames unless they are marked @END_OF_STREAM@.
+            --
+            -- TODO: <https://github.com/well-typed/grapesy/issues/349>
+            -- This relation between cancellation and outbound messages is wrong.
             writeChunkFinal stream $ mempty
             return trailers
 

--- a/grapesy/src/Network/GRPC/Util/Session/Channel.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Channel.hs
@@ -104,8 +104,12 @@ data Channel sess = Channel {
     , channelRecvFinal :: TVar (RecvFinal (Inbound sess))
     }
 
+-- | Has the client code received the final message from the peer yet?
+--
+-- NOTE: \"delivered\" here means: put the final message that we received from
+-- the peer into the hands of the client code.
 data RecvFinal flow =
-    -- | We have not yet delivered the final message to the client
+    -- | We have not yet delivered the final message to the client code
     RecvNotFinal
 
     -- | We delivered the final message, but not yet the trailers
@@ -113,6 +117,8 @@ data RecvFinal flow =
 
     -- | We delivered the final message and the trailers
   | RecvFinal Backtraces
+
+deriving instance DataFlow flow => Show (RecvFinal flow)
 
 -- | Data flow state
 data FlowState flow =
@@ -276,7 +282,7 @@ send Channel{channelOutbound, channelSentFinal} = \msg -> do
 -- and the trailers together. It is a bug to call 'recvBoth' again after this;
 -- doing so will result in a 'RecvAfterFinal' exception.
 recvBoth :: forall sess.
-     HasCallStack
+     (HasCallStack, IsSession sess)
   => Channel sess
   -> IO ( Either
             (NoMessages (Inbound sess))
@@ -296,7 +302,7 @@ recvBoth =
 -- 'recvEither'. Call 'recvEither' again /after/ receiving the trailers is a
 -- bug; doing so will result in a 'RecvAfterFinal' exception.
 recvEither ::
-     HasCallStack
+     (HasCallStack, IsSession sess)
   => Channel sess
   -> IO ( Either
             (NoMessages (Inbound sess))
@@ -310,7 +316,7 @@ recvEither =
 
 -- | Internal generalization of 'recvBoth' and 'recvEither'
 recv' :: forall sess b.
-     HasCallStack
+     (HasCallStack, IsSession sess)
   => (Message    (Inbound sess) -> b)  -- ^ Message without trailers
   -> (Trailers   (Inbound sess) -> b)  -- ^ Trailers without (final) message
   -> (    (Message (Inbound sess), Trailers (Inbound sess))
@@ -329,6 +335,8 @@ recv' messageWithoutTrailers
     backtrace <- collectBacktraces
     withThreadInterface channelInbound $ aux backtrace
   where
+    _ = addConstraint @(IsSession sess)
+
     aux ::
          Backtraces
       -> FlowState (Inbound sess)

--- a/grapesy/src/Network/GRPC/Util/Session/Client.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Client.hs
@@ -9,8 +9,7 @@ module Network.GRPC.Util.Session.Client (
 import Network.GRPC.Util.Imports
 
 import Control.Concurrent.MVar (MVar, newEmptyMVar, readMVar, putMVar)
-import Control.Concurrent.STM (atomically)
-import Control.Concurrent.STM.TVar (modifyTVar)
+import Control.Concurrent.STM qualified as STM
 import Control.Monad (join)
 import Data.ByteString qualified as BS.Strict
 import Data.ByteString qualified as Strict (ByteString)
@@ -139,7 +138,7 @@ setupRequestChannel sess
         -- Can't cancel non-streaming request
         putMVar cancelRequestVar $ \_ -> return ()
         atomically $
-          modifyTVar (channelOutbound channel) $ \oldState ->
+          STM.modifyTVar (channelOutbound channel) $ \oldState ->
             case oldState of
               ThreadNotStarted debugId ->
                 ThreadDone debugId state

--- a/grapesy/src/Network/GRPC/Util/Session/Client.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Client.hs
@@ -91,6 +91,10 @@ class NoTrailers sess where
 
 type CancelRequest = Maybe ExactException -> IO ()
 
+type InboundResult sess =
+       Either (NoMessages (Inbound sess))
+              (Trailers   (Inbound sess))
+
 -- | Setup request channel
 --
 -- This initiates a new request.
@@ -127,10 +131,7 @@ setupRequestChannel sess
                 $ outboundThread channel cancelRequestVar regular
         forkRequest channel req
       FlowStartNoMessages trailers -> do
-        let state :: FlowState (Outbound sess)
-            state = FlowStateNoMessages trailers
-
-            req :: Client.Request
+        let req :: Client.Request
             req = Client.requestNoBody
                     (requestMethod  requestInfo)
                     (requestPath    requestInfo)
@@ -141,7 +142,7 @@ setupRequestChannel sess
           STM.modifyTVar (channelOutbound channel) $ \oldState ->
             case oldState of
               ThreadNotStarted debugId ->
-                ThreadDone debugId state
+                ThreadTrivial debugId trailers
               _otherwise ->
                 error "setupRequestChannel: expected thread state"
         forkRequest channel req
@@ -152,39 +153,39 @@ setupRequestChannel sess
 
     forkRequest :: Channel sess -> Client.Request -> IO ()
     forkRequest channel req =
-        forkThread "grapesy:clientInbound" (channelInbound channel) $ \unmask markReady _debugId -> unmask $
-          linkOutboundToInbound (TerminateWhenInboundClosed terminateCall) channel $
-            sendRequest req $ \resp -> do
-              responseStatus <-
-                case Client.responseStatus resp of
-                  Just x  -> return x
-                  Nothing -> throwIO PeerMissingPseudoHeaderStatus
+        forkThread "grapesy:clientInbound" (channelInbound channel) $ \unmask ctxt -> unmask $
+          sendRequest req $ \resp -> do
+            responseStatus <-
+              case Client.responseStatus resp of
+                Just x  -> return x
+                Nothing -> throwIO PeerMissingPseudoHeaderStatus
 
-              -- Read the entire response body in case of a non-OK response
-              responseBody :: Maybe Lazy.ByteString <-
-                if HTTP.statusIsSuccessful responseStatus then
-                  return Nothing
-                else
-                  Just <$> readResponseBody resp
+            -- Read the entire response body in case of a non-OK response
+            responseBody :: Maybe Lazy.ByteString <-
+              if HTTP.statusIsSuccessful responseStatus then
+                return Nothing
+              else
+                Just <$> readResponseBody resp
 
-              let responseHeaders =
-                    fromHeaderTable $ Client.responseHeaders resp
-                  responseInfo = ResponseInfo {
-                    responseHeaders
-                  , responseStatus
-                  , responseBody
-                  }
+            let responseHeaders =
+                  fromHeaderTable $ Client.responseHeaders resp
+                responseInfo = ResponseInfo {
+                  responseHeaders
+                , responseStatus
+                , responseBody
+                }
 
-              flowStart <- parseResponse sess responseInfo
-              case flowStart of
-                FlowStartRegular headers -> do
-                  state <- initFlowStateRegular headers
-                  stream  <- clientInputStream resp
-                  markReady $ FlowStateRegular state
-                  Right <$> recvMessageLoop sess state stream
-                FlowStartNoMessages trailers -> do
-                  markReady $ FlowStateNoMessages trailers
-                  return $ Left trailers
+            flowStart <- parseResponse sess responseInfo
+            case flowStart of
+              FlowStartRegular headers -> do
+                regular <- initFlowStateRegular headers
+                stream  <- clientInputStream resp
+                threadMainBody ctxt regular $
+                  linkOutboundToInbound (TerminateWhenInboundClosed (terminateCall . Right)) channel $
+                    recvMessageLoop sess regular stream
+              FlowStartNoMessages trailers -> do
+                void $ cancelThread (channelOutbound channel) $ terminateCall (Left trailers)
+                threadTrivial ctxt trailers
 
     outboundThread ::
          Channel sess
@@ -193,22 +194,22 @@ setupRequestChannel sess
       -> OutBodyIface
       -> IO ()
     outboundThread channel cancelRequestVar regular iface =
-        threadBody "grapesy:clientOutbound" (channelOutbound channel) $ \markReady _debugId -> do
-          markReady $ FlowStateRegular regular
-          putMVar cancelRequestVar cancelRequest
-          stream <- clientOutputStream iface
-          -- Unlike the client inbound thread, or the inbound/outbound threads
-          -- of the server, http2 knows about this particular thread and may
-          -- raise an exception on it when the server dies. This results in a
-          -- race condition between that exception and the exception we get from
-          -- attempting to read the next message. No matter who wins that race,
-          -- we need to mark that as 'ServerDisconnected'.
-          --
-          -- We don't have this top-level exception handler in other places
-          -- because we don't want to mark /our own/ exceptions as
-          -- 'ServerDisconnected' or 'ClientDisconnected'.
-          wrapServerDisconnected $
-            Client.outBodyUnmask iface $ sendMessageLoop sess regular stream
+        threadBody "grapesy:clientOutbound" (channelOutbound channel) $ \ctxt -> do
+          threadMainBody ctxt regular $ do
+            putMVar cancelRequestVar cancelRequest
+            stream <- clientOutputStream iface
+            -- Unlike the client inbound thread, or the inbound/outbound threads
+            -- of the server, http2 knows about this particular thread and may
+            -- raise an exception on it when the server dies. This results in a
+            -- race condition between that exception and the exception we get from
+            -- attempting to read the next message. No matter who wins that race,
+            -- we need to mark that as 'ServerDisconnected'.
+            --
+            -- We don't have this top-level exception handler in other places
+            -- because we don't want to mark /our own/ exceptions as
+            -- 'ServerDisconnected' or 'ClientDisconnected'.
+            wrapServerDisconnected $
+              Client.outBodyUnmask iface $ sendMessageLoop sess regular stream
       where
         cancelRequest :: CancelRequest
         cancelRequest = Client.outBodyCancel iface . fmap unwrapExactException

--- a/grapesy/src/Network/GRPC/Util/Session/Client.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Client.hs
@@ -181,10 +181,8 @@ setupRequestChannel sess
                 regular <- initFlowStateRegular headers
                 stream  <- clientInputStream resp
                 threadMainBody ctxt regular $
-                  linkOutboundToInbound (TerminateWhenInboundClosed (terminateCall . Right)) channel $
-                    recvMessageLoop sess regular stream
+                  recvMessageLoop sess regular stream
               FlowStartNoMessages trailers -> do
-                void $ cancelThread (channelOutbound channel) $ terminateCall (Left trailers)
                 threadTrivial ctxt trailers
 
     outboundThread ::
@@ -197,7 +195,8 @@ setupRequestChannel sess
         threadBody "grapesy:clientOutbound" (channelOutbound channel) $ \ctxt -> do
           threadMainBody ctxt regular $ do
             putMVar cancelRequestVar cancelRequest
-            stream <- clientOutputStream iface
+            monitor <- threadMonitor ctxt (channelInbound channel) monitorPred
+            stream  <- clientOutputStream iface
             -- Unlike the client inbound thread, or the inbound/outbound threads
             -- of the server, http2 knows about this particular thread and may
             -- raise an exception on it when the server dies. This results in a
@@ -209,10 +208,29 @@ setupRequestChannel sess
             -- because we don't want to mark /our own/ exceptions as
             -- 'ServerDisconnected' or 'ClientDisconnected'.
             wrapServerDisconnected $
-              Client.outBodyUnmask iface $ sendMessageLoop sess regular stream
+              Client.outBodyUnmask iface $
+                sendMessageLoop sess regular stream monitor
       where
         cancelRequest :: CancelRequest
         cancelRequest = Client.outBodyCancel iface . fmap unwrapExactException
+
+        -- In HTTP2, streams are bidirectional and can be half-closed in either
+        -- direction. However, in gRPC the stream can be half-closed from the
+        -- client to the server (indicating that the client will not send any
+        -- more messages), but not from the server to the client: when the
+        -- server half-closes their connection, it sends the gRPC trailers and
+        -- this terminates the call.
+        monitorPred ::
+              Either
+                ThreadException
+                ( Either
+                    (NoMessages (Inbound sess))
+                    (Trailers   (Inbound sess))
+                )
+           -> Maybe ExactException
+        monitorPred = \case
+            Left  e        -> Just $ threadException e
+            Right trailers -> Just $ terminateCall trailers
 
 {-------------------------------------------------------------------------------
    Auxiliary http2

--- a/grapesy/src/Network/GRPC/Util/Session/Server.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Server.hs
@@ -113,8 +113,7 @@ setupResponseChannel sess
           regular <- initFlowStateRegular headers
           stream  <- serverInputStream (request conn)
           threadMainBody ctxt regular $
-            linkOutboundToInbound ContinueWhenInboundClosed channel $
-              recvMessageLoop sess regular stream
+            recvMessageLoop sess regular stream
         FlowStartNoMessages trailers ->
           -- The client sent a request with an empty body
           threadTrivial ctxt trailers
@@ -123,15 +122,34 @@ setupResponseChannel sess
       (outboundStart, responseInfo) <- startOutbound
       case outboundStart of
         FlowStartRegular headers -> do
+          monitor <- threadMonitor ctxt (channelInbound channel) monitorPred
           regular <- initFlowStateRegular headers
           threadMainBody ctxt regular $ do
             respondStreamingWithResult
                 conn
                 (outboundTrailersMaker sess channel regular)
                 responseInfo $ \stream ->
-              sendMessageLoop sess regular stream
+              sendMessageLoop sess regular stream monitor
         FlowStartNoMessages trailers -> do
           respondNoBody conn responseInfo
           threadTrivial ctxt trailers
 
     return channel
+  where
+    -- Unlike on the client-side, if the input thread terminates normally, the
+    -- server can continue to run normally (the stream can be half-closed from
+    -- the client). We only only terminate if the inbound thread threw an
+    -- exception, indicating that the client disconnected abruptly.
+    --
+    -- See also 'Network.GRPC.Util.Session.Client.setupRequestChannel'.
+    monitorPred ::
+          Either
+            ThreadException
+            ( Either
+                (NoMessages (Inbound sess))
+                (Trailers   (Inbound sess))
+            )
+       -> Maybe ExactException
+    monitorPred = \case
+        Left  e         -> Just $ threadException e
+        Right _trailers -> Nothing

--- a/grapesy/src/Network/GRPC/Util/Session/Server.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Server.hs
@@ -4,11 +4,16 @@ module Network.GRPC.Util.Session.Server (
   , setupResponseChannel
   ) where
 
+import Control.Concurrent
+import Control.Exception
+import Control.Monad
 import Network.HTTP.Semantics.Server qualified as Server
 
+import Network.GRPC.Common.Exception
 import Network.GRPC.Util.ServerStream
 import Network.GRPC.Util.Session.API
 import Network.GRPC.Util.Session.Channel
+import Network.GRPC.Util.Stream
 import Network.GRPC.Util.Thread
 
 {-------------------------------------------------------------------------------
@@ -20,6 +25,54 @@ data ConnectionToClient = ConnectionToClient {
       request :: Server.Request
     , respond :: Server.Response -> IO ()
     }
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary: constructing responses
+-------------------------------------------------------------------------------}
+
+respondStreaming ::
+     ConnectionToClient
+  -> Server.TrailersMaker
+  -> ResponseInfo
+  -> (OutputStream -> IO ())
+  -> IO ()
+respondStreaming conn trailers responseInfo body =
+    respond conn resp
+  where
+    resp :: Server.Response
+    resp =
+          flip Server.setResponseTrailersMaker trailers
+        . Server.responseStreamingIface
+            (responseStatus  responseInfo)
+            (responseHeaders responseInfo)
+        $ body <=< serverOutputStream
+
+respondStreamingWithResult :: forall a.
+     ConnectionToClient
+  -> Server.TrailersMaker
+  -> ResponseInfo
+  -> (OutputStream -> IO a)
+  -> IO a
+respondStreamingWithResult conn trailers responseInfo body = do
+    -- It's not completely clear what @http2@ will do if the callback for a
+    -- streaming response throws an exception. /If/ it rethrows that exception,
+    -- we're fine, but if not we need to ensure that we're not left blocking
+    -- indefinitely waiting for a result.
+    resultVar :: MVar (Either ExactException a) <- newEmptyMVar
+    respondStreaming conn trailers responseInfo $ \iface -> do
+      result <- try $ body iface
+      putMVar resultVar result
+      either throwExact (\_ -> return ()) result
+    either throwExact return =<< takeMVar resultVar
+
+respondNoBody :: ConnectionToClient -> ResponseInfo -> IO ()
+respondNoBody conn responseInfo =
+    respond conn resp
+  where
+    resp :: Server.Response
+    resp = Server.responseNoBody
+             (responseStatus  responseInfo)
+             (responseHeaders responseInfo)
 
 {-------------------------------------------------------------------------------
   Initiate response
@@ -54,57 +107,31 @@ setupResponseChannel sess
                    = do
     channel <- initChannel
 
-    forkThread "grapesy:serverInbound" (channelInbound channel) $
-      \unmask markReady _debugId -> unmask $
-        linkOutboundToInbound ContinueWhenInboundClosed channel $ do
-          case inboundStart of
-            FlowStartRegular headers -> do
-              regular <- initFlowStateRegular headers
-              stream  <- serverInputStream (request conn)
-              markReady $ FlowStateRegular regular
-              Right <$> recvMessageLoop sess regular stream
-            FlowStartNoMessages trailers -> do
-              -- The client sent a request with an empty body
-              markReady $ FlowStateNoMessages trailers
-              return $ Left trailers
-              -- Thread terminates immediately
+    forkThread "grapesy:serverInbound" (channelInbound channel) $ \unmask ctxt -> unmask $
+      case inboundStart of
+        FlowStartRegular headers -> do
+          regular <- initFlowStateRegular headers
+          stream  <- serverInputStream (request conn)
+          threadMainBody ctxt regular $
+            linkOutboundToInbound ContinueWhenInboundClosed channel $
+              recvMessageLoop sess regular stream
+        FlowStartNoMessages trailers ->
+          -- The client sent a request with an empty body
+          threadTrivial ctxt trailers
 
-    forkThread "grapesy:serverOutbound" (channelOutbound channel) $
-      \unmask markReady _debugId -> unmask $ do
-        (outboundStart, responseInfo) <- startOutbound
-        case outboundStart of
-          FlowStartRegular headers -> do
-            regular <- initFlowStateRegular headers
-            markReady $ FlowStateRegular regular
-            let resp :: Server.Response
-                resp = setResponseTrailers sess channel regular
-                     $ Server.responseStreamingIface
-                             (responseStatus  responseInfo)
-                             (responseHeaders responseInfo)
-                     $ \iface -> do
-                          stream <- serverOutputStream iface
-                          sendMessageLoop sess regular stream
-            respond conn resp
-          FlowStartNoMessages trailers -> do
-            markReady $ FlowStateNoMessages trailers
-            let resp :: Server.Response
-                resp = Server.responseNoBody
-                         (responseStatus  responseInfo)
-                         (responseHeaders responseInfo)
-            respond conn $ resp
+    forkThread "grapesy:serverOutbound" (channelOutbound channel) $ \unmask ctxt -> unmask $ do
+      (outboundStart, responseInfo) <- startOutbound
+      case outboundStart of
+        FlowStartRegular headers -> do
+          regular <- initFlowStateRegular headers
+          threadMainBody ctxt regular $ do
+            respondStreamingWithResult
+                conn
+                (outboundTrailersMaker sess channel regular)
+                responseInfo $ \stream ->
+              sendMessageLoop sess regular stream
+        FlowStartNoMessages trailers -> do
+          respondNoBody conn responseInfo
+          threadTrivial ctxt trailers
 
     return channel
-
-{-------------------------------------------------------------------------------
-  Auxiliary http2
--------------------------------------------------------------------------------}
-
-setResponseTrailers ::
-     IsSession sess
-  => sess
-  -> Channel sess
-  -> RegularFlowState (Outbound sess)
-  -> Server.Response -> Server.Response
-setResponseTrailers sess channel regular resp =
-    Server.setResponseTrailersMaker resp $
-      outboundTrailersMaker sess channel regular

--- a/grapesy/src/Network/GRPC/Util/Thread.hs
+++ b/grapesy/src/Network/GRPC/Util/Thread.hs
@@ -8,6 +8,7 @@ module Network.GRPC.Util.Thread (
   , ThreadException(..)
     -- * Creating threads
   , ThreadContext(..)
+  , threadMonitor
   , ThreadBody
   , newThreadState
   , forkThread
@@ -25,6 +26,10 @@ module Network.GRPC.Util.Thread (
   , withThreadInterface
   , waitForNormalThreadTermination
   , waitForNormalOrAbnormalThreadTermination
+    -- * Monitoring
+  , MonitorRef -- opaque
+  , MonitorAnnotation(..)
+  , demonitor
   ) where
 
 import Network.GRPC.Util.Imports
@@ -204,9 +209,24 @@ data ThreadContext a r r' = ThreadContext{
       -- this case to have a diferent result type.
     , threadTrivial :: r' -> IO ()
 
+      -- | Monitor another thread
+    , threadMonitor_ :: forall a2 r2 r'2.
+            HasCallStack
+         => TVar (ThreadState a2 r2 r'2)
+         -> (Either ThreadException (Either r'2 r2) -> Maybe ExactException)
+         -> IO MonitorRef
+
       -- | Unique identifier for this thread
     , threadId :: DebugThreadId
     }
+
+threadMonitor ::
+     HasCallStack
+  => ThreadContext a r r'
+  -> TVar (ThreadState a2 r2 r'2)
+  -> (Either ThreadException (Either r'2 r2) -> Maybe ExactException)
+  -> IO MonitorRef
+threadMonitor ThreadContext{threadMonitor_} = threadMonitor_
 
 type ThreadBody a r r' =
       (forall x. IO x -> IO x)
@@ -315,7 +335,8 @@ threadBody label state body = do
     res <- tryExact $ body ThreadContext{
           threadMainBody
         , threadTrivial
-        , threadId = threadDebugId initState
+        , threadMonitor_ = monitorJust state
+        , threadId       = threadDebugId initState
         }
     atomically $ done res
   where
@@ -512,6 +533,84 @@ getThreadState_ state onNotRunning = do
       ThreadDone         _ _ r -> return $ ThreadDone_ r
       ThreadTrivial      _ r'  -> return $ ThreadTrivial_ r'
       ThreadDied         _   e -> return $ ThreadException_ e
+
+{-------------------------------------------------------------------------------
+  Monitoring
+-------------------------------------------------------------------------------}
+
+newtype MonitorRef = MonitorRef ThreadId
+  deriving stock (Show, Eq)
+  deriving ToExceptionDoc via LinesToExceptionDoc MonitorRef
+
+-- | Annotation added to exceptions that were thrown by 'monitorJust'.
+data MonitorAnnotation = MonitorAnnotation{
+      -- | Backtrace to where the monitor was first established
+      monitorAnnotationContext :: Backtraces
+
+      -- | The ID of the monitor
+      --
+      -- Although the 'MonitorRef' is opaque, it /does/ have an 'Eq' instance,
+      -- so this can occassionally be useful to relate an exception back to
+      -- a specific monitor instance.
+    , monitorAnnotationRef :: MonitorRef
+    }
+  deriving stock (Show, Generic)
+  deriving anyclass (ToExceptionDoc)
+
+#if MIN_VERSION_base(4,20,0)
+instance ExceptionAnnotation MonitorAnnotation where
+  displayExceptionAnnotation = renderDoc . toExceptionDoc
+#endif
+
+-- | Monitor another thread
+--
+-- Inspired by monitoring in Erlang
+-- <https://www.erlang.org/docs/23/reference_manual/processes.html#monitors>.
+--
+-- Just like in Erlang, if the target thread has already died when we start
+-- monitoring, the monitor exception (if any) is thrown immediately (we inherit
+-- this behaviour from 'waitForNormalOrAbnormalThreadTermination').
+monitorJust ::
+     (HasCallStack, Exception e)
+  => TVar (ThreadState a1 r1 r'1)
+     -- ^ Thread doing the monitoring
+     --
+     -- This is the thread that wants to receive the exception when the other
+     -- thread terminates.
+  -> TVar (ThreadState a2 r2 r'2)
+     -- ^ The thread to monitor
+  -> (Either ThreadException (Either r'2 r2) -> Maybe e)
+     -- ^ Given the termination result of the target, should we throw an
+     -- exception to the monitoring thread?
+     --
+     -- If 'Just', the exception is given a 'MonitorAnnotation'.
+  -> IO MonitorRef
+monitorJust us them p = do
+    -- Backtrace to where the monitor was established
+    backtrace <- collectBacktraces
+    MonitorRef <$> forkIO (aux backtrace)
+  where
+    aux :: Backtraces -> IO ()
+    aux backtrace = do
+        -- The 'MonitorRef' is the ID of the thread that /actually/ doing the
+        -- monitoring: that is, us.
+        ref <- MonitorRef <$> myThreadId
+        res <- atomically $ waitForNormalOrAbnormalThreadTermination them
+        forM_ (p res) $ \e -> do
+          let ann :: MonitorAnnotation
+              ann = MonitorAnnotation{
+                    monitorAnnotationContext = backtrace
+                  , monitorAnnotationRef     = ref
+                  }
+          let e' :: E.SomeException
+              e' = addExceptionContext ann (toException e)
+          cancelThread us (WrapExactException e')
+
+-- | Remove monitor
+--
+-- The caller is guaranteed that on return the monitor will no longer fire.
+demonitor :: MonitorRef -> IO ()
+demonitor (MonitorRef ref) = killThread ref
 
 {-------------------------------------------------------------------------------
   Internal auxiliary

--- a/grapesy/src/Network/GRPC/Util/Thread.hs
+++ b/grapesy/src/Network/GRPC/Util/Thread.hs
@@ -7,6 +7,7 @@ module Network.GRPC.Util.Thread (
     ThreadState(..)
   , ThreadException(..)
     -- * Creating threads
+  , ThreadContext(..)
   , ThreadBody
   , newThreadState
   , forkThread
@@ -20,6 +21,7 @@ module Network.GRPC.Util.Thread (
   , ThreadState_(..)
   , getThreadState_
   , unlessAbnormallyTerminated
+  , ThreadIface(..)
   , withThreadInterface
   , waitForNormalThreadTermination
   , waitForNormalOrAbnormalThreadTermination
@@ -116,7 +118,7 @@ throwThreadException e = liftIO $ do
 -------------------------------------------------------------------------------}
 
 -- | State of a thread with public interface of type @a@
-data ThreadState a =
+data ThreadState a r r' =
     -- | The thread has not yet started
     --
     -- If the thread is cancelled before it is started, then the exception will
@@ -142,37 +144,89 @@ data ThreadState a =
     --
     -- This still carries the thread interface: we may need it to query the
     -- thread's final status, for example.
-  | ThreadDone DebugThreadId a
+  | ThreadDone DebugThreadId a r
+
+    -- | Trivial thread
+    --
+    -- See 'threadTrivial' for discussion.
+  | ThreadTrivial DebugThreadId r'
 
     -- | Thread terminated with an exception
   | ThreadDied DebugThreadId ThreadException
-  deriving stock (Show, Functor)
+  deriving stock (Show)
 
-threadDebugId :: ThreadState a -> DebugThreadId
+-- | For debugging: reduce to skeleton
+showableState :: ThreadState a r r' -> ThreadState () () ()
+showableState = \case
+    ThreadNotStarted   did       -> ThreadNotStarted   did
+    ThreadInitializing did tid   -> ThreadInitializing did tid
+    ThreadRunning      did tid _ -> ThreadRunning      did tid ()
+    ThreadDone         did _ _   -> ThreadDone         did () ()
+    ThreadTrivial      did _     -> ThreadTrivial      did ()
+    ThreadDied         did e     -> ThreadDied         did e
+
+threadDebugId :: ThreadState a r r' -> DebugThreadId
 threadDebugId (ThreadNotStarted   debugId    ) = debugId
 threadDebugId (ThreadInitializing debugId _  ) = debugId
 threadDebugId (ThreadRunning      debugId _ _) = debugId
-threadDebugId (ThreadDone         debugId   _) = debugId
+threadDebugId (ThreadDone         debugId _ _) = debugId
+threadDebugId (ThreadTrivial      debugId _  ) = debugId
 threadDebugId (ThreadDied         debugId   _) = debugId
 
 {-------------------------------------------------------------------------------
   Creating threads
 -------------------------------------------------------------------------------}
 
-type ThreadBody a =
-          (forall x. IO x -> IO x) -- ^ Unmask exceptions
-       -> (a -> IO ())             -- ^ Mark thread ready
-       -> DebugThreadId            -- ^ Unique identifier for this thread
-       -> IO ()
+-- | Thread context
+--
+-- The thread body /must/ call either 'threadMainBody' or 'threadTrivial' when
+-- it is ready:
+--
+-- > threadBody =
+-- >   .. initial setup ..
+-- >   case foo of
+-- >     .. -> .. threadMainBody ..
+-- >     .. -> .. treadTrivial   ..
+--
+-- Any attempt to interact with the thread will block until it marks itself
+-- ready through 'threadMainBody' or 'threadTrivial' (or it dies).
+data ThreadContext a r r' = ThreadContext{
+      -- | Mark thread ready, providing the main thread body
+      threadMainBody :: a -> IO r -> IO ()
 
-newThreadState :: HasCallStack => IO (TVar (ThreadState a))
+      -- | Terminate the thread immediately
+      --
+      -- We refer to this as a \"trivial\" thread: it's a thread that provides
+      -- a result without having to do further work. This is a slightly odd
+      -- abstraction, but useful: we may start a thread using @http2@ to
+      -- receive messages, but as soon as we receive the headers realize that
+      -- no further work needs to be done. We treat this separately, to allow
+      -- this case to have a diferent result type.
+    , threadTrivial :: r' -> IO ()
+
+      -- | Unique identifier for this thread
+    , threadId :: DebugThreadId
+    }
+
+type ThreadBody a r r' =
+      (forall x. IO x -> IO x)
+      -- ^ Unmask exceptions
+      --
+      -- If using 'forkThread', the thread is started with exceptions masked
+   -> ThreadContext a r r'
+      -- ^ Thread context
+      --
+      -- This allows the thread body to inspect and manipulate its own context.
+   -> IO ()
+
+newThreadState :: HasCallStack => IO (TVar (ThreadState a r r'))
 newThreadState = do
     debugId <- newDebugThreadId
     STM.newTVarIO $ ThreadNotStarted debugId
 
 forkThread ::
      HasCallStack
-  => ThreadLabel -> TVar (ThreadState a) -> ThreadBody a -> IO ()
+  => ThreadLabel -> TVar (ThreadState a r r') -> ThreadBody a r r' -> IO ()
 forkThread label state body =
     void $ E.mask_ $ forkIOWithUnmask $ \unmask ->
       threadBody label state $ body unmask
@@ -187,11 +241,11 @@ forkThread label state body =
 --
 -- If the 'ThreadState' is anything other than 'ThreadNotStarted' on entry,
 -- this function terminates immediately.
-threadBody :: forall a.
+threadBody :: forall a r r'.
      HasCallStack
   => ThreadLabel
-  -> TVar (ThreadState a)
-  -> ((a -> IO ()) -> DebugThreadId -> IO ())
+  -> TVar (ThreadState a r r')
+  -> (ThreadContext a r r' -> IO ())
   -> IO ()
 threadBody label state body = do
     labelThisThread label
@@ -213,23 +267,41 @@ threadBody label state body = do
       _otherwise -> do
         unexpected "initState" initState
 
-    let markReady :: a -> STM ()
-        markReady a = do
-            STM.modifyTVar state $ \oldState ->
+    let threadMainBody :: a -> IO r -> IO ()
+        threadMainBody a mainBody = do
+            atomically $ STM.modifyTVar state $ \oldState ->
               case oldState of
                 ThreadInitializing debugId _ ->
                   ThreadRunning debugId threadId a
                 ThreadDied _ _ ->
                   oldState -- leave alone (see discussion above)
                 _otherwise ->
-                  unexpected "markReady" oldState
+                  unexpected "mainBody before" oldState
+            r <- mainBody
+            atomically $ STM.modifyTVar state $ \oldState ->
+              case oldState of
+                ThreadRunning debugId _ _ ->
+                  ThreadDone debugId a r
+                ThreadDied{} ->
+                  oldState
+                _otherwise ->
+                  unexpected "mainBody after" oldState
 
-        markDone :: Either ExactException () -> STM ()
-        markDone mDone = do
+        threadTrivial :: r' -> IO ()
+        threadTrivial r' = do
+            atomically $ STM.modifyTVar state $ \oldState ->
+              case oldState of
+                ThreadInitializing debugId _ ->
+                  ThreadTrivial debugId r'
+                ThreadDied{} ->
+                  oldState
+                _otherwise ->
+                  unexpected "markReady before" oldState
+
+        done :: Either ExactException () -> STM ()
+        done mDone = do
             STM.modifyTVar state $ \oldState ->
               case (oldState, mDone) of
-                (ThreadRunning debugId _ iface, Right ()) ->
-                  ThreadDone debugId iface
                 (ThreadDied{}, _) ->
                   oldState -- record /first/ exception
                 (_, Left e) ->
@@ -238,16 +310,20 @@ threadBody label state body = do
                     , threadExceptionAnnotation = ThreadThrewException
                     }
                 _otherwise ->
-                  unexpected "markDone" oldState
+                  oldState
 
-    res <- tryExact $ body (atomically . markReady) (threadDebugId initState)
-    atomically $ markDone res
+    res <- tryExact $ body ThreadContext{
+          threadMainBody
+        , threadTrivial
+        , threadId = threadDebugId initState
+        }
+    atomically $ done res
   where
-    unexpected :: String -> ThreadState a -> x
+    unexpected :: HasCallStack => String -> ThreadState a r r' -> x
     unexpected msg st = error $ concat [
           msg
         , ": unexpected "
-        , show (const () <$> st)
+        , show (showableState st)
         ]
 
 {-------------------------------------------------------------------------------
@@ -255,9 +331,9 @@ threadBody label state body = do
 -------------------------------------------------------------------------------}
 
 -- | Result of cancelling a thread
-data CancelResult a =
+data CancelResult a r r' =
     -- | The thread terminated normally before we could cancel it
-    AlreadyTerminated a
+    AlreadyTerminated (Either (a, r)  r')
 
     -- | The thread terminated with an exception before we could cancel it
   | AlreadyAborted ThreadException
@@ -280,11 +356,11 @@ data CancelResult a =
 --
 -- In all cases, the caller is guaranteed that the thread state has been updated
 -- even if perhaps the thread is still shutting down.
-cancelThread :: forall a.
+cancelThread :: forall a r r'.
      HasCallStack
-  => TVar (ThreadState a)
+  => TVar (ThreadState a r r')
   -> ExactException
-  -> IO (CancelResult a)
+  -> IO (CancelResult a r r')
 cancelThread state e = do
     backtrace <- collectBacktraces
 
@@ -298,7 +374,7 @@ cancelThread state e = do
     forM_ mTid $ flip throwTo e
     return result
   where
-    aux :: ThreadException -> STM (CancelResult a, Maybe ThreadId)
+    aux :: ThreadException -> STM (CancelResult a r r', Maybe ThreadId)
     aux cancelled = do
         st <- STM.readTVar state
         case st of
@@ -313,12 +389,26 @@ cancelThread state e = do
             return (Cancelled, Just threadId)
           ThreadDied _debugId e' ->
             return (AlreadyAborted e', Nothing)
-          ThreadDone _debugId a ->
-            return (AlreadyTerminated a, Nothing)
+          ThreadDone _debugId a r ->
+            return (AlreadyTerminated (Left (a, r)), Nothing)
+          ThreadTrivial _debugId r' ->
+            return (AlreadyTerminated (Right r'), Nothing)
 
 {-------------------------------------------------------------------------------
   Interacting with the thread
 -------------------------------------------------------------------------------}
+
+data ThreadIface a r' =
+    -- | The thread interface is available
+    --
+    -- We do /not/ distinguish between 'ThreadDone' and 'ThreadRunning' here, as
+    -- doing so is inherently racy (we might return that the client is still
+    -- running, and then it terminates before the calling code can do anything with
+    -- that information).
+    IfaceAvailable a
+
+    -- | Thread was trivial (terminated immediately)
+  | IfaceTrivial r'
 
 -- | Get the thread's interface
 --
@@ -327,11 +417,6 @@ cancelThread state e = do
 -- * blocks if the thread in case of 'ThreadNotStarted' or 'ThreadInitializing'
 -- * throws 'ThreadInterfaceUnavailable' in case of 'ThreadException'.
 -- * returns the thread interface otherwise
---
--- We do /not/ distinguish between 'ThreadDone' and 'ThreadRunning' here, as
--- doing so is inherently racy (we might return that the client is still
--- running, and then it terminates before the calling code can do anything with
--- that information).
 --
 -- NOTE: This turns off deadlock detection for the duration of the transaction.
 -- It should therefore only be used for transactions that can never be blocked
@@ -343,10 +428,10 @@ cancelThread state e = do
 -- those exception and treat them as network failures. If a @grapesy@ function
 -- ever throws a "blocked indefinitely" exception, this should be reported as a
 -- bug in @grapesy@.
-withThreadInterface :: forall a b.
+withThreadInterface :: forall a b r r'.
      HasCallStack
-  => TVar (ThreadState a)
-  -> (a -> STM b)
+  => TVar (ThreadState a r r')
+  -> (ThreadIface a r' -> STM b)
   -> IO b
 withThreadInterface state k = do
     mb :: Either ThreadException b <- withoutDeadlockDetection $ atomically $ do
@@ -354,71 +439,78 @@ withThreadInterface state k = do
       either (return . Left) (fmap Right . k) ma
     either throwThreadException return mb
   where
-    getThreadInterface :: STM (Either ThreadException a)
+    getThreadInterface :: STM (Either ThreadException (ThreadIface a r'))
     getThreadInterface = do
         st <- STM.readTVar state
         case st of
-          ThreadNotStarted   _     -> STM.retry
-          ThreadInitializing _ _   -> STM.retry
-          ThreadRunning      _ _ a -> return (Right a)
-          ThreadDone         _   a -> return (Right a)
-          ThreadDied         _   e -> return (Left e)
+          ThreadNotStarted   _      -> STM.retry
+          ThreadInitializing _ _    -> STM.retry
+          ThreadDied         _   e  -> return $ Left e
+          ThreadRunning      _ _ a  -> return $ Right $ IfaceAvailable a
+          ThreadDone         _ a _  -> return $ Right $ IfaceAvailable a
+          ThreadTrivial      _   r' -> return $ Right $ IfaceTrivial r'
 
 -- | Wait for the thread to terminate normally
 --
 -- If the thread terminated with an exception, this rethrows that exception.
-waitForNormalThreadTermination :: HasCallStack => TVar (ThreadState a) -> IO ()
+waitForNormalThreadTermination ::
+     HasCallStack
+  => TVar (ThreadState a r r') -> IO (Either r' r)
 waitForNormalThreadTermination state = do
     mErr <- atomically $ waitForNormalOrAbnormalThreadTermination state
-    maybe (return ()) throwThreadException mErr
+    either throwThreadException return mErr
 
 -- | Wait for the thread to terminate normally or abnormally
 waitForNormalOrAbnormalThreadTermination ::
-     TVar (ThreadState a)
-  -> STM (Maybe ThreadException)
+     TVar (ThreadState a r r')
+  -> STM (Either ThreadException (Either r' r))
 waitForNormalOrAbnormalThreadTermination state =
     waitUntilInitialized state >>= \case
       ThreadNotYetRunning_ v -> absurd v
       ThreadRunning_         -> STM.retry
-      ThreadDone_            -> return $ Nothing
-      ThreadException_ e     -> return $ Just e
+      ThreadDone_ r          -> return $ Right (Right r)
+      ThreadTrivial_ r'      -> return $ Right (Left r')
+      ThreadException_ e     -> return $ Left e
 
 -- | Run the specified transaction, unless the thread terminated with an
 -- exception
 unlessAbnormallyTerminated ::
-     TVar (ThreadState a)
+     TVar (ThreadState a r r')
   -> STM b
   -> STM (Either ThreadException b)
 unlessAbnormallyTerminated state f =
     waitUntilInitialized state >>= \case
       ThreadNotYetRunning_ v -> absurd v
       ThreadRunning_         -> Right <$> f
-      ThreadDone_            -> Right <$> f
+      ThreadDone_ _          -> Right <$> f
+      ThreadTrivial_ _       -> Right <$> f
       ThreadException_ e     -> return $ Left e
 
 waitUntilInitialized ::
-     TVar (ThreadState a)
-  -> STM (ThreadState_ Void)
+     TVar (ThreadState a r r')
+  -> STM (ThreadState_ Void r r')
 waitUntilInitialized state = getThreadState_ state STM.retry
 
 -- | An abstraction of 'ThreadState' without the public interface type.
-data ThreadState_ notRunning =
+data ThreadState_ notRunning r r' =
       ThreadNotYetRunning_ notRunning
     | ThreadRunning_
-    | ThreadDone_
+    | ThreadDone_ r
+    | ThreadTrivial_ r'
     | ThreadException_ ThreadException
 
 getThreadState_ ::
-     TVar (ThreadState a)
+     TVar (ThreadState a r r')
   -> STM notRunning
-  -> STM (ThreadState_ notRunning)
+  -> STM (ThreadState_ notRunning r r')
 getThreadState_ state onNotRunning = do
     st <- STM.readTVar state
     case st of
       ThreadNotStarted   _     -> ThreadNotYetRunning_ <$> onNotRunning
       ThreadInitializing _ _   -> ThreadNotYetRunning_ <$> onNotRunning
       ThreadRunning      _ _ _ -> return $ ThreadRunning_
-      ThreadDone         _   _ -> return $ ThreadDone_
+      ThreadDone         _ _ r -> return $ ThreadDone_ r
+      ThreadTrivial      _ r'  -> return $ ThreadTrivial_ r'
       ThreadDied         _   e -> return $ ThreadException_ e
 
 {-------------------------------------------------------------------------------

--- a/grapesy/src/Network/GRPC/Util/Thread.hs
+++ b/grapesy/src/Network/GRPC/Util/Thread.hs
@@ -28,7 +28,8 @@ module Network.GRPC.Util.Thread (
 import Network.GRPC.Util.Imports
 
 import Control.Concurrent
-import Control.Concurrent.STM
+import Control.Concurrent.STM (STM, TVar)
+import Control.Concurrent.STM qualified as STM
 import Control.Exception qualified as E
 import Foreign qualified
 import System.IO.Unsafe (unsafePerformIO)
@@ -167,7 +168,7 @@ type ThreadBody a =
 newThreadState :: HasCallStack => IO (TVar (ThreadState a))
 newThreadState = do
     debugId <- newDebugThreadId
-    newTVarIO $ ThreadNotStarted debugId
+    STM.newTVarIO $ ThreadNotStarted debugId
 
 forkThread ::
      HasCallStack
@@ -195,13 +196,13 @@ threadBody :: forall a.
 threadBody label state body = do
     labelThisThread label
     threadId  <- myThreadId
-    initState <- readTVarIO state
+    initState <- STM.readTVarIO state
 
     -- See discussion of 'ThreadNotStarted'
     -- It's critical that async exceptions are masked at this point.
     case initState of
       ThreadNotStarted debugId -> do
-        atomically $ writeTVar state $ ThreadInitializing debugId threadId
+        atomically $ STM.writeTVar state $ ThreadInitializing debugId threadId
       ThreadDied _ ThreadException{threadException} ->
         -- We don't change the thread status here: 'cancelThread' offers the
         -- guarantee that the thread status /will/ be in aborted or done state
@@ -214,7 +215,7 @@ threadBody label state body = do
 
     let markReady :: a -> STM ()
         markReady a = do
-            modifyTVar state $ \oldState ->
+            STM.modifyTVar state $ \oldState ->
               case oldState of
                 ThreadInitializing debugId _ ->
                   ThreadRunning debugId threadId a
@@ -225,7 +226,7 @@ threadBody label state body = do
 
         markDone :: Either ExactException () -> STM ()
         markDone mDone = do
-            modifyTVar state $ \oldState ->
+            STM.modifyTVar state $ \oldState ->
               case (oldState, mDone) of
                 (ThreadRunning debugId _ iface, Right ()) ->
                   ThreadDone debugId iface
@@ -299,16 +300,16 @@ cancelThread state e = do
   where
     aux :: ThreadException -> STM (CancelResult a, Maybe ThreadId)
     aux cancelled = do
-        st <- readTVar state
+        st <- STM.readTVar state
         case st of
           ThreadNotStarted debugId -> do
-            writeTVar state $ ThreadDied debugId cancelled
+            STM.writeTVar state $ ThreadDied debugId cancelled
             return (Cancelled, Nothing)
           ThreadInitializing debugId threadId -> do
-            writeTVar state $ ThreadDied debugId cancelled
+            STM.writeTVar state $ ThreadDied debugId cancelled
             return (Cancelled, Just threadId)
           ThreadRunning debugId threadId _ -> do
-            writeTVar state $ ThreadDied debugId cancelled
+            STM.writeTVar state $ ThreadDied debugId cancelled
             return (Cancelled, Just threadId)
           ThreadDied _debugId e' ->
             return (AlreadyAborted e', Nothing)
@@ -355,10 +356,10 @@ withThreadInterface state k = do
   where
     getThreadInterface :: STM (Either ThreadException a)
     getThreadInterface = do
-        st <- readTVar state
+        st <- STM.readTVar state
         case st of
-          ThreadNotStarted   _     -> retry
-          ThreadInitializing _ _   -> retry
+          ThreadNotStarted   _     -> STM.retry
+          ThreadInitializing _ _   -> STM.retry
           ThreadRunning      _ _ a -> return (Right a)
           ThreadDone         _   a -> return (Right a)
           ThreadDied         _   e -> return (Left e)
@@ -378,7 +379,7 @@ waitForNormalOrAbnormalThreadTermination ::
 waitForNormalOrAbnormalThreadTermination state =
     waitUntilInitialized state >>= \case
       ThreadNotYetRunning_ v -> absurd v
-      ThreadRunning_         -> retry
+      ThreadRunning_         -> STM.retry
       ThreadDone_            -> return $ Nothing
       ThreadException_ e     -> return $ Just e
 
@@ -398,7 +399,7 @@ unlessAbnormallyTerminated state f =
 waitUntilInitialized ::
      TVar (ThreadState a)
   -> STM (ThreadState_ Void)
-waitUntilInitialized state = getThreadState_ state retry
+waitUntilInitialized state = getThreadState_ state STM.retry
 
 -- | An abstraction of 'ThreadState' without the public interface type.
 data ThreadState_ notRunning =
@@ -412,7 +413,7 @@ getThreadState_ ::
   -> STM notRunning
   -> STM (ThreadState_ notRunning)
 getThreadState_ state onNotRunning = do
-    st <- readTVar state
+    st <- STM.readTVar state
     case st of
       ThreadNotStarted   _     -> ThreadNotYetRunning_ <$> onNotRunning
       ThreadInitializing _ _   -> ThreadNotYetRunning_ <$> onNotRunning

--- a/grapesy/src/Network/GRPC/Util/Thread.hs
+++ b/grapesy/src/Network/GRPC/Util/Thread.hs
@@ -29,7 +29,7 @@ import Network.GRPC.Util.Imports
 
 import Control.Concurrent
 import Control.Concurrent.STM
-import Control.Exception
+import Control.Exception qualified as E
 import Foreign qualified
 import System.IO.Unsafe (unsafePerformIO)
 
@@ -173,7 +173,7 @@ forkThread ::
      HasCallStack
   => ThreadLabel -> TVar (ThreadState a) -> ThreadBody a -> IO ()
 forkThread label state body =
-    void $ mask_ $ forkIOWithUnmask $ \unmask ->
+    void $ E.mask_ $ forkIOWithUnmask $ \unmask ->
       threadBody label state $ body unmask
 
 -- | Wrap the thread body

--- a/grapesy/test-grapesy/Test/Driver/ClientServer.hs
+++ b/grapesy/test-grapesy/Test/Driver/ClientServer.hs
@@ -30,7 +30,8 @@ module Test.Driver.ClientServer (
 
 import Control.Concurrent
 import Control.Concurrent.Async
-import Control.Concurrent.STM
+import Control.Concurrent.STM (STM, TVar, TMVar)
+import Control.Concurrent.STM qualified as STM
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class
@@ -309,7 +310,7 @@ data TestFailure = TestFailure
 -- Does nothing if an earlier test failure has already been marked.
 markTestFailure :: TMVar FirstTestFailure -> FirstTestFailure  -> IO ()
 markTestFailure firstTestFailure err =
-    void $ atomically $ tryPutTMVar firstTestFailure err
+    void $ atomically $ STM.tryPutTMVar firstTestFailure err
 
 {-------------------------------------------------------------------------------
   Server handler lock
@@ -325,12 +326,12 @@ markTestFailure firstTestFailure err =
 newtype ServerHandlerLock = ServerHandlerLock (TVar Int)
 
 newServerHandlerLock :: IO ServerHandlerLock
-newServerHandlerLock = ServerHandlerLock <$> newTVarIO 0
+newServerHandlerLock = ServerHandlerLock <$> STM.newTVarIO 0
 
 waitForHandlerTermination :: ServerHandlerLock -> STM ()
 waitForHandlerTermination (ServerHandlerLock lock) = do
-    activeHandlers <- readTVar lock
-    when (activeHandlers > 0) retry
+    activeHandlers <- STM.readTVar lock
+    when (activeHandlers > 0) STM.retry
 
 topLevelWithHandlerLock ::
      ClientServerConfig
@@ -362,8 +363,8 @@ topLevelWithHandlerLock cfg
         markDone
 
     markActive, markDone :: IO ()
-    markActive = atomically $ modifyTVar lock (\n -> n + 1)
-    markDone   = atomically $ modifyTVar lock (\n -> n - 1)
+    markActive = atomically $ STM.modifyTVar lock (\n -> n + 1)
+    markDone   = atomically $ STM.modifyTVar lock (\n -> n - 1)
 
 {-------------------------------------------------------------------------------
   Server
@@ -573,7 +574,7 @@ data ClientServerTest = ClientServerTest {
 runTestClientServer :: ClientServerTest -> IO ()
 runTestClientServer (ClientServerTest cfg clientRun handlers) = do
     -- Setup client and server
-    firstTestFailure  <- newEmptyTMVarIO
+    firstTestFailure  <- STM.newEmptyTMVarIO
     serverHandlerLock <- newServerHandlerLock
 
     let server :: (Server.RunningServer -> IO a) -> IO a
@@ -595,19 +596,19 @@ runTestClientServer (ClientServerTest cfg clientRun handlers) = do
         -- (the 'orElse' is only relevant if a /handler/ throws an exception)
         atomically $
             (void $ waitCatchSTM clientThread)
-          `orElse`
+          `STM.orElse`
             (void failure)
 
         -- Wait for handlers to terminate (or test failure)
         -- (Note that the server /itself/ normally never terminates)
         atomically $
             (waitForHandlerTermination serverHandlerLock)
-          `orElse`
+          `STM.orElse`
             (void failure)
 
         atomically $ do
-            (failure >>= throwSTM)
-          `orElse`
+            (failure >>= STM.throwSTM)
+          `STM.orElse`
             return ()
 
 -- | Wait for test failure (retries/blocks if tests have not yet failed)
@@ -623,10 +624,10 @@ waitForFailure ::
   -> TMVar FirstTestFailure  -- ^ First test failure
   -> STM FirstTestFailure
 waitForFailure server client firstTestFailure =
-      (readTMVar firstTestFailure)
-    `orElse`
+      (STM.readTMVar firstTestFailure)
+    `STM.orElse`
       (Server.waitServerSTM server >>= serverAux)
-    `orElse`
+    `STM.orElse`
       (waitCatchExact client >>= clientAux)
   where
     serverAux ::
@@ -636,11 +637,11 @@ waitForFailure server client firstTestFailure =
       -> STM FirstTestFailure
     serverAux (Left e, _) = return (firstFailureInServer e)
     serverAux (_, Left e) = return (firstFailureInServer e)
-    serverAux _otherwise  = throwSTM $ UnexpectedServerTermination
+    serverAux _otherwise  = STM.throwSTM $ UnexpectedServerTermination
 
     clientAux :: Either ExactException () -> STM FirstTestFailure
     clientAux (Left e)   = return (firstFailureInClient e)
-    clientAux _otherwise = retry
+    clientAux _otherwise = STM.retry
 
 -- | We don't expect the server to shutdown until we kill it
 data UnexpectedServerTermination = UnexpectedServerTermination

--- a/grapesy/test-grapesy/Test/Driver/ClientServer.hs
+++ b/grapesy/test-grapesy/Test/Driver/ClientServer.hs
@@ -31,7 +31,6 @@ module Test.Driver.ClientServer (
 import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Concurrent.STM
-import Control.Exception (throwIO)
 import Control.Monad
 import Control.Monad.Catch
 import Control.Monad.IO.Class

--- a/grapesy/test-grapesy/Test/Driver/Dialogue/Definition.hs
+++ b/grapesy/test-grapesy/Test/Driver/Dialogue/Definition.hs
@@ -19,7 +19,7 @@ module Test.Driver.Dialogue.Definition (
   , hasEarlyTermination
   ) where
 
-import Control.Monad.Catch
+import Control.Monad.Catch (MonadThrow)
 import Control.Monad.State (StateT, execStateT, modify)
 import Data.Bifunctor
 import Data.ByteString qualified as Strict (ByteString)

--- a/grapesy/test-grapesy/Test/Driver/Dialogue/Execution.hs
+++ b/grapesy/test-grapesy/Test/Driver/Dialogue/Execution.hs
@@ -8,8 +8,10 @@ module Test.Driver.Dialogue.Execution (
 
 import Control.Concurrent
 import Control.Concurrent.Async
+import Control.Exception (Exception(..))
 import Control.Monad
-import Control.Monad.Catch
+import Control.Monad.Catch (MonadThrow)
+import Control.Monad.Catch qualified as E
 import Control.Monad.State
 import Data.List (sortBy)
 import Data.Ord (comparing)
@@ -167,7 +169,7 @@ clientLocal clock call = \(LocalSteps steps) ->
         case step of
           ClientAction action -> do
             within timeoutClock step $ TestClock.waitForTick clock tick
-            continue <- clientAct tick action `finally` TestClock.advance clock
+            continue <- clientAct tick action `E.finally` TestClock.advance clock
             when continue $ go steps
           ServerAction action -> do
             TestClock.giveGreenLight clock tick
@@ -221,11 +223,11 @@ clientLocal clock call = \(LocalSteps steps) ->
             reactToServer tick $ Send (StreamElem a)
             reactToServer tick $ Send (NoMoreElems b)
           Send expectedElem -> do
-            mOut <- try $ within timeoutReceive action $
+            mOut <- E.try $ within timeoutReceive action $
                       Client.Binary.recvOutput call
             expect (tick, action) (isExpectedElem expectedElem) mOut
           Terminate mErr -> do
-            mOut <- try $ within timeoutReceive action $
+            mOut <- E.try $ within timeoutReceive action $
                       Client.Binary.recvOutput call
             let expectation = isGrpcException mErr
             expect (tick, action) expectation mOut
@@ -247,7 +249,7 @@ clientLocal clock call = \(LocalSteps steps) ->
         -- We only do this when we know the client has terminated, so the
         -- /type/ of the message we send here as a probe does not matter.
         loop = do
-            mFailed <- try $ Client.Binary.sendNextInput call ()
+            mFailed <- E.try $ Client.Binary.sendNextInput call ()
             case mFailed of
               Left (_ :: GrpcException) ->
                 return ()
@@ -372,7 +374,7 @@ serverLocal clock call = \(LocalSteps steps) -> do
         case step of
           ServerAction action -> do
             within timeoutClock step $ TestClock.waitForTick clock tick
-            continue <- serverAct tick action `finally` TestClock.advance clock
+            continue <- serverAct tick action `E.finally` TestClock.advance clock
             when continue $ go steps
           ClientAction action -> do
             TestClock.giveGreenLight clock tick
@@ -416,11 +418,11 @@ serverLocal clock call = \(LocalSteps steps) -> do
           Initiate _ ->
             error "serverLocal: unexpected ClientInitiateRequest"
           Send expectedElem -> do
-            mInp <- liftIO $ try $ within timeoutReceive action $
+            mInp <- liftIO $ E.try $ within timeoutReceive action $
                       Server.Binary.recvInput call
             expect (tick, action) (isExpectedElem expectedElem) mInp
           Terminate mErr -> do
-            mInp <- liftIO $ try $ within timeoutReceive action $
+            mInp <- liftIO $ E.try $ within timeoutReceive action $
                       Server.Binary.recvInput call
             expect (tick, action) isExpectedDisconnect mInp
             modify $ ifPeerAlive $ PeerTerminated mErr
@@ -440,7 +442,7 @@ serverLocal clock call = \(LocalSteps steps) -> do
         -- We only do this when we know the client has terminated, so the
         -- /type/ of the message we send here as a probe does not matter.
         loop = do
-            mFailed <- try $ Server.Binary.sendNextOutput call ()
+            mFailed <- E.try $ Server.Binary.sendNextOutput call ()
             case mFailed of
               Left (_ :: Server.ClientDisconnected) ->
                 return ()

--- a/grapesy/test-grapesy/Test/Driver/Dialogue/TestClock.hs
+++ b/grapesy/test-grapesy/Test/Driver/Dialogue/TestClock.hs
@@ -15,7 +15,8 @@ module Test.Driver.Dialogue.TestClock (
 
 import Prelude hiding (id)
 
-import Control.Concurrent.STM
+import Control.Concurrent.STM (TVar)
+import Control.Concurrent.STM qualified as STM
 import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class
@@ -28,6 +29,8 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 import GHC.Stack
 import Test.QuickCheck (Gen, choose)
+
+import Network.GRPC.Common.Exception
 
 {-------------------------------------------------------------------------------
   Definition
@@ -90,7 +93,7 @@ newtype Tick = Tick Word
 
 -- | Start the clock
 new :: IO TestClock
-new = TestClock <$> newTVarIO initState
+new = TestClock <$> STM.newTVarIO initState
   where
     initState :: State
     initState = State {
@@ -116,10 +119,10 @@ data TimePassed = TimePassed {
 -- If the clock has already gone past the specified time, throws 'TimePassed'.
 waitForTick :: MonadIO m => TestClock -> Tick -> m ()
 waitForTick (TestClock clock) t = liftIO . atomically $ do
-    State{stateNow} <- readTVar clock
-    if | stateNow < t  -> retry
+    State{stateNow} <- STM.readTVar clock
+    if | stateNow < t  -> STM.retry
        | stateNow == t -> return ()
-       | otherwise     -> throwSTM $ TimePassed {
+       | otherwise     -> STM.throwSTM $ TimePassed {
                               timePassedNow    = stateNow
                             , timePassedWanted = t
                             , timePassedAt     = callStack
@@ -131,7 +134,7 @@ waitForTick (TestClock clock) t = liftIO . atomically $ do
 -- at any given time.
 advance :: MonadIO m => TestClock -> m ()
 advance (TestClock clock) = liftIO . atomically $ do
-    modifyTVar clock $ \st@State{stateNow} ->
+    STM.modifyTVar clock $ \st@State{stateNow} ->
       st{stateNow = succ stateNow}
 
 {-------------------------------------------------------------------------------
@@ -143,15 +146,15 @@ advance (TestClock clock) = liftIO . atomically $ do
 -- See 'TestClock' for discussion.
 waitForGreenLight :: MonadIO m => TestClock -> Tick -> m ()
 waitForGreenLight (TestClock clock) t = liftIO . atomically $ do
-    State{stateGreen} <- readTVar clock
-    unless (t `Set.member` stateGreen) retry
+    State{stateGreen} <- STM.readTVar clock
+    unless (t `Set.member` stateGreen) STM.retry
 
 -- | Give green light
 --
 -- See 'TestClock' for discussion.
 giveGreenLight :: MonadIO m => TestClock -> Tick -> m ()
 giveGreenLight (TestClock clock) t = liftIO . atomically $ do
-    modifyTVar clock $ \st@State{stateGreen} ->
+    STM.modifyTVar clock $ \st@State{stateGreen} ->
       st{stateGreen = Set.insert t stateGreen}
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
This inverts control, in the hope that this will allow to resolve the race condition documented in `sendMessageLoop`, which is (the? one of?) the causes of the flaky tests. However, this is currently not working: we're getting some blocked indefinitely on STM exceptions. I'm not yet sure where they are coming from, and we get no helpful backtraces. Figuring that out will be useful in its own right, however, since we were very occassionally seeing those under other circumstances also. If the stars align, they are now simply revealed and more easily reproducible, rather than that we introduced a second source.
