### PR TITLE
Improve how we deal with trailers

### DIFF
--- a/grapesy/grapesy.cabal
+++ b/grapesy/grapesy.cabal
@@ -263,6 +263,7 @@ test-suite test-grapesy
       Test.Sanity.Compression
       Test.Sanity.EndOfStream
       Test.Sanity.Interop
+      Test.Sanity.Metadata
       Test.Sanity.NoIsLabel
       Test.Sanity.Reclamation
       Test.Sanity.StreamingType.CustomFormat
@@ -290,10 +291,12 @@ test-suite test-grapesy
   build-depends:
       -- Inherited dependencies
     , async
+    , binary
     , bytestring
     , containers
     , deepseq
     , exceptions
+    , grpc-spec
     , http-types
     , http2
     , mtl

--- a/grapesy/src/Network/GRPC/Client/Call.hs
+++ b/grapesy/src/Network/GRPC/Client/Call.hs
@@ -595,8 +595,8 @@ recvInitialResponse :: forall rpc m.
      MonadIO m
   => Call rpc
   -> m ( Either (TrailersOnly'    HandledSynthesized)
-                 (ResponseHeaders' HandledSynthesized)
-        )
+                (ResponseHeaders' HandledSynthesized)
+       )
 recvInitialResponse Call{callChannel} = liftIO $
     fmap inbHeaders <$> Session.getInboundHeaders callChannel
 

--- a/grapesy/src/Network/GRPC/Common.hs
+++ b/grapesy/src/Network/GRPC/Common.hs
@@ -26,6 +26,7 @@ module Network.GRPC.Common (
   , customMetadataName
   , customMetadataValue
   , HeaderName(BinaryHeader, AsciiHeader)
+  , getHeaderName
   , NoMetadata(..)
     -- ** Typed
   , RequestMetadata

--- a/grapesy/src/Network/GRPC/Server.hs
+++ b/grapesy/src/Network/GRPC/Server.hs
@@ -25,6 +25,7 @@ module Network.GRPC.Server (
   , sendGrpcException
   , getRequestMetadata
   , setResponseInitialMetadata
+  , setResponseInitialMetadataAndTrailers
 
     -- ** Protocol specific wrappers
   , sendNextOutput

--- a/grapesy/src/Network/GRPC/Server/Call.hs
+++ b/grapesy/src/Network/GRPC/Server/Call.hs
@@ -15,6 +15,7 @@ module Network.GRPC.Server.Call (
   , sendGrpcException
   , getRequestMetadata
   , setResponseInitialMetadata
+  , setResponseInitialMetadataAndTrailers
 
     -- ** Protocol specific wrappers
   , sendNextOutput
@@ -85,7 +86,7 @@ data Call rpc = SupportsServerRpc rpc => Call {
       --
       -- Can be updated until the first message (see 'callFirstMessage'), at
       -- which point it /must/ have been set (if not, an exception is thrown).
-    , callResponseMetadata :: TVar (CallInitialMetadata rpc)
+    , callResponseMetadata :: TVar (Maybe (CallInitialMetadata rpc))
 
       -- | What kicked off the response?
       --
@@ -96,14 +97,16 @@ data Call rpc = SupportsServerRpc rpc => Call {
 -- | Initial metadata
 --
 -- See 'callResponseMetadata' for discussion.
-data CallInitialMetadata rpc =
-    -- | Initial metadata not yet set
-    CallInitialMetadataNotSet
+data CallInitialMetadata rpc = CallInitialMetadata{
+      -- | Initial response metadata
+      callInitialResponseMetadata :: ResponseInitialMetadata rpc
 
-    -- | Initial metadata has been set
-    --
-    -- We record the backtrace of where the metadata was set.
-  | CallInitialMetadataSet (ResponseInitialMetadata rpc) Backtraces
+      -- | The set of trailers that the client can expect
+    , callInitialExpectedTrailers :: Maybe [HeaderName]
+
+      -- | Backtrace of where the metadata was set.
+    , callInitialMetadataBacktrace :: Backtraces
+    }
 
 deriving stock instance IsRPC rpc => Show (CallInitialMetadata rpc)
 
@@ -147,7 +150,7 @@ setupCall :: forall rpc.
   -> ServerContext
   -> IO (Call rpc, Maybe Timeout)
 setupCall conn callContext@ServerContext{serverParams} = do
-    callResponseMetadata <- STM.newTVarIO CallInitialMetadataNotSet
+    callResponseMetadata <- STM.newTVarIO Nothing
     callResponseKickoff  <- STM.newEmptyTMVarIO
 
     (inboundHeaders, timeout) <- determineInbound callSession req
@@ -227,7 +230,7 @@ determineInbound session req = do
 startOutbound :: forall rpc.
      SupportsServerRpc rpc
   => ServerParams
-  -> TVar (CallInitialMetadata rpc)
+  -> TVar (Maybe (CallInitialMetadata rpc))
   -> TMVar Kickoff
   -> Compression
   -> IO (Session.FlowStart (ServerOutbound rpc), Session.ResponseInfo)
@@ -236,65 +239,73 @@ startOutbound serverParams metadataVar kickoffVar cOut = do
     kickoff <- atomically $ STM.readTMVar kickoffVar
 
     -- Session start
-    flowStart :: Session.FlowStart (ServerOutbound rpc) <-
-      case kickoff of
-        KickoffRegular _backtrace -> do
-          -- Get response metadata (see 'setResponseMetadata')
-          --
-          -- It is important we do this only for 'KickoffRegular', because the
-          -- initial metadata is not used in the Trailers-Only case, and we
-          -- should not unecessarily throw the 'ResponseInitialMetadataNotSet'
-          -- exception. This is especially important when that Trailers-Only
-          -- case was triggered by an exception in the handler, because the
-          -- handler might not yet have had the opportunity to set the initial
-          -- metdata prior to the error.
-          responseMetadata <- do
-            mMetadata <- atomically $ STM.readTVar metadataVar
-            case mMetadata of
-              CallInitialMetadataSet md _backtrace ->
-                buildMetadataIO md
-              CallInitialMetadataNotSet ->
-                throwIO ResponseInitialMetadataNotSet
+    case kickoff of
+      KickoffRegular _backtrace -> do
+        -- Get response metadata (see 'setResponseInitialMetadata')
+        --
+        -- It is important we do this only for 'KickoffRegular', because the
+        -- initial metadata is not used in the Trailers-Only case, and we
+        -- should not unecessarily throw the 'ResponseInitialMetadataNotSet'
+        -- exception. This is especially important when that Trailers-Only
+        -- case was triggered by an exception in the handler, because the
+        -- handler might not yet have had the opportunity to set the initial
+        -- metdata prior to the error.
+        (responseMetadata, trailers) <- do
+          mMetadata <- atomically $ STM.readTVar metadataVar
+          case mMetadata of
+            Just md ->
+              (, callInitialExpectedTrailers md) <$>
+                buildMetadataIO (callInitialResponseMetadata md)
+            Nothing ->
+              throwIO ResponseInitialMetadataNotSet
 
-          return $ Session.FlowStartRegular $ OutboundHeaders {
-              outHeaders = ResponseHeaders {
-                  responseCompression =
-                    Just $ Compr.compressionId cOut
-                , responseAcceptCompression =
-                    Just $ Compr.offer compr
-                , responseContentType =
-                    serverContentType serverParams
-                , responseMetadata =
-                    customMetadataMapFromList responseMetadata
-                , responseUnrecognized =
-                    ()
-                }
-            , outCompression = cOut
-            }
-        KickoffTrailersOnly _backtrace trailers ->
-          return $ Session.FlowStartNoMessages trailers
-
-    return (flowStart, buildResponseInfo flowStart)
+        let headers :: Headers (ServerOutbound rpc)
+            headers = OutboundHeaders {
+                outHeaders = ResponseHeaders {
+                    responseCompression =
+                      Just $ Compr.compressionId cOut
+                  , responseAcceptCompression =
+                      Just $ Compr.offer compr
+                  , responseContentType =
+                      serverContentType serverParams
+                  , responseTrailerNames =
+                      allPotentialTrailers <$> trailers
+                  , responseMetadata =
+                      customMetadataMapFromList responseMetadata
+                  , responseUnrecognized =
+                      ()
+                  }
+              , outCompression = cOut
+              }
+        return (
+            Session.FlowStartRegular headers
+          , responseInfoRegular headers
+          )
+      KickoffTrailersOnly _backtrace trailers ->
+        return (
+            Session.FlowStartNoMessages trailers
+          , responseInfoTrailersOnly trailers
+          )
   where
     compr :: Compr.Negotation
     compr = serverCompression serverParams
 
-    buildResponseInfo ::
-         Session.FlowStart (ServerOutbound rpc)
-      -> Session.ResponseInfo
-    buildResponseInfo start = Session.ResponseInfo {
+    responseInfoRegular :: Headers (ServerOutbound rpc) -> Session.ResponseInfo
+    responseInfoRegular headers = Session.ResponseInfo {
           responseStatus  = HTTP.ok200
-        , responseHeaders =
-            case start of
-              Session.FlowStartRegular headers ->
-                buildResponseHeaders
-                  (Proxy @rpc)
-                  (outHeaders headers)
-              Session.FlowStartNoMessages trailers ->
-                buildTrailersOnly
-                  (Just . chooseContentType (Proxy @rpc))
-                  trailers
-        , responseBody = Nothing
+        , responseHeaders = buildResponseHeaders
+                              (Proxy @rpc)
+                              (outHeaders headers)
+        , responseBody    = Nothing
+        }
+
+    responseInfoTrailersOnly :: TrailersOnly -> Session.ResponseInfo
+    responseInfoTrailersOnly trailers = Session.ResponseInfo {
+          responseStatus  = HTTP.ok200
+        , responseHeaders = buildTrailersOnly
+                              (Just . chooseContentType (Proxy @rpc))
+                              trailers
+        , responseBody    = Nothing
         }
 
 -- | Determine compression used by the peer for messages to us
@@ -513,26 +524,72 @@ getRequestMetadata Call{callRequestHeaders} =
 --
 -- Note that this is about the /initial/ metadata; additional metadata can be
 -- sent after the final message; see 'sendOutput'.
-setResponseInitialMetadata ::
+setResponseInitialMetadata :: forall rpc.
+     ( StaticMetadata (ResponseTrailingMetadata rpc)
+     , HasCallStack
+     )
+  => Call rpc
+  -> ResponseInitialMetadata rpc
+  -> IO ()
+setResponseInitialMetadata call md =
+    setResponseInitialMetadataAndTrailers call md $
+      Just $ metadataHeaderNames (Proxy @(ResponseTrailingMetadata rpc))
+
+-- | Generalization of 'setResponseInitialMetadata'
+--
+-- Trailers are HTTP headers that come /after/ the response body; a typical
+-- example is a trailer containing a checksum of the body. Clients must be told
+-- /ahead of time/ which trailers to expect (that is, their names). For most
+-- RPCs this set of trailers is static, determined only by the endpoint (indeed,
+-- the vast majority of gRPC endpoints don't use custom trailers at all, using
+-- only the standard gRPC trailers @grpc-status@, @grpc-message@, and
+-- @grpc-status-details-bin@); this is why 'setResponseInitialMetadata' needs
+--
+-- > StaticMetadata (ResponseTrailingMetadata rpc)
+--
+-- Occassionally however the set of trailers can vary from request to request,
+-- even for the same RPC; 'setResponseInitialMetadataAndTrailers' can be used to
+-- declare which trailers the client can expect in such a case. Note that this
+-- does not mean that those trailers /must/ be present, only that they /can/ be;
+-- to quote RFC9110:
+--
+-- > The "Trailer" header field (Section 6.6.2) can be sent to indicate fields
+-- > likely to be sent in the trailer section, which allows recipients to
+-- > prepare for their receipt before processing the content.
+setResponseInitialMetadataAndTrailers ::
      HasCallStack
-  => Call rpc -> ResponseInitialMetadata rpc -> IO ()
-setResponseInitialMetadata Call{ callResponseMetadata
-                               , callResponseKickoff
-                               }
-                           md = do
+  => Call rpc
+  -> ResponseInitialMetadata rpc
+  -> Maybe [HeaderName]
+     -- ^ Trailers
+     --
+     -- If 'Just', the standard gRPC trailers will be added automatically.
+     --
+     -- Use 'Nothing' if you do not want to announce the trailers ahead of time;
+     -- this is permitted by the HTTP2 spec, but it is not recommended: it can
+     -- result in trailers being dropped, for example by some proxies.
+  -> IO ()
+setResponseInitialMetadataAndTrailers call md trailers = do
     newBacktrace <- collectBacktraces
     atomically $ do
       mKickoff  <- fmap kickoffBacktrace <$> STM.tryReadTMVar callResponseKickoff
       case mKickoff of
         Nothing ->
-          STM.writeTVar callResponseMetadata $
-            CallInitialMetadataSet md newBacktrace
+          STM.writeTVar callResponseMetadata $ Just CallInitialMetadata{
+              callInitialResponseMetadata  = md
+            , callInitialExpectedTrailers  = trailers
+            , callInitialMetadataBacktrace = newBacktrace
+            }
         Just oldBacktrace ->
           STM.throwSTM $ ResponseAlreadyInitiated {
               responseInitiatedFirst = oldBacktrace
             , responseInitiatedAgain = newBacktrace
             }
-
+  where
+    Call{
+        callResponseMetadata
+      , callResponseKickoff
+      } = call
 {-------------------------------------------------------------------------------
   Low-level API
 -------------------------------------------------------------------------------}
@@ -540,7 +597,7 @@ setResponseInitialMetadata Call{ callResponseMetadata
 -- | Initiate the response
 --
 -- This will cause the initial response metadata to be sent
--- (see also 'setResponseMetadata').
+-- (see also 'setResponseInitialMetadata').
 --
 -- Does nothing if the response was already initated (that is, the response
 -- headers, or trailers in the case of 'sendTrailersOnly', have already been

--- a/grapesy/src/Network/GRPC/Server/Handler.hs
+++ b/grapesy/src/Network/GRPC/Server/Handler.hs
@@ -101,7 +101,8 @@ hoistRpcHandler f (RpcHandler h) = RpcHandler (f . h)
 -- response metadata needs the request metadata from the client, or even some
 -- messages from the client), you can use 'mkRpcHandlerNoDefMetadata'.
 mkRpcHandler ::
-     ( Default (ResponseInitialMetadata rpc)
+     ( Default        (ResponseInitialMetadata  rpc)
+     , StaticMetadata (ResponseTrailingMetadata rpc)
      , MonadIO m
      )
   => (HasCallStack => Call rpc -> m ())

--- a/grapesy/src/Network/GRPC/Server/StreamType.hs
+++ b/grapesy/src/Network/GRPC/Server/StreamType.hs
@@ -113,6 +113,7 @@ class FromStreamingHandler (styp :: StreamingType) where
   -- specification of the server's API, you can use 'fromStreamingHandler'.
   fromStreamingHandler :: forall k (rpc :: k) m.
         ( SupportsServerRpc rpc
+        , StaticMetadata (ResponseTrailingMetadata rpc)
         , Default (ResponseInitialMetadata rpc)
         , Default (ResponseTrailingMetadata rpc)
         , MonadIO m
@@ -232,6 +233,7 @@ data Methods (m :: Type -> Type) (rpcs :: [k]) where
   -- the example above).
   Method ::
        ( SupportsServerRpc rpc
+       , StaticMetadata (ResponseTrailingMetadata rpc)
        , Default (ResponseInitialMetadata rpc)
        , Default (ResponseTrailingMetadata rpc)
        , SupportsStreamingType rpc styp
@@ -295,9 +297,10 @@ data Services m (servs :: [[k]]) where
 -- > Server.fromMethod @Ping $ Server.mkNonStreaming $ ..
 fromMethod :: forall rpc styp m.
      ( SupportsServerRpc rpc
-     , ValidStreamingType styp
+     , StaticMetadata (ResponseTrailingMetadata rpc)
      , Default (ResponseInitialMetadata rpc)
      , Default (ResponseTrailingMetadata rpc)
+     , ValidStreamingType styp
      , MonadIO m
      )
   => ServerHandler' styp m rpc -> SomeRpcHandler m
@@ -385,6 +388,7 @@ instance SimpleMethods m '[] rpcs (Methods m rpcs) where
 instance
     ( -- Requirements inherited from the 'Method' constructor
       SupportsServerRpc rpc
+    , StaticMetadata (ResponseTrailingMetadata rpc)
     , Default (ResponseInitialMetadata rpc)
     , Default (ResponseTrailingMetadata rpc)
     , SupportsStreamingType rpc (RpcStreamingType rpc)

--- a/grapesy/src/Network/GRPC/Util/Session/Channel.hs
+++ b/grapesy/src/Network/GRPC/Util/Session/Channel.hs
@@ -139,7 +139,7 @@ data RegularFlowState flow = RegularFlowState {
       --
       -- On the server side, the inbound headers are recorded when the request
       -- comes in, and the outbound headers are specified
-      -- ('setResponseMetadata') before the response is initiated
+      -- ('setResponseInitialMetadata') before the response is initiated
       -- ('initiateResponse'/'sendTrailersOnly').
       flowHeaders :: Headers flow
 

--- a/grapesy/test-disconnect/Test/Disconnect/Util/Server.hs
+++ b/grapesy/test-disconnect/Test/Disconnect/Util/Server.hs
@@ -32,6 +32,7 @@ data HandlerResults = HandlerResults{
 -- | Construct 'TVar' that records the result of each handler invocation
 monitoredHandler :: forall rpc.
      ( SupportsServerRpc rpc
+     , StaticMetadata (ResponseTrailingMetadata rpc)
      , Default (ResponseInitialMetadata rpc)
      )
   => (Server.Call rpc -> IO ())

--- a/grapesy/test-grapesy/Main.hs
+++ b/grapesy/test-grapesy/Main.hs
@@ -14,6 +14,7 @@ import Test.Sanity.BrokenDeployments          qualified as BrokenDeployments
 import Test.Sanity.Compression                qualified as Compression
 import Test.Sanity.EndOfStream                qualified as EndOfStream
 import Test.Sanity.Interop                    qualified as Interop
+import Test.Sanity.Metadata                   qualified as Metadata
 import Test.Sanity.NoIsLabel                  qualified as NoIsLabel
 import Test.Sanity.Reclamation                qualified as Reclamation
 import Test.Sanity.StreamingType.CustomFormat qualified as StreamingType.CustomFormat
@@ -36,6 +37,7 @@ main = do
           , Reclamation.tests
           , BrokenDeployments.tests
           , NoIsLabel.tests
+          , Metadata.tests
           ]
       , testGroup "Regression" [
             Issue102.tests

--- a/grapesy/test-grapesy/Test/Sanity/Metadata.hs
+++ b/grapesy/test-grapesy/Test/Sanity/Metadata.hs
@@ -1,0 +1,121 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Test.Sanity.Metadata (tests) where
+
+import Control.Monad
+import Data.Binary (Binary)
+import Data.ByteString qualified as BSS
+import Data.ByteString qualified as Strict (ByteString)
+import Data.String
+import GHC.Generics (Generic)
+import Test.Driver.ClientServer
+import Test.Tasty
+import Test.Tasty.HUnit
+import Text.Printf
+
+import Network.GRPC.Client qualified as Client
+import Network.GRPC.Client.Binary qualified as Client.Binary
+import Network.GRPC.Common
+import Network.GRPC.Common.Binary
+import Network.GRPC.Server qualified as Server
+import Network.GRPC.Server.Binary qualified as Server.Binary
+import Network.GRPC.Spec.Serialization qualified as Spec
+
+tests :: TestTree
+tests = testGroup "Test.Sanity.Metadata" [
+      testCase "summarizeAndEcho" $ test_summarizeAndEcho 10
+    ]
+
+{-------------------------------------------------------------------------------
+  Trailers
+-------------------------------------------------------------------------------}
+
+-- | Sanity check: test that the server can receive client metadata and can
+-- echo it as trailing metadata. We also verify that the server can /announce/
+-- that trailing metadata before it sends it.
+test_summarizeAndEcho :: Int -> Assertion
+test_summarizeAndEcho n = testClientServer $ ClientServerTest {
+      config = def{serverPort = Right 50051}
+    , server = [Server.someRpcHandler execInstr]
+    , client = simpleTestClient $ \conn -> do
+          Client.withRPC conn callParams (Proxy @ExecInstr) $ \call -> do
+            Client.Binary.sendFinalInput call SummarizeAndEcho
+
+            -- Check that trailers announced
+            initResponse <- Client.recvInitialResponse call
+            case initResponse of
+              Left trailersOnly ->
+                assertFailure $ "Unexpected trailers-only " ++ show trailersOnly
+              Right x ->
+                case Client.responseTrailerNames x of
+                  Left err ->
+                    assertFailure $ show err
+                  Right Nothing ->
+                    assertFailure "Trailer not present"
+                  Right (Just names) ->
+                    forM_ metadata $ \md ->
+                      assertBool ("Missing " ++ show md) $ flip elem names $
+                        Spec.buildHeaderName (customMetadataName md)
+
+            -- Check summary and trailing metadata
+            (summary, trailers) <- Client.Binary.recvFinalOutput call
+            assertEqual "" (summarize metadata) $ summary
+            assertEqual "" metadata             $ trailers
+
+    }
+  where
+    metadata :: [CustomMetadata]
+    metadata = [
+          CustomMetadata
+            (fromString $ "md-" ++ printf "%02d" i) -- for sorting purposes
+            (fromString $ show i)
+        | i <- [1 .. n]
+        ]
+
+    callParams :: Client.CallParams ExecInstr
+    callParams = def{Client.callRequestMetadata = metadata}
+
+{-------------------------------------------------------------------------------
+  Server handler
+-------------------------------------------------------------------------------}
+
+type ExecInstr = RawRpc "TestMetadata" "ExecInstr"
+
+type instance RequestMetadata          ExecInstr = [CustomMetadata]
+type instance ResponseInitialMetadata  ExecInstr = [CustomMetadata]
+type instance ResponseTrailingMetadata ExecInstr = [CustomMetadata]
+
+data Instruction =
+    -- | Summary the request metadata, and echo it as trailing metadata
+    SummarizeAndEcho
+  deriving stock (Generic)
+  deriving anyclass (Binary)
+
+execInstr :: Server.RpcHandler IO ExecInstr
+execInstr = Server.mkRpcHandlerNoDefMetadata $ \call -> do
+    requestMetadata <- Server.getRequestMetadata call
+    instr <- Server.Binary.recvFinalInput call
+    case instr of
+      SummarizeAndEcho -> do
+        -- We need to explicitly set the trailers, because they vary from one
+        -- request to the next (that is, they aren't static)
+        Server.setResponseInitialMetadataAndTrailers call [] . Just $
+          map customMetadataName requestMetadata
+        Server.Binary.sendFinalOutput @Summary call (
+            summarize requestMetadata
+          , requestMetadata
+          )
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
+
+type Summary = [(Strict.ByteString, Int)]
+
+summarize :: [CustomMetadata] -> Summary
+summarize = map aux
+  where
+    aux :: CustomMetadata -> (Strict.ByteString, Int)
+    aux md = (
+          getHeaderName $ customMetadataName  md
+        , BSS.length    $ customMetadataValue md
+        )

--- a/grpc-spec/src/Network/GRPC/Spec.hs
+++ b/grpc-spec/src/Network/GRPC/Spec.hs
@@ -119,6 +119,7 @@ module Network.GRPC.Spec (
   , customMetadataValue
   , safeCustomMetadata
   , HeaderName(BinaryHeader, AsciiHeader)
+  , getHeaderName
   , safeHeaderName
   , isValidAsciiValue
   , NoMetadata(..)

--- a/grpc-spec/src/Network/GRPC/Spec/CustomMetadata/Raw.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/CustomMetadata/Raw.hs
@@ -12,6 +12,7 @@ module Network.GRPC.Spec.CustomMetadata.Raw (
   , customMetadataValue
   , safeCustomMetadata
   , HeaderName(BinaryHeader, AsciiHeader)
+  , getHeaderName
   , safeHeaderName
   , isValidAsciiValue
   ) where
@@ -152,7 +153,8 @@ data HeaderName =
     -- suffix to detect binary headers and properly apply base64 encoding &
     -- decoding as headers are sent and received).
     --
-    -- Since this is binary data, padding considerations do not apply.
+    -- Since this kind of header contains binary data, padding considerations do
+    -- not apply.
     UnsafeBinaryHeader Strict.ByteString
 
     -- | ASCII header
@@ -167,6 +169,12 @@ data HeaderName =
   | UnsafeAsciiHeader Strict.ByteString
   deriving stock (Eq, Ord, Generic)
   deriving anyclass (NFData)
+
+-- | The flattened header name (including any @-bin@ suffix)
+getHeaderName :: HeaderName -> Strict.ByteString
+getHeaderName = \case
+    UnsafeBinaryHeader name -> name
+    UnsafeAsciiHeader  name -> name
 
 pattern BinaryHeader :: HasCallStack => Strict.ByteString -> HeaderName
 pattern BinaryHeader name <- UnsafeBinaryHeader name

--- a/grpc-spec/src/Network/GRPC/Spec/CustomMetadata/Typed.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/CustomMetadata/Typed.hs
@@ -84,6 +84,9 @@ deriving stock instance
 class BuildMetadata a where
   buildMetadata :: a -> [CustomMetadata]
 
+instance BuildMetadata [CustomMetadata] where
+  buildMetadata = id
+
 -- | Wrapper around 'buildMetadata' that catches any pure exceptions
 --
 -- These pure exceptions can arise when invalid headers are generated (for
@@ -122,6 +125,9 @@ class BuildMetadata a => StaticMetadata a where
 --   throwing an error runs the risk of unnecessarily aborting an RPC.
 class ParseMetadata a where
   parseMetadata :: MonadThrow m => [CustomMetadata] -> m a
+
+instance ParseMetadata [CustomMetadata] where
+  parseMetadata = pure
 
 -- | Unexpected metadata
 --

--- a/grpc-spec/src/Network/GRPC/Spec/Headers/Response.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/Headers/Response.hs
@@ -33,6 +33,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Proxy
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import Network.HTTP.Types qualified as HTTP
 
 import Network.GRPC.Spec.Compression (CompressionId)
 import Network.GRPC.Spec.CustomMetadata.Map
@@ -60,6 +61,14 @@ data ResponseHeaders_ f = ResponseHeaders {
       --
       -- Set to 'Nothing' to omit the content-type header altogether.
     , responseContentType :: HKD f (Maybe ContentType)
+
+      -- | Response trailers
+      --
+      -- The initial response headers should announce which trailers can be
+      -- expected after the response body.
+      --
+      -- See <https://datatracker.ietf.org/doc/html/rfc9110#name-trailer>
+    , responseTrailerNames :: HKD f (Maybe [HTTP.HeaderName])
 
       -- | Initial response metadata
       --
@@ -96,6 +105,7 @@ instance HKD.Traversable ResponseHeaders_ where
         <$> (f    $ responseCompression       x)
         <*> (f    $ responseAcceptCompression x)
         <*> (f    $ responseContentType       x)
+        <*> (f    $ responseTrailerNames      x)
         <*> (pure $ responseMetadata          x)
         <*> (f    $ responseUnrecognized      x)
 

--- a/grpc-spec/src/Network/GRPC/Spec/RPC.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/RPC.hs
@@ -132,9 +132,9 @@ class ( IsRPC rpc
 class ( IsRPC rpc
 
         -- Serialization
-      , ParseMetadata (RequestMetadata rpc)
-      , BuildMetadata (ResponseInitialMetadata rpc)
-      , StaticMetadata (ResponseTrailingMetadata rpc)
+      , ParseMetadata (RequestMetadata          rpc)
+      , BuildMetadata (ResponseInitialMetadata  rpc)
+      , BuildMetadata (ResponseTrailingMetadata rpc)
       ) => SupportsServerRpc rpc where
 
   -- | Deserialize RPC input

--- a/grpc-spec/src/Network/GRPC/Spec/RPC/JSON.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/RPC/JSON.hs
@@ -99,9 +99,9 @@ instance ( IsRPC (JsonRpc serv meth)
          , ToJSON   (Output (JsonRpc serv meth))
 
            -- Metadata constraints
-         , ParseMetadata (RequestMetadata           (JsonRpc serv meth))
-         , BuildMetadata (ResponseInitialMetadata   (JsonRpc serv meth))
-         , StaticMetadata (ResponseTrailingMetadata (JsonRpc serv meth))
+         , ParseMetadata (RequestMetadata          (JsonRpc serv meth))
+         , BuildMetadata (ResponseInitialMetadata  (JsonRpc serv meth))
+         , BuildMetadata (ResponseTrailingMetadata (JsonRpc serv meth))
          ) => SupportsServerRpc (JsonRpc serv meth) where
   rpcDeserializeInput _ = Aeson.eitherDecode
   rpcSerializeOutput  _ = Aeson.encode

--- a/grpc-spec/src/Network/GRPC/Spec/RPC/Protobuf.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/RPC/Protobuf.hs
@@ -92,9 +92,9 @@ instance ( IsRPC (Protobuf serv meth)
          , HasMethodImpl serv meth
 
            -- Metadata constraints
-         , ParseMetadata (RequestMetadata (Protobuf serv meth))
-         , BuildMetadata (ResponseInitialMetadata (Protobuf serv meth))
-         , StaticMetadata (ResponseTrailingMetadata (Protobuf serv meth))
+         , ParseMetadata (RequestMetadata          (Protobuf serv meth))
+         , BuildMetadata (ResponseInitialMetadata  (Protobuf serv meth))
+         , BuildMetadata (ResponseTrailingMetadata (Protobuf serv meth))
          ) => SupportsServerRpc (Protobuf serv meth) where
   rpcDeserializeInput _ = Protobuf.parseLazy
   rpcSerializeOutput  _ = Protobuf.buildLazy

--- a/grpc-spec/src/Network/GRPC/Spec/RPC/Raw.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/RPC/Raw.hs
@@ -52,9 +52,9 @@ instance ( IsRPC (RawRpc serv meth)
 instance ( IsRPC (RawRpc serv meth)
 
            -- Metadata constraints
-         , ParseMetadata (RequestMetadata (RawRpc serv meth))
-         , BuildMetadata (ResponseInitialMetadata (RawRpc serv meth))
-         , StaticMetadata (ResponseTrailingMetadata (RawRpc serv meth))
+         , ParseMetadata (RequestMetadata          (RawRpc serv meth))
+         , BuildMetadata (ResponseInitialMetadata  (RawRpc serv meth))
+         , BuildMetadata (ResponseTrailingMetadata (RawRpc serv meth))
          ) => SupportsServerRpc (RawRpc serv meth) where
   rpcDeserializeInput _ = return
   rpcSerializeOutput  _ = id

--- a/grpc-spec/src/Network/GRPC/Spec/Serialization.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/Serialization.hs
@@ -33,6 +33,10 @@ module Network.GRPC.Spec.Serialization (
   , buildResponseHeaders
   , parseResponseHeaders
   , parseResponseHeaders'
+    -- * HTTP @Trailer@ header
+  , buildTrailer
+  , parseTrailer
+  , allPotentialTrailers
     -- *** Pushback
   , buildPushback
   , parsePushback
@@ -49,6 +53,9 @@ module Network.GRPC.Spec.Serialization (
     -- ** Custom metadata
   , parseCustomMetadata
   , buildCustomMetadata
+    -- *** Header names
+  , buildHeaderName
+  , parseHeaderName
     -- *** Binary values
   , buildBinaryValue
   , parseBinaryValue

--- a/grpc-spec/src/Network/GRPC/Spec/Serialization/Headers/Response.hs
+++ b/grpc-spec/src/Network/GRPC/Spec/Serialization/Headers/Response.hs
@@ -9,6 +9,10 @@ module Network.GRPC.Spec.Serialization.Headers.Response (
     buildResponseHeaders
   , parseResponseHeaders
   , parseResponseHeaders'
+    -- * HTTP @Trailer@ header
+  , buildTrailer
+  , parseTrailer
+  , allPotentialTrailers
     -- * ProperTrailers
   , buildProperTrailers
   , parseProperTrailers
@@ -193,12 +197,7 @@ hasGrpcStatus = isJust . lookup "grpc-status"
 buildResponseHeaders :: forall rpc.
      SupportsServerRpc rpc
   => Proxy rpc -> ResponseHeaders -> [HTTP.Header]
-buildResponseHeaders proxy
-             ResponseHeaders{ responseCompression
-                            , responseAcceptCompression
-                            , responseMetadata
-                            , responseContentType
-                            } = concat [
+buildResponseHeaders proxy headers = concat [
       [ buildContentType $ Just (chooseContentType proxy x)
       | Just x <- [responseContentType]
       ]
@@ -208,11 +207,21 @@ buildResponseHeaders proxy
     , [ buildMessageAcceptEncoding x
       | Just x <- [responseAcceptCompression]
       ]
-    , [ buildTrailer proxy ]
+    , [ buildTrailer x
+      | Just x <- [responseTrailerNames]
+      ]
     , [ buildCustomMetadata x
       | x <- customMetadataMapToList responseMetadata
       ]
     ]
+  where
+    ResponseHeaders{
+        responseCompression
+      , responseAcceptCompression
+      , responseTrailerNames
+      , responseMetadata
+      , responseContentType
+      } = headers
 
 -- | Parse response headers
 parseResponseHeaders :: forall rpc m.
@@ -251,7 +260,9 @@ parseResponseHeaders' proxy =
           }
 
       | name == "trailer"
-      = return () -- ignore the HTTP trailer header
+      = modify $ \x -> x {
+            responseTrailerNames = pure $ Just $ parseTrailer hdr
+          }
 
       | otherwise
       = modify $ \x ->
@@ -271,6 +282,7 @@ parseResponseHeaders' proxy =
     uninitResponseHeaders = ResponseHeaders {
           responseCompression       = return Nothing
         , responseAcceptCompression = return Nothing
+        , responseTrailerNames      = return Nothing
         , responseMetadata          = mempty
         , responseUnrecognized      = return ()
 
@@ -312,6 +324,59 @@ invalidContentType err = invalidHeaderSynthesize GrpcException {
     }
 
 {-------------------------------------------------------------------------------
+  HTTP @Trailer@ header
+
+  See <https://datatracker.ietf.org/doc/html/rfc9110#name-trailer>
+
+  > Trailer = #field-name
+
+  where
+
+  > A construct "#" is defined, similar to "*", for defining comma-delimited
+  > lists of elements. The full form is "<n>#<m>element" indicating at least <n>
+  > and at most <m> elements, each separated by a single comma (",") and
+  > optional whitespace
+-------------------------------------------------------------------------------}
+
+-- | Construct the HTTP @Trailer@ header
+--
+-- This lists all headers that /might/ be present in the trailers.
+--
+-- See
+--
+-- * <https://datatracker.ietf.org/doc/html/rfc7230#section-4.4>
+-- * <https://www.rfc-editor.org/rfc/rfc9110#name-processing-trailer-fields>
+buildTrailer :: [HTTP.HeaderName] -> HTTP.Header
+buildTrailer trailerNames = (
+      "Trailer"
+    , BS.Strict.intercalate ", " $ map CI.original trailerNames
+    )
+
+parseTrailer :: HTTP.Header -> [HTTP.HeaderName]
+parseTrailer (_name, val) = map (CI.mk . trim) $ BS.Strict.C8.split ',' val
+
+-- | All potential trailers
+allPotentialTrailers ::
+     [HeaderName] -- ^ Additional user-defined trailers, if any
+  -> [HTTP.HeaderName]
+allPotentialTrailers additional = concat [
+      reservedTrailers
+    , map buildHeaderName additional
+    ]
+  where
+    -- These cannot be 'HeaderName' (which disallow reserved names)
+    --
+    -- This list must match the names used by 'buildProperTrailers'
+    -- and recognized by 'parseProperTrailers'.
+    reservedTrailers :: [HTTP.HeaderName]
+    reservedTrailers = [
+          "grpc-status"
+        , "grpc-message"
+        , "grpc-retry-pushback-ms"
+        , "endpoint-load-metrics-bin"
+        ]
+
+{-------------------------------------------------------------------------------
   > Trailers       → Status [Status-Message] *Custom-Metadata Status         →
   > "grpc-status" 1*DIGIT ; 0-9 Status-Message → "grpc-message" Percent-Encoded
   > Status-Details → "grpc-status-details-bin" {base64 encoded value}
@@ -323,39 +388,6 @@ invalidContentType err = invalidHeaderSynthesize GrpcException {
   > code field, it MUST NOT contradict the Status header. The consumer MUST
   > verify this requirement.
 -------------------------------------------------------------------------------}
-
--- | Construct the HTTP @Trailer@ header
---
--- This lists all headers that /might/ be present in the trailers.
---
--- See
---
--- * <https://datatracker.ietf.org/doc/html/rfc7230#section-4.4>
--- * <https://www.rfc-editor.org/rfc/rfc9110#name-processing-trailer-fields>
-buildTrailer :: forall rpc. SupportsServerRpc rpc => Proxy rpc -> HTTP.Header
-buildTrailer _ = (
-      "Trailer"
-    , BS.Strict.intercalate ", " allPotentialTrailers
-    )
-  where
-    allPotentialTrailers :: [Strict.ByteString]
-    allPotentialTrailers = concat [
-          reservedTrailers
-        , map (CI.original . buildHeaderName) $
-            metadataHeaderNames (Proxy @(ResponseTrailingMetadata rpc))
-        ]
-
-    -- These cannot be 'HeaderName' (which disallow reserved names)
-    --
-    -- This list must match the names used by 'buildProperTrailers'
-    -- and recognized by 'parseProperTrailers'.
-    reservedTrailers :: [Strict.ByteString]
-    reservedTrailers = [
-          "grpc-status"
-        , "grpc-message"
-        , "grpc-retry-pushback-ms"
-        , "endpoint-load-metrics-bin"
-        ]
 
 -- | Build trailers (see 'buildTrailersOnly' for the Trailers-Only case)
 buildProperTrailers :: ProperTrailers -> [HTTP.Header]

--- a/grpc-spec/test-grpc-spec/Test/Prop/Serialization.hs
+++ b/grpc-spec/test-grpc-spec/Test/Prop/Serialization.hs
@@ -438,11 +438,13 @@ instance Arbitrary (Awkward ResponseHeaders) where
       responseCompression       <- awkward
       responseAcceptCompression <- awkward
       responseContentType       <- Just <$> awkward
+      responseTrailerNames      <- awkward
       responseMetadata          <- awkward
       return ResponseHeaders {
           responseCompression
         , responseAcceptCompression
         , responseContentType
+        , responseTrailerNames
         , responseMetadata
         , responseUnrecognized = ()
         }

--- a/grpc-spec/test-grpc-spec/Test/Util/Awkward.hs
+++ b/grpc-spec/test-grpc-spec/Test/Util/Awkward.hs
@@ -11,6 +11,7 @@ import Control.Monad
 import Data.ByteString qualified as BS.Strict
 import Data.ByteString qualified as Strict (ByteString)
 import Data.ByteString.Char8 qualified as Strict.BS.Char8
+import Data.CaseInsensitive qualified as CI
 import Data.Char (ord, chr, isSpace)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.Strict (Map)
@@ -18,6 +19,7 @@ import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Word
+import Network.HTTP.Types qualified as HTTP
 import Test.QuickCheck
 import Test.QuickCheck.Instances ()
 
@@ -133,6 +135,49 @@ instance Arbitrary (Awkward Double) where
   arbitrary = Awkward <$> arbitrary
   shrink    = map Awkward . shrink . getAwkward
 
+-- | Header-names can't actually be all that awkward
+instance Arbitrary (Awkward HTTP.HeaderName) where
+  arbitrary =
+      fmap (Awkward . CI.mk . BS.Strict.pack) $ do
+        n <- choose (1, 20)
+        replicateM n validChar
+    where
+      validChar :: Gen Word8
+      validChar = oneof [
+            choose (0x30, 0x39)
+          , choose (0x61, 0x7A)
+          , elements [ord8 '_', ord8 '-', ord8 '.']
+          ]
+  shrink =
+        map (Awkward . CI.mk . BS.Strict.pack)
+      . aux
+      . (BS.Strict.unpack . CI.original . getAwkward)
+    where
+      aux :: [Word8] -> [[Word8]]
+      aux name = concat [
+            -- Try to replace any character with 'a'
+            [ prev ++ [ord8 'a'] ++ after
+            | (prev, x, after) <- isolate name
+            , x /= ord8 'a'
+            ]
+
+            -- Standard list shrinking
+          , filter isValid $ shrink name
+          ]
+
+      isValid :: [Word8] -> Bool
+      isValid name = and [
+            all isValidChar name
+          , length name > 0
+          ]
+
+      isValidChar :: Word8 -> Bool
+      isValidChar x = or [
+            0x30 <= x && x <= 0x39
+          , 0x61 <= x && x <= 0x7A
+          , x `elem` [ord8 '_', ord8 '-', ord8 '.']
+          ]
+
 {-------------------------------------------------------------------------------
   Trimming
 
@@ -152,3 +197,17 @@ trimByteString :: Strict.ByteString -> Strict.ByteString
 trimByteString =
       Strict.BS.Char8.dropWhile    isSpace
     . Strict.BS.Char8.dropWhileEnd isSpace
+
+{-------------------------------------------------------------------------------
+  Internal auxiliary
+-------------------------------------------------------------------------------}
+
+isolate :: [a] -> [([a], a, [a])]
+isolate = go []
+  where
+    go :: [a] -> [a] -> [([a], a, [a])]
+    go _    []     = []
+    go prev (x:xs) = (reverse prev, x, xs) : go (x:prev) xs
+
+ord8 :: Char -> Word8
+ord8 = fromIntegral . ord


### PR DESCRIPTION
* Support dynamic trailers (not statically determined by the RPC); see `setResponseInitialMetadataAndTrailers`
* Default instances for `{Build,Parse}Metadata` for `[CustomMetadata]`
* Make the HTTP `Trailer` header available to clients