### PR TITLE
Use ediffEq instead of assertEqual

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -307,6 +307,7 @@ test-suite test-grapesy
     , tasty-hunit        >= 0.10    && < 0.11
     , tasty-quickcheck   >= 0.10    && < 0.12
     , temporary          >= 1.3     && < 1.4
+    , tree-diff          >= 0.4.1   && < 0.5
 
   if(flag(test-no-islabel))
     build-depends: proto-lens-protobuf-types >= 0.7.2.3

--- a/grapesy/test-grapesy/Test/Common/Exception.hs
+++ b/grapesy/test-grapesy/Test/Common/Exception.hs
@@ -2,18 +2,21 @@ module Test.Common.Exception (tests) where
 
 import Control.Exception (SomeException (..))
 import Test.Tasty
-import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
 import System.ThreadManager qualified as ThreadManager
+import Data.TreeDiff.QuickCheck (ediffEq)
 
 import Network.GRPC.Common.Exception
 
 tests :: TestTree
 tests = testGroup "Test.Common.Exception"
-    [ testCase "thread-manager" $ do
+    [ testProperty "thread-manager-1" $ do
+        let expected = unlines
+                [ "KilledByThreadManager"
+                , "  IOException"
+                , "    user error (foo)"
+                ]
+
         let ex = ThreadManager.KilledByThreadManager $ Just $ SomeException $ userError "foo"
-        renderException ex @?= unlines
-            [ "KilledByThreadManager"
-            , "  IOException"
-            , "    user error (foo)"
-            ]
+        ediffEq expected (renderException ex)
     ]


### PR DESCRIPTION
We get nicer report when things don't match.
Using nullary property is a bit weird, but it does work as assertEqual substitute.