### PR TITLE
Fix `recvNextOutputElem`

### DIFF
--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -513,9 +513,15 @@ recvOutput call@Call{} = liftIO $ do
 recvNextOutputElem ::
      (MonadIO m, HasCallStack)
   => Call rpc -> m (NextElem (Output rpc))
-recvNextOutputElem =
-      fmap (either (const NoNextElem) (NextElem . snd))
-    . recvEither
+recvNextOutputElem call = do
+    mOut <- recvEither call
+    case mOut of
+      Left trailers -> do
+        -- Rethrow any exceptions that the server handler might have thrown
+        _trailingMetadata <- responseTrailingMetadata call trailers
+        return NoNextElem
+      Right (_env, out) ->
+        return $ NextElem out
 
 -- | Generalization of 'recvOutput', providing additional meta-information
 --
@@ -755,7 +761,6 @@ responseTrailingMetadata Call{} trailers = liftIO $
         parseMetadata $ grpcTerminatedMetadata terminatedNormally
       Left exception ->
         throwM exception
-
 
 -- | Forget that we are in the Trailers-Only case
 --


### PR DESCRIPTION
Even if we're not interested in the trailing metadata, we should still check that that metadata does not indicate a server exception.