### PR TITLE
Update dependencies where possible

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -153,32 +153,32 @@ library
       Network.GRPC.Util.Version
 
   build-depends:
-    , aeson                     >= 1.5     && < 2.3
+    , aeson                     >= 1.5     && < 2.4
     , async                     >= 2.2     && < 2.3
     , binary                    >= 0.8     && < 0.9
     , bytestring                >= 0.10.12 && < 0.13
     , conduit                   >= 1.3     && < 1.4
     , containers                >= 0.6     && < 0.9
-    , crypton-x509              >= 1.7     && < 1.8
-    , crypton-x509-store        >= 1.6     && < 1.7
-    , crypton-x509-system       >= 1.6     && < 1.7
+    , crypton-x509              >= 1.7     && < 1.10
+    , crypton-x509-store        >= 1.6     && < 1.10
+    , crypton-x509-system       >= 1.6     && < 1.10
     , data-default              >= 0.7     && < 0.9
     , deepseq                   >= 1.4     && < 1.6
     , grpc-spec                 >= 1.0     && < 1.1
-    , http-semantics            >= 0.3.0   && < 0.3.1
+    , http-semantics            >= 0.3.0   && < 0.5
     , http-types                >= 0.12    && < 0.13
     , http2-tls                 >= 0.4.9   && < 0.5
     , lens                      >= 5.0     && < 5.4
     , mtl                       >= 2.2     && < 2.4
     , network                   >= 3.2.4   && < 3.3
-    , network-run               >= 0.4.3   && < 0.5
+    , network-run               >= 0.4.3   && < 0.6
     , proto-lens                >= 0.7     && < 0.8
     , proto-lens-protobuf-types >= 0.7     && < 0.8
     , random                    >= 1.2     && < 1.4
     , recv                      >= 0.1     && < 0.2
     , stm                       >= 2.5     && < 2.6
     , text                      >= 1.2     && < 2.2
-    , time-manager              >= 0.2.2   && < 0.3
+    , time-manager              >= 0.2.2   && < 0.4
     , tls                       >= 1.7     && < 2.5
     , unbounded-delays          >= 0.1.1   && < 0.2
     , unordered-containers      >= 0.2     && < 0.3
@@ -366,7 +366,7 @@ test-suite test-stress
     , directory            >= 1.3     && < 1.4
     , filepath             >= 1.4.2.1 && < 1.6
     , ghc-events           >= 0.17    && < 0.22
-    , optparse-applicative >= 0.16    && < 0.19
+    , optparse-applicative >= 0.16    && < 0.20
     , pretty-show          >= 1.10    && < 1.11
     , process              >= 1.6.12  && < 1.7
     , random               >= 1.2     && < 1.4
@@ -444,7 +444,7 @@ test-suite grapesy-interop
   build-depends:
       -- Additional dependencies
     , ansi-terminal        >= 1.1  && < 1.2
-    , optparse-applicative >= 0.16 && < 0.19
+    , optparse-applicative >= 0.16 && < 0.20
     , proto-lens-runtime   >= 0.7  && < 0.8
 
 benchmark grapesy-kvstore
@@ -487,7 +487,7 @@ benchmark grapesy-kvstore
     , base16-bytestring    >= 1.0  && < 1.1
     , base64-bytestring    >= 1.2  && < 1.3
     , hashable             >= 1.3  && < 1.6
-    , optparse-applicative >= 0.16 && < 0.19
+    , optparse-applicative >= 0.16 && < 0.20
     , proto-lens-runtime   >= 0.7  && < 0.8
     , splitmix             >= 0.1  && < 0.2
 

--- a/tutorials/basics/basics-tutorial.cabal
+++ b/tutorials/basics/basics-tutorial.cabal
@@ -46,12 +46,12 @@ library
   hs-source-dirs: src, generated
 
   build-depends:
-    , aeson              >= 1.5 && < 2.3
+    , aeson              >= 1.5 && < 2.4
     , containers         >= 0.6 && < 0.9
     , grapesy            >= 1.1 && < 1.2
     , proto-lens         >= 0.7 && < 0.8
     , proto-lens-runtime >= 0.7 && < 0.8
-    , time               >= 1.9 && < 1.16
+    , time               >= 1.9 && < 1.17
   exposed-modules:
       RouteGuide
       Proto.API.RouteGuide

--- a/tutorials/lowlevel/lowlevel-tutorial.cabal
+++ b/tutorials/lowlevel/lowlevel-tutorial.cabal
@@ -44,7 +44,7 @@ executable route_guide_server
   build-depends:
     , grapesy    >= 1.1 && < 1.2
     , proto-lens >= 0.7 && < 0.8
-    , time       >= 1.9 && < 1.16
+    , time       >= 1.9 && < 1.17
 
 executable route_guide_client
   import:         lang

--- a/tutorials/metadata/metadata-tutorial.cabal
+++ b/tutorials/metadata/metadata-tutorial.cabal
@@ -51,7 +51,7 @@ library
     , grapesy            >= 1.1  && < 1.2
     , proto-lens         >= 0.7  && < 0.8
     , proto-lens-runtime >= 0.7  && < 0.8
-    , time               >= 1.9  && < 1.16
+    , time               >= 1.9  && < 1.17
   exposed-modules:
       Proto.API.Fileserver
   other-modules:

--- a/tutorials/monadstack/monadstack-tutorial.cabal
+++ b/tutorials/monadstack/monadstack-tutorial.cabal
@@ -49,7 +49,7 @@ executable route_guide_server
   build-depends:
     , grapesy >= 1.1 && < 1.2
     , mtl     >= 2.2 && < 2.4
-    , time    >= 1.9 && < 1.16
+    , time    >= 1.9 && < 1.17
 
 executable route_guide_client
   import:         lang

--- a/tutorials/trailers-only/trailers-only-tutorial.cabal
+++ b/tutorials/trailers-only/trailers-only-tutorial.cabal
@@ -44,4 +44,4 @@ executable route_guide_server
 
   build-depends:
     , grapesy >= 1.1 && < 1.2
-    , time    >= 1.9 && < 1.16
+    , time    >= 1.9 && < 1.17


### PR DESCRIPTION
There are new versions of `http2` and `http2-tls` but I didn't update them because of the scary comment about `http2` in the cabal file.

Tests fine locally (with an occasional intermittent failure related to https://github.com/well-typed/grapesy/issues/347).