### PR TITLE
Slight improvement to timeout implementation, clarify role of `closeRPC`

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -432,6 +432,7 @@ test-suite grapesy-interop
       Interop.Util.ANSI
       Interop.Util.Exceptions
       Interop.Util.Messages
+      Interop.Util.NonInterleaved
 
       Paths_
 

--- a/grapesy/interop/Interop/Client.hs
+++ b/grapesy/interop/Interop/Client.hs
@@ -11,6 +11,7 @@ import System.Timeout
 import Interop.Cmdline
 import Interop.Util.ANSI
 import Interop.Util.Exceptions
+import Interop.Util.NonInterleaved qualified as NI
 
 import Interop.Client.TestCase.EmptyUnary                qualified as EmptyUnary
 import Interop.Client.TestCase.LargeUnary                qualified as LargeUnary
@@ -119,7 +120,7 @@ initTestStats = TestStats {
 
 testOK :: IORef TestStats -> TestCase -> IO ()
 testOK statsRef test = do
-    putDocLn $ mconcat [
+    NI.putDocLn $ mconcat [
         Show test
       , ": "
       , Color Green "OK"
@@ -129,7 +130,7 @@ testOK statsRef test = do
 
 testFailed :: IORef TestStats -> TestCase -> String -> IO ()
 testFailed statsRef test err = do
-    putDocLn $ mconcat [
+    NI.putDocLn $ mconcat [
         Show test
       , ": "
       , Color Red "Failed: "
@@ -140,7 +141,7 @@ testFailed statsRef test err = do
 
 testSkipped :: IORef TestStats -> TestCase -> String -> IO ()
 testSkipped statsRef test reason = do
-    putDocLn $ mconcat [
+    NI.putDocLn $ mconcat [
         Show test
       , ": "
       , Color Yellow "Skipped: "
@@ -154,7 +155,7 @@ ranAllTests statsRef = do
     stats <- readIORef statsRef
 
     when (numSucceeded stats + numFailed stats > 1 || numSkipped stats > 0) $
-      putStrLn $ concat [
+      NI.putStrLn $ concat [
           show $ numSucceeded stats
         , " succeeded, "
         , show $ numFailed stats

--- a/grapesy/interop/Interop/Server.hs
+++ b/grapesy/interop/Interop/Server.hs
@@ -13,6 +13,7 @@ import Network.GRPC.Server.Run
 import Network.GRPC.Server.StreamType
 
 import Interop.Cmdline
+import Interop.Util.NonInterleaved qualified as NI
 
 import Interop.Server.PingService.Ping                qualified as Ping
 import Interop.Server.TestService.EmptyCall           qualified as EmptyCall
@@ -123,10 +124,10 @@ showStartStop act = fst <$>
       (\() -> act)
   where
     start :: IO ()
-    start = putStrLn "grapesy interop server started"
+    start = NI.putStrLn "grapesy interop server started"
 
     stop :: ExitCase a -> IO ()
-    stop (ExitCaseSuccess _)   = putStrLn $ "server terminated normally"
-    stop (ExitCaseException e) = putStrLn $ "server exception: " ++ show e
+    stop (ExitCaseSuccess _)   = NI.putStrLn $ "server terminated normally"
+    stop (ExitCaseException e) = NI.putStrLn $ "server exception: " ++ show e
     stop  ExitCaseAbort        = error "impossible in IO"
 

--- a/grapesy/interop/Interop/Server/Common.hs
+++ b/grapesy/interop/Interop/Server/Common.hs
@@ -7,7 +7,6 @@ module Interop.Server.Common (
   , checkInboundCompression
   ) where
 
-import Control.Exception
 import Data.ProtoLens.Labels ()
 
 import Network.GRPC.Common

--- a/grapesy/interop/Interop/Util/Exceptions.hs
+++ b/grapesy/interop/Interop/Util/Exceptions.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Interop.Util.Exceptions (
     TestSkipped(..)
   , TestUnimplemented(..)
@@ -9,15 +11,32 @@ module Interop.Util.Exceptions (
   , assertEqual
   , assertThrows
   , assertTerminatesWithinSeconds
+    -- * Uncaught exception handler
+  , uncaughtExceptionHandler
     -- * Re-exports
   , HasCallStack
   , throwIO
   ) where
 
-import Control.Exception
+import Control.Concurrent
+import Control.Exception (Exception(..))
+import Control.Exception qualified as E
 import Data.List (intercalate)
+import Data.Maybe (fromMaybe)
 import GHC.Stack
+import Network.GRPC.Common.Exception
+import System.IO
 import System.Timeout
+
+#if MIN_VERSION_base(4,18,0)
+import GHC.Conc.Sync (threadLabel)
+#endif
+
+import Interop.Util.NonInterleaved qualified as NI
+
+{-------------------------------------------------------------------------------
+  Exceptions thrown by the tests
+-------------------------------------------------------------------------------}
 
 data TestSkipped = TestSkipped String
   deriving stock (Show)
@@ -69,7 +88,7 @@ assertEqual expected actual
 
 assertThrows :: (HasCallStack, Exception e) => (e -> IO ()) -> IO a -> IO ()
 assertThrows p io = do
-    ma <- try io
+    ma <- E.try io
     case ma of
       Right _  -> assertFailure "Expected exception"
       Left err -> p err
@@ -81,4 +100,26 @@ assertTerminatesWithinSeconds s io = do
       Nothing -> assertFailure "Timeout"
       Just () -> return ()
 
+
+{-------------------------------------------------------------------------------
+  Uncaught exception handler
+-------------------------------------------------------------------------------}
+
+uncaughtExceptionHandler :: E.SomeException -> IO ()
+uncaughtExceptionHandler e = do
+    tid    <- myThreadId
+    mLabel :: Maybe String <-
+#if MIN_VERSION_base(4,18,0)
+      threadLabel tid
+#else
+      return $ Just "unknown label"
+#endif
+    NI.hPutStrLn stderr $ concat [
+         "Uncaught exception in "
+      , show tid
+      , " ("
+      , fromMaybe "unlabelled" mLabel
+      , "): "
+      , renderException e
+      ]
 

--- a/grapesy/interop/Interop/Util/NonInterleaved.hs
+++ b/grapesy/interop/Interop/Util/NonInterleaved.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Non-interleaved output
+--
+-- Intended for qualified import.
+--
+-- > import Interop.Util.NonInterleaved qualified as NI
+module Interop.Util.NonInterleaved (
+    putStrLn
+  , hPutStrLn
+  , putDocLn
+  ) where
+
+import Prelude hiding (putStrLn)
+import Prelude qualified
+
+import Control.Concurrent
+import System.IO (Handle)
+import System.IO qualified
+import System.IO.Unsafe (unsafePerformIO)
+
+import Interop.Util.ANSI qualified as ANSI
+
+{-------------------------------------------------------------------------------
+  Internal: output lock
+-------------------------------------------------------------------------------}
+
+outputLock :: MVar ()
+{-# NOINLINE outputLock #-}
+outputLock = unsafePerformIO $ newMVar ()
+
+withOutputLock :: IO a -> IO a
+withOutputLock k = withMVar outputLock $ \() -> k
+
+{-------------------------------------------------------------------------------
+  Wrappers
+-------------------------------------------------------------------------------}
+
+putStrLn :: String -> IO ()
+putStrLn str = withOutputLock $ Prelude.putStrLn str
+
+hPutStrLn :: Handle -> String -> IO ()
+hPutStrLn h str = withOutputLock $ System.IO.hPutStrLn h str
+
+putDocLn :: ANSI.Doc -> IO ()
+putDocLn doc = withOutputLock $ ANSI.putDocLn doc

--- a/grapesy/interop/Main.hs
+++ b/grapesy/interop/Main.hs
@@ -8,6 +8,7 @@ import Interop.Client.Ping (ping)
 import Interop.Cmdline
 import Interop.SelfTest (selfTest)
 import Interop.Server (runInteropServer)
+import Interop.Util.Exceptions
 
 {-------------------------------------------------------------------------------
   Top-level application driver
@@ -15,9 +16,7 @@ import Interop.Server (runInteropServer)
 
 main :: IO ()
 main = do
-    setUncaughtExceptionHandler $ \err -> do
-      hPutStrLn stderr $ "Uncaught exception: " ++ show err
-      hFlush stderr
+    setUncaughtExceptionHandler uncaughtExceptionHandler
 
     -- Ensure we see server output when running inside docker
     hSetBuffering stdout NoBuffering

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -57,7 +57,6 @@ import Network.GRPC.Util.Session.Channel qualified as Session
 import Network.GRPC.Util.Session.Client qualified as Session
 import Network.GRPC.Util.Stream (ServerDisconnected(..))
 import Network.GRPC.Util.Thread qualified as Thread
-
 import Network.GRPC.Util.Version qualified as Grapesy
 
 {-------------------------------------------------------------------------------
@@ -196,34 +195,31 @@ startRPC conn _ callParams = do
                   , grpcErrorMetadata = []
                   }
 
-          -- We recognized client-side that the timeout we imposed on the server
-          -- has passed. Acting on this is however tricky:
-          --
-          -- o A call to 'closeRPC' will only terminate the /outbound/ thread;
-          --   the idea is the inbound thread might still be reading in-flight
-          --   messages, and it will terminate once the last message is read or
-          --   the thread notices a broken connection.
-          -- o Unfortunately, this does not work in the timeout case: /if/ the
-          --   outbound thread has not yet terminated (that is, the client has
-          --   not yet sent their final message), then calling 'closeRPC' will
-          --   result in a RST_STREAM being sent to the server, which /should/
-          --   result in the inbound connection being closed also, but may not,
-          --   in the case of a non-compliant server.
-          -- o Worse, if the client /did/ already send their final message, the
-          --   outbound thread has already terminated, no RST_STREAM will be
-          --   sent, and the we will continue to wait for messages from the
-          --   server.
-          --
-          -- Ideally we'd inform the receiving thread that a timeout has been
-          -- reached and to "continue until it would block", but that is hard
-          -- to do. So instead we just kill the receiving thread, which means
-          -- that once the timeout is reached, the client will not be able to
-          -- receive any further messages (even if that is because the /client/
-          -- was slow, rather than the server).
+              timeoutExitCase :: ExitCase ()
+              timeoutExitCase = ExitCaseException (unwrapExactException timeout)
 
+          -- We recognized client-side that the timeout we imposed on the server
+          -- has passed, and don't want to rely on a compliant server
+          -- implementation to enforce that timeout. We will therefore close the
+          -- connection in the client, but the normal procedure for closing the
+          -- connection (implemented in 'closeRPC'), is not quite right here:
+          --
+          -- o Unless the client has sent their final message to the server,
+          --   closing the connection is normally considered a cancellation,
+          --   which should result in a RST_STREAM frame being sent to the
+          --   server and 'GrpcCancelled' cancelled raised in the client.
+          -- o We normally terminate only the /outbound/ thread, to allow the
+          --   inbound thread to continue to read any messages that might still
+          --   be in-flight; we then rely on the serve closing the connection
+          --   (normally or abnormally) to close the inbound thread.
+          --
+          -- Neither of these apply in the case of a timeout, so instead we just
+          -- terminate both the inbound and the output thread. This /does/ mean
+          -- that once the timeout is reached, the client will not be able to
+          -- receive any further messages, even if that is because the /client/
+          -- was slow, rather than the server.
           void $ Thread.cancelThread (Session.channelInbound channel) timeout
-          closeRPC channel cancelRequest $
-            ExitCaseException (unwrapExactException timeout)
+          void $ Session.close channel timeoutExitCase
 
     -- Spawn a thread to monitor the connection, and close the new channel when
     -- the connection is closed. To prevent a memory leak by hanging on to the

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -333,6 +333,30 @@ closeRPC ::
      Session.Channel rpc
   -> Session.CancelRequest
   -> ExitCase a
+     -- ^ Reason for closing the connection
+     --
+     -- This serves two purposes:
+     --
+     -- o Further interaction with the connection will throw an exception
+     --   reflecting the reason that the connection was closed.
+     --
+     -- o If 'closeRPC' is called /before/ the client sent their final message
+     --   to the server, the server is sent a @RST_FRAME@. The error code in
+     --   the @RST_FRAME@ depends on the 'ExitCase':
+     --
+     --   a. If the 'ExitCase' is 'ExitCaseSuccess', indicating that the client
+     --      terminated normally, this is interpreted as the client cancelling
+     --      the request. The error code in the @RST_FRAME@ will therefore be
+     --      @CANCEL@, and a 'GrpcCancelled' exception is raised in the thread
+     --      calling 'closeRPC' (as mandated by the gRPC spec).
+     --   b. If not, the client terminated with an exception; since gRPC does
+     --      not support client-side trailers, we have no way of communicating
+     --      the nature of the client error to the client; instead, the
+     --      @RST_FRAME@ will have error code @INTERNAL_ERROR@.
+     --
+     -- If (b), the exception is not re-raised by 'closeRPC'; the assumption is
+     -- that in this case 'closeRPC' is called /in response to/ an exception,
+     -- and the /caller/ will re-raise that exception; see 'withRPC'.
   -> IO ()
 closeRPC callChannel cancelRequest exitCase = liftIO $ do
     -- /Before/ we do anything else (see below), check if we have evidence
@@ -359,9 +383,9 @@ closeRPC callChannel cancelRequest exitCase = liftIO $ do
       Just ex ->
         case fromException (unwrapExactException ex) of
           Nothing ->
-            -- We are leaving the scope of 'withRPC' because of an exception
-            -- in the client, just rethrow that exception.
-            throwM ex
+            -- We are leaving the scope of 'withRPC' because of an exception in
+            -- the client; caller is responsible for re-raising that exception.
+            return ()
           Just (discarded :: ChannelDiscarded) ->
             -- We are leaving the scope of 'withRPC' without having sent the
             -- final message.


### PR DESCRIPTION
Verified that `grapesy` `main` branch passes all the v1.72.2 interop tests. One of the tests exposed a minor bug, which I think has been present since essentially forever, where a timeout would result in an exception making it to the top-level uncaught exception handler for an auxiliary thread. No big deal, but cleaner to fix it, and an opportunity to make some other improvements. 