### PR TITLE
Fix race condition in `sendMessageLoop`

### DIFF
--- a/dev/wireshark.md
+++ b/dev/wireshark.md
@@ -44,3 +44,49 @@ This is less useful when debugging connectivity issues, of course.
 
   Another symptom of this (especially when the server runs inside Docker) is
   when the client TLS handshake fails with `HandshakeFailed Error_EOF`.
+
+## `tshark`
+
+It is sometimes useful to use a CLI rather than the GUI, especially when there
+are non-deterministic test failures, and we want to repeatedly start and stop
+capture.
+
+* List available interfaces:
+
+  ```
+  dumpcap -D
+  ```
+
+* Capture traffic to and from 50051
+
+  ```
+  dumpcap -i lo -f "port 50051" -w capture.pcapng
+  ```
+
+* Example of repeatedly running a test until failure, capturing each test
+  separately:
+
+  ```bash
+  #!/bin/bash
+
+  for i in $(seq -f "%03g" 1 100)
+  do
+    echo "Test run $i"
+    dumpcap -i lo -f "port 50051" -w capture-$i.pcapng &
+    DUMPCAP=$!
+    cabal run -- test-grapesy -p multipleMsgs
+    TESTRESULT=$?
+    sleep 0.5
+    kill -SIGINT $DUMPCAP
+    if [ $TESTRESULT -ne 0 ]
+    then
+      break
+    fi
+  done
+  ```
+
+  The call to `sleep` is necessary to give `dumpcap` a chance to actually
+  write the packets (I don't know of a cleaner way to do this).
+
+  Note: the tests in the `grapesy` test suite use random ports by default; they
+  must be modified before they will use a static port such as 50051.

--- a/grapesy/src/Network/GRPC/Util/Exception/Shims.hs
+++ b/grapesy/src/Network/GRPC/Util/Exception/Shims.hs
@@ -18,22 +18,27 @@ module Network.GRPC.Util.Exception.Shims (
     -- * STM
 #ifndef PATCHED_GHC_FOR_EXCEPTION_DEBUGGING
   , AtomicallyBacktrace(..)
-#endif
   , atomically
+#else
+  , STM.atomically
+#endif
   ) where
 
-import Control.Concurrent.STM (STM)
 import Control.Concurrent.STM qualified as STM
 import Control.Exception (Exception(..))
 import Control.Exception qualified as Base
 import Control.Monad.Catch qualified as Exceptions
-import GHC.Generics
 import GHC.Stack
 
 #if MIN_VERSION_base(4,20,0)
 import Control.Exception.Annotation
 import Control.Exception.Backtrace qualified as Backtrace
 import Control.Exception.Context
+#endif
+
+#ifndef PATCHED_GHC_FOR_EXCEPTION_DEBUGGING
+import Control.Concurrent.STM (STM)
+import GHC.Generics
 #endif
 
 {-------------------------------------------------------------------------------

--- a/grapesy/src/Network/GRPC/Util/Session/Channel.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Channel.hs
@@ -505,37 +505,89 @@ data ChannelAborted = ChannelAborted Backtraces
 
 -- | Send all messages to the node's peer
 --
--- The outbound thread is set up to monitor the input thread:
+-- == Invariant: eventual progress
 --
--- * The outbound thread spends most of its time blocked waiting for messages to
---   send to the network peer, and may not notice when the connection is lost.
---   The inbound thread however spends most of its time blocked on waiting for
---   messages /from/ the peer and so will notice more or less immediately.
+-- The outbound thread, the thread running `sendMessageLoop`, communicates by
+-- reading a shared 'TMVar'. When a write to this 'TMVar' is blocked (in another
+-- thread), eventually one of the following two things will happen:
 --
--- * We need an important \"atomicity\" property however: once the outbound
---   thread has sent the trailers, we _expect_ the client to disconnect. We
---   must therefore stop monitoring the inboud thread prior to sending the
---   trailers, to avoid a race condition where
+-- * The outbound thread empties the 'TMVar'
+-- * The outbound thread dies (itself observable;
+--   see 'Network.GRPC.Util.Thread.withThreadInterface').
 --
---   1. the outbound thread sends the final chunk
---   2. the client receives the trailers and disconnects
---   3. the outbound thread gets the monitor notification before it gets a chance
---      to terminate, and dies, resulting in unexpected exceptions
+-- This invariant will cease to be true after the final message ('FinalElem' or
+-- 'NoMoreElems') is consumed: the thread will not read from the 'TMVar' after
+-- that point.
 --
---   Note that the client disconnecting /before/ receiving the final chunk
---   constitutes a violation of the protocol, and so it would be correct for
---   the outbound thread to report abnormal termination.
+-- == Exceptions
+--
+-- When a write /fails/ (say, connection lost) we'd like to be able to
+-- communicate this back to the caller: the outbound thread dies, which is
+-- observable (see above). It is important to note that the /absence/ of such an
+-- exception (a quote-unquote \"successful\" write) is no guarantee of anything;
+-- for example, it may be that the connection is lost after the message was
+-- successfully enqueued in some OS buffer but before it was put on the wire; or
+-- indeed somewhere along the way across the network to the destination.
+--
+-- However, the outbound thread spends most of its time blocked waiting for
+-- messages to send to the network peer, and may not notice when the connection
+-- is lost. It therefore /monitors/ the inbound thread, which spends most of its
+-- time blocked on waiting for messages /from/ the peer and so will notice more
+-- or less immediately.
+--
+-- We need an important \"atomicity\" property however: once the outbound thread
+-- has sent the trailers, we /expect/ the client to disconnect. We therefore
+-- mark ourselves as done prior to sending the trailers, to avoid a race
+-- condition where
+--
+-- 1. the outbound thread sends the final chunk
+-- 2. the client receives the trailers and disconnects
+-- 3. before the outbound thread gets the chance to terminate (the only thing
+--    left to do), it is killed (perhaps due to a monitor notification, or due
+--    to @http2@ sending an async exception to a server handler)
+--
+-- Such a race condition would result in timing-sensitive, non-deterministic
+-- exceptions. By marking ourselves done, /we cannot be killed anymore/, hence
+-- preventing the problem.
+--
+-- Note that if a client disconnects /before/ receiving the final chunk, this
+-- constitutes a violation of the protocol, and so it would be correct for the
+-- outbound thread to report abnormal termination.
+--
+-- == Failure on the final message
+--
+-- Conceptually, we'd want something like
+--
+-- > do ..
+-- >    writeChunkFinal ..
+-- >    -- .. prevent async exceptions here ..
+--
+-- but of course that is impossible to do /literally/; anything we do /after/
+-- the call to 'writeChunkFinal' still leaves a gap in between 'writeChunkFinal'
+-- and the next instruction. However, we cannot mask async exceptions /before/
+-- the call to 'writeChunkFinal' either, because 'writeChunkFinal' itself may
+-- block, and if it does, we do want to be interruptible while we wait.
+--
+-- By declaring ourselves done /before/ sending the final chunk (see previous
+-- section) we side-step the problem, at the cost of being unable to report if
+-- that final send fails. However, this is a small price to pay:
+--
+-- * As discussed above, the absence of a reported failure of a send is /anyway/
+--   no guarantee of success
+-- * Reporting failed sends is primarily useful for code that is repeatedly
+--   sending messages, and so if one message fails to send there is no point in
+--   sending the next. But for the final message there /cannot be/ a next
+--   message: this must anyway be the final write.
 sendMessageLoop :: forall sess.
      IsSession sess
   => sess
   -> RegularFlowState (Outbound sess)
   -> OutputStream
-  -> MonitorRef -- ^ Monitor for the inbound thread
-  -> IO (Trailers (Outbound sess))
-sendMessageLoop sess st stream monitorInbound = do
+  -> (Trailers (Outbound sess) -> IO ())
+  -> IO ()
+sendMessageLoop sess st stream markDone = do
     trailers <- loop
     atomically $ STM.putTMVar (flowTerminated st) trailers
-    return trailers
   where
     build :: (Message (Outbound sess) -> Builder)
     build = buildMsg sess (flowHeaders st)
@@ -549,11 +601,11 @@ sendMessageLoop sess st stream monitorInbound = do
             flush stream
             loop
           FinalElem x trailers -> do
-            demonitor monitorInbound
+            markDone trailers
             writeChunkFinal stream $ build x
             return trailers
           NoMoreElems trailers -> do
-            demonitor monitorInbound
+            markDone trailers
             -- Send empty chunk marked \"final\" to let our peer know that we
             -- have sent our last message. Note that this does not /necessarily/
             -- write a DATA frame, since http2 avoids writing empty data frames

--- a/grapesy/src/Network/GRPC/Util/Session/Client.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Client.hs
@@ -180,8 +180,8 @@ setupRequestChannel sess
               FlowStartRegular headers -> do
                 regular <- initFlowStateRegular headers
                 stream  <- clientInputStream resp
-                threadMainBody ctxt regular $
-                  recvMessageLoop sess regular stream
+                threadMainBody ctxt regular $ \markDone ->
+                  markDone =<< recvMessageLoop sess regular stream
               FlowStartNoMessages trailers -> do
                 threadTrivial ctxt trailers
 
@@ -193,10 +193,10 @@ setupRequestChannel sess
       -> IO ()
     outboundThread channel cancelRequestVar regular iface =
         threadBody "grapesy:clientOutbound" (channelOutbound channel) $ \ctxt -> do
-          threadMainBody ctxt regular $ do
+          threadMainBody ctxt regular $ \markDone -> do
             putMVar cancelRequestVar cancelRequest
-            monitor <- threadMonitor ctxt (channelInbound channel) monitorPred
-            stream  <- clientOutputStream iface
+            _monitor <- threadMonitor ctxt (channelInbound channel) monitorPred
+            stream   <- clientOutputStream iface
             -- Unlike the client inbound thread, or the inbound/outbound threads
             -- of the server, http2 knows about this particular thread and may
             -- raise an exception on it when the server dies. This results in a
@@ -209,7 +209,7 @@ setupRequestChannel sess
             -- 'ServerDisconnected' or 'ClientDisconnected'.
             wrapServerDisconnected $
               Client.outBodyUnmask iface $
-                sendMessageLoop sess regular stream monitor
+                sendMessageLoop sess regular stream markDone
       where
         cancelRequest :: CancelRequest
         cancelRequest = Client.outBodyCancel iface . fmap unwrapExactException

--- a/grapesy/src/Network/GRPC/Util/Session/Server.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Server.hs
@@ -118,8 +118,8 @@ setupResponseChannel sess
         FlowStartRegular headers -> do
           regular <- initFlowStateRegular headers
           stream  <- serverInputStream (request conn)
-          threadMainBody ctxt regular $
-            recvMessageLoop sess regular stream
+          threadMainBody ctxt regular $ \markDone ->
+            markDone =<< recvMessageLoop sess regular stream
         FlowStartNoMessages trailers ->
           -- The client sent a request with an empty body
           threadTrivial ctxt trailers
@@ -129,18 +129,18 @@ setupResponseChannel sess
       case outboundStart of
         FlowStartRegular headers -> do
           regular <- initFlowStateRegular headers
-          threadMainBody ctxt regular $ do
+          threadMainBody ctxt regular $ \markDone -> do
             -- Monitoring here is a bit subtle: http2 will spawn an auxiliary
             -- thread, which will be the one that will actually run the
             -- 'sendMessageLoop'. Meanwhile, we will simply be waiting for that
             -- auxiliary thread to terminate; if the monitor fires, is it
             -- /this/ thread that receives it, not the auxiliary http2 thread.
-            monitor <- threadMonitor ctxt (channelInbound channel) monitorPred
+            _monitor <- threadMonitor ctxt (channelInbound channel) monitorPred
             respondStreamingWithResult
                 conn
                 (outboundTrailersMaker sess channel regular)
                 responseInfo $ \stream ->
-              sendMessageLoop sess regular stream monitor
+              sendMessageLoop sess regular stream markDone
         FlowStartNoMessages trailers -> do
           respondNoBody conn responseInfo
           threadTrivial ctxt trailers

--- a/grapesy/src/Network/GRPC/Util/Thread.hs
+++ b/grapesy/src/Network/GRPC/Util/Thread.hs
@@ -139,6 +139,9 @@ data ThreadState a r r' =
     ThreadNotStarted DebugThreadId
 
     -- | The externally visible thread interface is still being initialized
+    --
+    -- This period ends once the thread body calls 'threadMainBody' or
+    -- 'threadTrivial'.
   | ThreadInitializing DebugThreadId ThreadId
 
     -- | Thread is ready
@@ -196,7 +199,11 @@ threadDebugId (ThreadDied         debugId   _) = debugId
 -- ready through 'threadMainBody' or 'threadTrivial' (or it dies).
 data ThreadContext a r r' = ThreadContext{
       -- | Mark thread ready, providing the main thread body
-      threadMainBody :: a -> IO r -> IO ()
+      --
+      -- The thread body is given a callback that it can use to declare itself
+      -- done. Once declared done, any further exceptions that happen in the
+      -- thread will not be recorded in the thread state anymore.
+      threadMainBody :: a -> ((r -> IO ()) -> IO ()) -> IO ()
 
       -- | Terminate the thread immediately
       --
@@ -253,7 +260,8 @@ forkThread label state body =
 -- | Wrap the thread body
 --
 -- This should be wrapped around the body of the thread, and should be called
--- with exceptions masked.
+-- with exceptions masked; the thread body itself should unmask when appropriate
+-- (by using the 'ThreadContext').
 --
 -- This is intended for integration with existing libraries (such as @http2@),
 -- which might do the forking under the hood.
@@ -284,67 +292,100 @@ threadBody label state body = do
         -- actions before it can actually terminate.
         void . forkIO $ throwTo threadId threadException
       _otherwise -> do
-        unexpected "initState" initState
+        unexpected initState
 
-    let threadMainBody :: a -> IO r -> IO ()
-        threadMainBody a mainBody = do
-            atomically $ STM.modifyTVar state $ \oldState ->
-              case oldState of
-                ThreadInitializing debugId _ ->
-                  ThreadRunning debugId threadId a
-                ThreadDied _ _ ->
-                  oldState -- leave alone (see discussion above)
-                _otherwise ->
-                  unexpected "mainBody before" oldState
-            r <- mainBody
-            atomically $ STM.modifyTVar state $ \oldState ->
-              case oldState of
-                ThreadRunning debugId _ _ ->
-                  ThreadDone debugId a r
-                ThreadDied{} ->
-                  oldState
-                _otherwise ->
-                  unexpected "mainBody after" oldState
+    -- 'markRunning' is invoked when the thread body calls 'threadMainBody'
+    let markRunning :: a -> IO ()
+        markRunning a = atomically $ do
+             oldState <- STM.readTVar state
+             case oldState of
+               ThreadInitializing debugId _ -> do
+                 STM.writeTVar state $ ThreadRunning debugId threadId a
+               ThreadDied{} ->
+                 -- leave alone (see discussion above)
+                 return ()
+               _otherwise ->
+                 unexpected oldState
 
-        threadTrivial :: r' -> IO ()
-        threadTrivial r' = do
-            atomically $ STM.modifyTVar state $ \oldState ->
-              case oldState of
-                ThreadInitializing debugId _ ->
-                  ThreadTrivial debugId r'
-                ThreadDied{} ->
-                  oldState
-                _otherwise ->
-                  unexpected "markReady before" oldState
+    -- 'markDone' is invoked /by/ the thread body, to mark itself done
+    let markDone :: r -> IO ()
+        markDone r = atomically $ do
+            oldState <- STM.readTVar state
+            case oldState of
+              ThreadRunning debugId _ a ->
+                STM.writeTVar state $ ThreadDone debugId a r
+              ThreadDied{} ->
+                -- Thread got cancelled before it could mark itself done.
+                return ()
+              _otherwise ->
+                unexpected oldState
 
-        done :: Either ExactException () -> STM ()
-        done mDone = do
-            STM.modifyTVar state $ \oldState ->
-              case (oldState, mDone) of
-                (ThreadDied{}, _) ->
-                  oldState -- record /first/ exception
-                (_, Left e) ->
-                  ThreadDied (threadDebugId oldState) ThreadException{
-                      threadException = e
-                    , threadExceptionAnnotation = ThreadThrewException
-                    }
-                _otherwise ->
-                  oldState
+    -- 'markTrivial' is invoked when the thread body calls 'threadTrivial'
+    let markTrivial :: r' -> IO ()
+        markTrivial r' = atomically $ do
+            oldState <- STM.readTVar state
+            case oldState of
+              ThreadInitializing debugId _ ->
+                STM.writeTVar state $ ThreadTrivial debugId r'
+              ThreadDied{} ->
+                -- Bit of a weird case: trivial thread, but cancelled;
+                -- we record it as cancelled.
+                return ()
+              _otherwise ->
+                unexpected oldState
+
+    -- 'markResult' is invoked on the result of the thread body.
+    let markResult :: Either ExactException () -> IO ()
+        markResult (Right ()) = atomically $ do
+            -- Thread completed normally; thread state is already updated,
+            -- /provided/ the thread body called 'markDone'. If it didn't,
+            -- that's a bug in the thread body.
+            oldState <- STM.readTVar state
+            case oldState of
+              ThreadRunning{} ->
+                unexpected oldState
+              _otherwise ->
+                return ()
+        markResult (Left e) = atomically $ do
+          oldState <- STM.readTVar state
+          case oldState of
+            ThreadDone{} ->
+              -- Thread died /after/ it marked itself done. Such an exception
+              -- is invisible; see 'threadMainBody'.
+              return ()
+            ThreadDied{} ->
+              -- If the state is /already/ 'ThreadDied', that means the thread
+              -- was cancelled. The actual exception that we catch may be the
+              -- same exception, or (depending on when the thread unmasked
+              -- exceptions), it may be a different one. Either way, we keep
+              -- the exception passed to 'cancelThread' as the reason.
+              return ()
+            ThreadTrivial{} ->
+              -- Cannot happen; trivial threads don't run anything
+              unexpected oldState
+            ThreadNotStarted{} ->
+              -- Can't happen
+              unexpected oldState
+            ThreadInitializing debugId _ ->
+              -- Thread died before it could decide between 'threadMainBody' or
+              -- 'threadTrivial'
+              STM.writeTVar state $
+                ThreadDied debugId (ThreadException e ThreadThrewException)
+            ThreadRunning debugId _ _ ->
+              -- Thread died before it could declare itself done
+              STM.writeTVar state $
+                ThreadDied debugId (ThreadException e ThreadThrewException)
 
     res <- tryExact $ body ThreadContext{
-          threadMainBody
-        , threadTrivial
+          threadMainBody = \a k -> markRunning a >> k markDone
+        , threadTrivial  = markTrivial
         , threadMonitor_ = monitorJust state
         , threadId       = threadDebugId initState
         }
-    atomically $ done res
+    markResult res
   where
-    unexpected :: HasCallStack => String -> ThreadState a r r' -> x
-    unexpected msg st = error $ concat [
-          msg
-        , ": unexpected "
-        , show (showableState st)
-        ]
+    unexpected :: HasCallStack => ThreadState a r r' -> x
+    unexpected st = error $ "unexpected " <> show (showableState st)
 
 {-------------------------------------------------------------------------------
   Stopping
@@ -433,7 +474,7 @@ data ThreadIface a r' =
 
 -- | Get the thread's interface
 --
--- The behaviour of this 'getThreadInterface' depends on the thread state; it
+-- The behaviour of 'withThreadInterface' depends on the thread state; it
 --
 -- * blocks if the thread in case of 'ThreadNotStarted' or 'ThreadInitializing'
 -- * throws 'ThreadInterfaceUnavailable' in case of 'ThreadException'.

--- a/grapesy/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
+++ b/grapesy/test-grapesy/Test/Sanity/StreamingType/NonStreaming.hs
@@ -126,6 +126,8 @@ tests = testGroup "Test.Sanity.StreamingType.NonStreaming" [
                     test_increment def {
                         isExpectedClientException =
                            isClientUnsupportedCompression
+                      , isExpectedServerException =
+                           isClientDisconnected
                       , clientCompr =
                           Compr.none
                       , serverCompr =


### PR DESCRIPTION
In 345d7a5ef98273469c5ab1d79f38e7777d00c6c0 (#345) we fixed an important race condition in `sendMessageLoop`. At the time I was _sure_ that this would fix the problems we were seeing with CI failing, but it didn't, which was a bit of a soul-crushing moment. However, it turns out, I was _right_; it's just that the race condition can happen in two ways: when a client disconnects, we might learn about this fact in one of two ways (at least, server-side): our inbound thread (`recvMessageLoop`) might notice first, or we might receive a `KilledByThreadManager` from `http2` first. The fix addressed the former, but not the latter. In this PR we generalize the solution. 